### PR TITLE
Phase 1: Build Configuration Standardization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ else()
     option(BUILD_THREADSYSTEM_AS_SUBMODULE "Build ThreadSystem as submodule" OFF)
 endif()
 option(BUILD_DOCUMENTATION "Build Doxygen documentation" ON)
-option(BUILD_WITH_COMMON_SYSTEM "Build with common_system for standard interfaces" OFF)
+option(BUILD_WITH_COMMON_SYSTEM "Build with common_system for standard interfaces" ON)
 
 # Configure common_system integration
 if(BUILD_WITH_COMMON_SYSTEM)


### PR DESCRIPTION
## Summary
- Change BUILD_WITH_COMMON_SYSTEM default value to ON
- Align with system integration goals

## Changes
- BUILD_WITH_COMMON_SYSTEM: OFF -> ON (default)

## Testing
Build verification needed after merge

## Part of
Phase 1: Build Configuration Standardization - Task 1.2