### PR TITLE
Phase 2: Interface Unification (Logger & Executor)

### DIFF
--- a/include/kcenon/thread/adapters/common_system_logger_adapter.h
+++ b/include/kcenon/thread/adapters/common_system_logger_adapter.h
@@ -161,11 +161,19 @@ private:
 
 /**
  * @brief Adapter to expose common::interfaces::ILogger as thread_system logger
+ * @deprecated This reverse adapter will be removed in Phase 3
  *
+ * Phase 2 Note: Bidirectional adapters create circular conversion risk.
  * This adapter allows a common_system logger to be used
  * through the thread_system logger interface.
+ *
+ * MIGRATION: Use common::interfaces::ILogger directly instead of wrapping it.
+ * Reverse adapters (Common→System) are being phased out in favor of
+ * native common interface adoption.
+ *
+ * Will be removed in Phase 3 (Adapter Optimization)
  */
-class logger_from_common_adapter : public logger_interface {
+class [[deprecated("Will be removed in Phase 3. Use common::interfaces::ILogger directly")]] logger_from_common_adapter : public logger_interface {
 public:
     /**
      * @brief Construct adapter with common logger

--- a/include/kcenon/thread/interfaces/executor_interface.h
+++ b/include/kcenon/thread/interfaces/executor_interface.h
@@ -5,6 +5,38 @@
 
 #pragma once
 
+/**
+ * @file executor_interface.h
+ * @brief DEPRECATED: This interface is deprecated and will be removed in v2.0
+ *
+ * Phase 2: Executor Interface Unification
+ *
+ * This interface has been superseded by common::interfaces::IExecutor.
+ * Please migrate to the unified executor interface in common_system:
+ *
+ * Migration:
+ *   OLD: #include <kcenon/thread/interfaces/executor_interface.h>
+ *        kcenon::thread::executor_interface* executor;
+ *        executor->execute(std::move(job));
+ *
+ *   NEW: #include <kcenon/common/interfaces/executor_interface.h>
+ *        common::interfaces::IExecutor* executor;
+ *        executor->execute(std::move(job));  // Returns Result<std::future<void>>
+ *
+ * The unified interface provides:
+ * - Result<T> based error handling
+ * - Both function-based and job-based execution
+ * - Unified IJob interface
+ * - Better integration across all systems
+ * - Delayed execution support
+ *
+ * Deprecation Timeline:
+ * - v1.x: Deprecated but functional (current)
+ * - v2.0: Removed entirely
+ *
+ * @deprecated Use common::interfaces::IExecutor instead
+ */
+
 #include <memory>
 
 // Use project result type and job forward declarations
@@ -15,8 +47,12 @@ namespace kcenon::thread {
 
 /**
  * @brief Executor interface for submitting work and coordinating shutdown.
+ * @deprecated Use common::interfaces::IExecutor instead
+ *
+ * MIGRATION: The unified interface provides job-based execution with Result<T>
+ * and function-based execution for compatibility.
  */
-class executor_interface {
+class [[deprecated("Use common::interfaces::IExecutor instead")]] executor_interface {
 public:
     virtual ~executor_interface() = default;
 

--- a/include/kcenon/thread/interfaces/logger_interface.h
+++ b/include/kcenon/thread/interfaces/logger_interface.h
@@ -25,6 +25,35 @@
 
 #pragma once
 
+/**
+ * @file logger_interface.h
+ * @brief DEPRECATED: This interface is deprecated and will be removed in v2.0
+ *
+ * Phase 2: Logger Interface Unification
+ *
+ * This interface has been superseded by common::interfaces::ILogger.
+ * Please migrate to the unified logger interface in common_system:
+ *
+ * Migration:
+ *   OLD: #include <kcenon/thread/interfaces/logger_interface.h>
+ *        kcenon::thread::logger_interface* logger;
+ *
+ *   NEW: #include <kcenon/common/interfaces/logger_interface.h>
+ *        common::interfaces::ILogger* logger;
+ *
+ * The unified interface provides:
+ * - Result<T> based error handling
+ * - Consistent log_level ordering (trace=0...critical=5)
+ * - Extended configuration with ILoggerRegistry
+ * - Better integration across all systems
+ *
+ * Deprecation Timeline:
+ * - v1.x: Deprecated but functional (current)
+ * - v2.0: Removed entirely
+ *
+ * @deprecated Use common::interfaces::ILogger instead
+ */
+
 #include <memory>
 #include <mutex>
 #include <string>
@@ -33,6 +62,10 @@ namespace kcenon::thread {
 
 /**
  * @brief Log level enumeration
+ * @deprecated Use common::interfaces::log_level instead
+ *
+ * WARNING: This enumeration has inverted ordering (critical=0, trace=5).
+ * The unified interface uses standard ordering (trace=0, critical=5).
  */
 enum class log_level {
   critical = 0,
@@ -45,11 +78,17 @@ enum class log_level {
 
 /**
  * @brief Logger interface for thread system
+ * @deprecated Use common::interfaces::ILogger instead
  *
  * This interface allows the thread system to log messages without
  * depending on a specific logger implementation.
+ *
+ * MIGRATION: Replace with common::interfaces::ILogger which provides:
+ * - VoidResult return types for better error handling
+ * - Unified log_entry structure
+ * - Compatible method signatures
  */
-class logger_interface {
+class [[deprecated("Use common::interfaces::ILogger instead")]] logger_interface {
 public:
   virtual ~logger_interface() = default;
 
@@ -87,10 +126,16 @@ public:
 
 /**
  * @brief Global logger registry
+ * @deprecated Use common::interfaces::ILoggerRegistry instead
  *
  * Manages the global logger instance used by the thread system.
+ *
+ * MIGRATION: Use the unified ILoggerRegistry interface which provides:
+ * - Named logger support
+ * - Thread-safe registration
+ * - Default logger management
  */
-class logger_registry {
+class [[deprecated("Use common::interfaces::ILoggerRegistry instead")]] logger_registry {
 public:
   /**
    * @brief Set the global logger instance


### PR DESCRIPTION
## Summary

Phase 2 Interface Unification - Part 1 (Logger & Executor)

This PR deprecates thread_system-specific logger and executor interfaces in favor of unified common_system interfaces.

## Changes

### Task 2.1: Logger Interface Deprecation
- Deprecated `logger_interface` with detailed migration guide
- Deprecated `logger_registry` 
- Deprecated `logger_from_common_adapter` (reverse adapter)
- Added log level ordering warnings (critical=0 vs trace=0)
- Documented unified interface benefits

### Task 2.2: Executor Interface Deprecation
- Deprecated `executor_interface`
- Added migration guide to `common::interfaces::IExecutor`
- Documented Result<T> based error handling advantages
- Added v2.0 removal timeline

## Migration Guide

```cpp
// Old: thread_system logger
#include <kcenon/thread/interfaces/logger_interface.h>
kcenon::thread::logger_interface* logger;

// New: unified common logger
#include <kcenon/common/interfaces/logger_interface.h>
common::interfaces::ILogger* logger;
```

```cpp
// Old: thread_system executor
#include <kcenon/thread/interfaces/executor_interface.h>
executor->execute(std::move(job));

// New: unified common executor
#include <kcenon/common/interfaces/executor_interface.h>
auto result = executor->execute(std::move(job));  // Returns Result<future>
```

## Impact

- **Breaking Changes**: None (deprecation warnings only)
- **Deprecation Timeline**: v2.0 removal
- **Reverse Adapters**: Marked for Phase 3 removal

## Related PRs

- common_system: https://github.com/kcenon/common_system/pull/12
- logger_system: Phase 2 Interface Unification (Logger)