### PR TITLE
feat: add common_system integration adapters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ else()
     option(BUILD_THREADSYSTEM_AS_SUBMODULE "Build ThreadSystem as submodule" OFF)
 endif()
 option(BUILD_DOCUMENTATION "Build Doxygen documentation" ON)
+option(USE_COMMON_SYSTEM "Use common_system for standard interfaces" OFF)
 
 ##################################################
 # C++ Standard Configuration

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -25,6 +25,19 @@ target_include_directories(${PROJECT_NAME} PUBLIC
     $<INSTALL_INTERFACE:include>
 )
 
+# Add common_system support if available
+if(USE_COMMON_SYSTEM)
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../../common_system/include")
+        target_include_directories(${PROJECT_NAME} PUBLIC
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../common_system/include>
+        )
+        target_compile_definitions(${PROJECT_NAME} PUBLIC USE_COMMON_SYSTEM)
+        message(STATUS "ThreadSystem: common_system support enabled")
+    else()
+        message(WARNING "ThreadSystem: USE_COMMON_SYSTEM is ON but common_system not found")
+    endif()
+endif()
+
 target_link_libraries(${PROJECT_NAME} PUBLIC
     utilities
     interfaces

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -233,6 +233,9 @@ Design rules:
 - `monitoring_interface` provides pool/worker/system metrics
 - `logger_interface` keeps logging pluggable and optional
 
+Ecosystem Integration Note
+- network_system integrates with external thread pools via its `thread_integration_manager` and adapters; there is no hard compile-time dependency on thread_system.
+
 ### Error Handling Excellence
 - **`result<T>` pattern**: Modern error handling similar to C++23 std::expected
   - Type-safe error codes

--- a/include/kcenon/thread/adapters/common_system_executor_adapter.h
+++ b/include/kcenon/thread/adapters/common_system_executor_adapter.h
@@ -1,0 +1,206 @@
+/*
+ * BSD 3-Clause License
+ * Copyright (c) 2025, kcenon
+ */
+
+#pragma once
+
+#include <memory>
+#include <future>
+#include <functional>
+
+// Check if common_system is available
+#ifdef USE_COMMON_SYSTEM
+#include <kcenon/common/interfaces/executor_interface.h>
+#include <kcenon/common/patterns/result.h>
+#endif
+
+#include "../core/thread_pool.h"
+#include "../interfaces/executor_interface.h"
+
+namespace kcenon::thread::adapters {
+
+#ifdef USE_COMMON_SYSTEM
+
+/**
+ * @brief Adapter to expose thread_pool as common::interfaces::IExecutor
+ *
+ * This adapter allows thread_system's thread_pool to be used
+ * through the standard common_system executor interface.
+ */
+class common_system_executor_adapter : public ::common::interfaces::IExecutor {
+public:
+    /**
+     * @brief Construct adapter with existing thread pool
+     * @param pool Shared pointer to thread pool
+     */
+    explicit common_system_executor_adapter(std::shared_ptr<thread_pool> pool)
+        : pool_(pool) {}
+
+    /**
+     * @brief Construct adapter with new thread pool
+     * @param worker_count Number of worker threads
+     */
+    explicit common_system_executor_adapter(size_t worker_count = std::thread::hardware_concurrency())
+        : pool_(std::make_shared<thread_pool>(worker_count)) {}
+
+    ~common_system_executor_adapter() override = default;
+
+    /**
+     * @brief Submit a task for immediate execution
+     * @param task The function to execute
+     * @return Future representing the task result
+     */
+    std::future<void> submit(std::function<void()> task) override {
+        if (!pool_) {
+            std::promise<void> promise;
+            promise.set_exception(std::make_exception_ptr(
+                std::runtime_error("Thread pool not initialized")));
+            return promise.get_future();
+        }
+
+        return pool_->enqueue(std::move(task));
+    }
+
+    /**
+     * @brief Submit a task for delayed execution
+     * @param task The function to execute
+     * @param delay The delay before execution
+     * @return Future representing the task result
+     */
+    std::future<void> submit_delayed(
+        std::function<void()> task,
+        std::chrono::milliseconds delay) override {
+        if (!pool_) {
+            std::promise<void> promise;
+            promise.set_exception(std::make_exception_ptr(
+                std::runtime_error("Thread pool not initialized")));
+            return promise.get_future();
+        }
+
+        // Schedule delayed execution
+        return std::async(std::launch::async, [this, task = std::move(task), delay]() {
+            std::this_thread::sleep_for(delay);
+            pool_->enqueue(std::move(task)).wait();
+        });
+    }
+
+    /**
+     * @brief Get the number of worker threads
+     * @return Number of available workers
+     */
+    size_t worker_count() const override {
+        return pool_ ? pool_->size() : 0;
+    }
+
+    /**
+     * @brief Check if the executor is running
+     * @return true if running, false otherwise
+     */
+    bool is_running() const override {
+        return pool_ && !pool_->is_stopped();
+    }
+
+    /**
+     * @brief Get the number of pending tasks
+     * @return Number of tasks waiting to be executed
+     */
+    size_t pending_tasks() const override {
+        return pool_ ? pool_->queue_size() : 0;
+    }
+
+    /**
+     * @brief Shutdown the executor gracefully
+     * @param wait_for_completion Wait for all pending tasks to complete
+     */
+    void shutdown(bool wait_for_completion = true) override {
+        if (pool_) {
+            if (wait_for_completion) {
+                pool_->wait();
+            }
+            pool_->stop();
+        }
+    }
+
+    /**
+     * @brief Get the underlying thread pool
+     * @return Shared pointer to thread pool
+     */
+    std::shared_ptr<thread_pool> get_thread_pool() const {
+        return pool_;
+    }
+
+private:
+    std::shared_ptr<thread_pool> pool_;
+};
+
+/**
+ * @brief Adapter to expose common::interfaces::IExecutor as thread_system executor
+ *
+ * This adapter allows a common_system executor to be used
+ * through the thread_system executor interface.
+ */
+class executor_from_common_adapter : public executor_interface {
+public:
+    /**
+     * @brief Construct adapter with common executor
+     * @param executor Shared pointer to common executor
+     */
+    explicit executor_from_common_adapter(
+        std::shared_ptr<::common::interfaces::IExecutor> executor)
+        : executor_(executor) {}
+
+    ~executor_from_common_adapter() override = default;
+
+    /**
+     * @brief Submit a unit of work for asynchronous execution
+     */
+    auto execute(std::unique_ptr<job>&& work) -> result_void override {
+        if (!executor_) {
+            return result_void::failure(
+                error_code::invalid_argument,
+                "Common executor not initialized");
+        }
+
+        try {
+            // Convert job to function and submit
+            executor_->submit([j = std::move(work)]() mutable {
+                if (j) {
+                    j->execute();
+                }
+            });
+            return result_void::success();
+        } catch (const std::exception& e) {
+            return result_void::failure(
+                error_code::runtime_error,
+                std::string("Failed to submit job: ") + e.what());
+        }
+    }
+
+    /**
+     * @brief Initiate a cooperative shutdown
+     */
+    auto shutdown() -> result_void override {
+        if (!executor_) {
+            return result_void::failure(
+                error_code::invalid_state,
+                "Common executor not initialized");
+        }
+
+        try {
+            executor_->shutdown(true);
+            return result_void::success();
+        } catch (const std::exception& e) {
+            return result_void::failure(
+                error_code::runtime_error,
+                std::string("Failed to shutdown: ") + e.what());
+        }
+    }
+
+private:
+    std::shared_ptr<::common::interfaces::IExecutor> executor_;
+};
+
+#endif // USE_COMMON_SYSTEM
+
+} // namespace kcenon::thread::adapters

--- a/include/kcenon/thread/adapters/common_system_logger_adapter.h
+++ b/include/kcenon/thread/adapters/common_system_logger_adapter.h
@@ -1,0 +1,256 @@
+/*
+ * BSD 3-Clause License
+ * Copyright (c) 2025, kcenon
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+// Check if common_system is available
+#ifdef USE_COMMON_SYSTEM
+#include <kcenon/common/interfaces/logger_interface.h>
+#include <kcenon/common/patterns/result.h>
+#endif
+
+#include "../interfaces/logger_interface.h"
+
+namespace kcenon::thread::adapters {
+
+#ifdef USE_COMMON_SYSTEM
+
+/**
+ * @brief Adapter to expose thread_system logger as common::interfaces::ILogger
+ *
+ * This adapter allows thread_system's logger to be used
+ * through the standard common_system logger interface.
+ */
+class common_system_logger_adapter : public ::common::interfaces::ILogger {
+public:
+    /**
+     * @brief Construct adapter with thread_system logger
+     * @param logger Shared pointer to thread_system logger
+     */
+    explicit common_system_logger_adapter(
+        std::shared_ptr<logger_interface> logger)
+        : logger_(logger) {}
+
+    ~common_system_logger_adapter() override = default;
+
+    /**
+     * @brief Log a message with specified level
+     */
+    ::common::VoidResult log(
+        ::common::interfaces::log_level level,
+        const std::string& message) override {
+        if (!logger_) {
+            return ::common::VoidResult(
+                ::common::error_info(1, "Logger not initialized", "thread_system"));
+        }
+
+        // Convert common log level to thread_system log level
+        auto thread_level = convert_level_to_thread(level);
+        logger_->log(thread_level, message);
+        return ::common::VoidResult(std::monostate{});
+    }
+
+    /**
+     * @brief Log a message with source location information
+     */
+    ::common::VoidResult log(
+        ::common::interfaces::log_level level,
+        const std::string& message,
+        const std::string& file,
+        int line,
+        const std::string& function) override {
+        if (!logger_) {
+            return ::common::VoidResult(
+                ::common::error_info(1, "Logger not initialized", "thread_system"));
+        }
+
+        auto thread_level = convert_level_to_thread(level);
+        logger_->log(thread_level, message, file, line, function);
+        return ::common::VoidResult(std::monostate{});
+    }
+
+    /**
+     * @brief Log a structured entry
+     */
+    ::common::VoidResult log(
+        const ::common::interfaces::log_entry& entry) override {
+        if (!logger_) {
+            return ::common::VoidResult(
+                ::common::error_info(1, "Logger not initialized", "thread_system"));
+        }
+
+        auto thread_level = convert_level_to_thread(entry.level);
+        logger_->log(thread_level, entry.message,
+                    entry.file, entry.line, entry.function);
+        return ::common::VoidResult(std::monostate{});
+    }
+
+    /**
+     * @brief Check if logging is enabled for the specified level
+     */
+    bool is_enabled(::common::interfaces::log_level level) const override {
+        if (!logger_) {
+            return false;
+        }
+        auto thread_level = convert_level_to_thread(level);
+        return logger_->is_enabled(thread_level);
+    }
+
+    /**
+     * @brief Set the minimum log level
+     */
+    ::common::VoidResult set_level(
+        ::common::interfaces::log_level level) override {
+        // Thread_system logger doesn't have set_level in interface
+        // Store it locally for filtering
+        min_level_ = level;
+        return ::common::VoidResult(std::monostate{});
+    }
+
+    /**
+     * @brief Get the current minimum log level
+     */
+    ::common::interfaces::log_level get_level() const override {
+        return min_level_;
+    }
+
+    /**
+     * @brief Flush any buffered log messages
+     */
+    ::common::VoidResult flush() override {
+        if (!logger_) {
+            return ::common::VoidResult(
+                ::common::error_info(1, "Logger not initialized", "thread_system"));
+        }
+        logger_->flush();
+        return ::common::VoidResult(std::monostate{});
+    }
+
+private:
+    std::shared_ptr<logger_interface> logger_;
+    ::common::interfaces::log_level min_level_ = ::common::interfaces::log_level::info;
+
+    /**
+     * @brief Convert common log level to thread_system log level
+     */
+    static log_level convert_level_to_thread(::common::interfaces::log_level level) {
+        switch(level) {
+            case ::common::interfaces::log_level::trace:
+                return log_level::trace;
+            case ::common::interfaces::log_level::debug:
+                return log_level::debug;
+            case ::common::interfaces::log_level::info:
+                return log_level::info;
+            case ::common::interfaces::log_level::warning:
+                return log_level::warning;
+            case ::common::interfaces::log_level::error:
+                return log_level::error;
+            case ::common::interfaces::log_level::critical:
+                return log_level::critical;
+            case ::common::interfaces::log_level::off:
+            default:
+                return log_level::info;
+        }
+    }
+};
+
+/**
+ * @brief Adapter to expose common::interfaces::ILogger as thread_system logger
+ *
+ * This adapter allows a common_system logger to be used
+ * through the thread_system logger interface.
+ */
+class logger_from_common_adapter : public logger_interface {
+public:
+    /**
+     * @brief Construct adapter with common logger
+     * @param logger Shared pointer to common logger
+     */
+    explicit logger_from_common_adapter(
+        std::shared_ptr<::common::interfaces::ILogger> logger)
+        : logger_(logger) {}
+
+    ~logger_from_common_adapter() override = default;
+
+    /**
+     * @brief Log a message with specified level
+     */
+    void log(log_level level, const std::string& message) override {
+        if (!logger_) {
+            return;
+        }
+
+        auto common_level = convert_level_to_common(level);
+        logger_->log(common_level, message);
+    }
+
+    /**
+     * @brief Log a message with source location information
+     */
+    void log(log_level level,
+             const std::string& message,
+             const std::string& file,
+             int line,
+             const std::string& function) override {
+        if (!logger_) {
+            return;
+        }
+
+        auto common_level = convert_level_to_common(level);
+        logger_->log(common_level, message, file, line, function);
+    }
+
+    /**
+     * @brief Check if logging is enabled for the specified level
+     */
+    bool is_enabled(log_level level) const override {
+        if (!logger_) {
+            return false;
+        }
+        auto common_level = convert_level_to_common(level);
+        return logger_->is_enabled(common_level);
+    }
+
+    /**
+     * @brief Flush any buffered log messages
+     */
+    void flush() override {
+        if (logger_) {
+            logger_->flush();
+        }
+    }
+
+private:
+    std::shared_ptr<::common::interfaces::ILogger> logger_;
+
+    /**
+     * @brief Convert thread_system log level to common log level
+     */
+    static ::common::interfaces::log_level convert_level_to_common(log_level level) {
+        switch(level) {
+            case log_level::trace:
+                return ::common::interfaces::log_level::trace;
+            case log_level::debug:
+                return ::common::interfaces::log_level::debug;
+            case log_level::info:
+                return ::common::interfaces::log_level::info;
+            case log_level::warning:
+                return ::common::interfaces::log_level::warning;
+            case log_level::error:
+                return ::common::interfaces::log_level::error;
+            case log_level::critical:
+                return ::common::interfaces::log_level::critical;
+            default:
+                return ::common::interfaces::log_level::info;
+        }
+    }
+};
+
+#endif // USE_COMMON_SYSTEM
+
+} // namespace kcenon::thread::adapters

--- a/include/kcenon/thread/adapters/common_system_monitoring_adapter.h
+++ b/include/kcenon/thread/adapters/common_system_monitoring_adapter.h
@@ -1,0 +1,211 @@
+/*
+ * BSD 3-Clause License
+ * Copyright (c) 2025, kcenon
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+// Check if common_system is available
+#ifdef USE_COMMON_SYSTEM
+#include <kcenon/common/interfaces/monitoring_interface.h>
+#include <kcenon/common/patterns/result.h>
+#endif
+
+#include "../interfaces/monitorable_interface.h"
+#include "../interfaces/monitoring_interface.h"
+
+namespace kcenon::thread::adapters {
+
+#ifdef USE_COMMON_SYSTEM
+
+/**
+ * @brief Adapter to expose thread_system monitorable as common::interfaces::IMonitorable
+ *
+ * This adapter allows thread_system's monitorable objects to be monitored
+ * through the standard common_system monitoring interface.
+ */
+class common_system_monitorable_adapter : public ::common::interfaces::IMonitorable {
+public:
+    /**
+     * @brief Construct adapter with thread_system monitorable
+     * @param monitorable Shared pointer to thread_system monitorable
+     * @param name Component name
+     */
+    explicit common_system_monitorable_adapter(
+        std::shared_ptr<monitorable_interface> monitorable,
+        const std::string& name = "thread_component")
+        : monitorable_(monitorable), component_name_(name) {}
+
+    ~common_system_monitorable_adapter() override = default;
+
+    /**
+     * @brief Get monitoring data
+     * @return Result containing metrics snapshot or error
+     */
+    ::common::Result<::common::interfaces::metrics_snapshot> get_monitoring_data() override {
+        if (!monitorable_) {
+            return ::common::error_info(1, "Monitorable not initialized", "thread_system");
+        }
+
+        auto thread_data = monitorable_->get_monitoring_data();
+        if (!thread_data) {
+            return ::common::error_info(2, "Failed to get monitoring data", "thread_system");
+        }
+
+        // Convert thread_system monitoring_data to common metrics_snapshot
+        ::common::interfaces::metrics_snapshot snapshot;
+        snapshot.source_id = component_name_;
+
+        // Extract metrics from thread_system monitoring_data
+        if (thread_data->active_threads.has_value()) {
+            snapshot.add_metric("active_threads",
+                              static_cast<double>(thread_data->active_threads.value()));
+        }
+        if (thread_data->pending_tasks.has_value()) {
+            snapshot.add_metric("pending_tasks",
+                              static_cast<double>(thread_data->pending_tasks.value()));
+        }
+        if (thread_data->total_tasks.has_value()) {
+            snapshot.add_metric("total_tasks",
+                              static_cast<double>(thread_data->total_tasks.value()));
+        }
+        if (thread_data->failed_tasks.has_value()) {
+            snapshot.add_metric("failed_tasks",
+                              static_cast<double>(thread_data->failed_tasks.value()));
+        }
+
+        return snapshot;
+    }
+
+    /**
+     * @brief Check health status
+     * @return Result containing health check result or error
+     */
+    ::common::Result<::common::interfaces::health_check_result> health_check() override {
+        if (!monitorable_) {
+            return ::common::error_info(1, "Monitorable not initialized", "thread_system");
+        }
+
+        auto thread_health = monitorable_->health_check();
+
+        // Convert thread_system health to common health_check_result
+        ::common::interfaces::health_check_result result;
+
+        if (thread_health.is_healthy) {
+            result.status = ::common::interfaces::health_status::healthy;
+            result.message = thread_health.message.value_or("Healthy");
+        } else if (thread_health.is_operational) {
+            result.status = ::common::interfaces::health_status::degraded;
+            result.message = thread_health.message.value_or("Degraded");
+        } else {
+            result.status = ::common::interfaces::health_status::unhealthy;
+            result.message = thread_health.message.value_or("Unhealthy");
+        }
+
+        return result;
+    }
+
+    /**
+     * @brief Get component name for monitoring
+     * @return Component identifier
+     */
+    std::string get_component_name() const override {
+        return component_name_;
+    }
+
+private:
+    std::shared_ptr<monitorable_interface> monitorable_;
+    std::string component_name_;
+};
+
+/**
+ * @brief Adapter to expose common::interfaces::IMonitorable as thread_system monitorable
+ *
+ * This adapter allows a common_system monitorable to be used
+ * through the thread_system monitorable interface.
+ */
+class monitorable_from_common_adapter : public monitorable_interface {
+public:
+    /**
+     * @brief Construct adapter with common monitorable
+     * @param monitorable Shared pointer to common monitorable
+     */
+    explicit monitorable_from_common_adapter(
+        std::shared_ptr<::common::interfaces::IMonitorable> monitorable)
+        : monitorable_(monitorable) {}
+
+    ~monitorable_from_common_adapter() override = default;
+
+    /**
+     * @brief Get monitoring data
+     */
+    std::optional<monitoring_data> get_monitoring_data() const override {
+        if (!monitorable_) {
+            return std::nullopt;
+        }
+
+        auto result = monitorable_->get_monitoring_data();
+        if (::common::is_error(result)) {
+            return std::nullopt;
+        }
+
+        const auto& snapshot = ::common::get_value(result);
+        monitoring_data data;
+
+        // Convert common metrics_snapshot to thread_system monitoring_data
+        for (const auto& metric : snapshot.metrics) {
+            if (metric.name == "active_threads") {
+                data.active_threads = static_cast<std::size_t>(metric.value);
+            } else if (metric.name == "pending_tasks") {
+                data.pending_tasks = static_cast<std::size_t>(metric.value);
+            } else if (metric.name == "total_tasks") {
+                data.total_tasks = static_cast<std::size_t>(metric.value);
+            } else if (metric.name == "failed_tasks") {
+                data.failed_tasks = static_cast<std::size_t>(metric.value);
+            }
+        }
+
+        data.timestamp = std::chrono::steady_clock::now();
+        return data;
+    }
+
+    /**
+     * @brief Check health status
+     */
+    health_status health_check() const override {
+        if (!monitorable_) {
+            return health_status{false, false, "Monitorable not initialized"};
+        }
+
+        auto result = monitorable_->health_check();
+        if (::common::is_error(result)) {
+            return health_status{false, false, "Health check failed"};
+        }
+
+        const auto& health = ::common::get_value(result);
+        return health_status{
+            health.is_healthy(),
+            health.is_operational(),
+            health.message
+        };
+    }
+
+    /**
+     * @brief Reset monitoring statistics
+     */
+    void reset_stats() override {
+        // Common system doesn't have reset in IMonitorable interface
+        // This is a no-op
+    }
+
+private:
+    std::shared_ptr<::common::interfaces::IMonitorable> monitorable_;
+};
+
+#endif // USE_COMMON_SYSTEM
+
+} // namespace kcenon::thread::adapters


### PR DESCRIPTION
## Summary
- Implemented adapter pattern to integrate thread_system with common_system standard interfaces
- Added conditional compilation support via USE_COMMON_SYSTEM flag for optional integration
- Updated build configuration and documentation to reflect ecosystem integration capabilities

## Changes

### New Adapters
- **common_system_executor_adapter**: Bridges thread_pool to common::interfaces::IExecutor
- **common_system_logger_adapter**: Adapts thread_system logger to common::interfaces::ILogger  
- **common_system_monitoring_adapter**: Exposes thread metrics through common::interfaces::IMonitoring

### Build System Updates
- Added USE_COMMON_SYSTEM CMake option for conditional compilation
- Updated CMakeLists.txt to support common_system integration when enabled

### Documentation
- Updated ARCHITECTURE.md with ecosystem integration notes
- Clarified that network_system integrates via adapters without hard dependencies

## Purpose
This PR enables thread_system to seamlessly integrate with the broader ecosystem through common_system's standardized interfaces. Key benefits:
- **Interoperability**: Thread pools can be used by any module supporting IExecutor interface
- **Consistency**: Unified logging and monitoring across all ecosystem modules
- **Flexibility**: Optional integration via compile flag preserves backward compatibility
- **Modularity**: Adapter pattern allows gradual migration without breaking existing code

## Technical Details
The adapters use conditional compilation (#ifdef USE_COMMON_SYSTEM) to:
- Maintain zero overhead when integration is disabled
- Allow progressive adoption across projects
- Preserve existing thread_system APIs while adding common_system compatibility

## Test Plan
- [ ] Verify compilation with USE_COMMON_SYSTEM=OFF (default behavior)
- [ ] Test compilation with USE_COMMON_SYSTEM=ON 
- [ ] Validate adapter implementations match interface contracts
- [ ] Test thread_pool functionality through executor adapter
- [ ] Verify logger adapter correctly maps log levels
- [ ] Confirm monitoring adapter exposes accurate metrics
- [ ] Integration test with network_system using shared interfaces