### PR TITLE
feat(phase2): Migrate interfaces to Result<T> pattern

### DIFF
--- a/include/kcenon/thread/interfaces/monitorable_interface.h
+++ b/include/kcenon/thread/interfaces/monitorable_interface.h
@@ -7,6 +7,10 @@
 
 #include "monitoring_interface.h"
 
+#ifdef BUILD_WITH_COMMON_SYSTEM
+#include <kcenon/common/patterns/result.h>
+#endif
+
 namespace kcenon::thread {
 
 /**
@@ -19,8 +23,17 @@ public:
     /** @brief Fetch current metrics snapshot. */
     virtual auto get_metrics() -> ::monitoring_interface::metrics_snapshot = 0;
 
-    /** @brief Reset internal metrics counters. */
+    /**
+     * @brief Reset internal metrics counters.
+     * @return VoidResult indicating success or error
+     *
+     * @note Can fail if metrics system state cannot be reset
+     */
+#ifdef BUILD_WITH_COMMON_SYSTEM
+    virtual auto reset_metrics() -> common::VoidResult = 0;
+#else
     virtual void reset_metrics() = 0;
+#endif
 };
 
 } // namespace kcenon::thread


### PR DESCRIPTION
## Summary

Converted 9 interface methods to use Result<T> pattern for explicit error handling, replacing bool/void returns that couldn't convey failure details.

## Changes

### shared_interfaces.h (8 methods)

1. **ILogger::log()** → `VoidResult`
   - Can fail due to I/O errors, disk space issues, or queue overflow

2. **ILogger::flush()** → `VoidResult`
   - Can fail due to I/O errors during flush operation

3. **IMonitorable::set_metrics_enabled()** → `VoidResult`
   - Can fail if metrics system cannot be initialized or shutdown

4. **IExecutor::execute()** → `Result<std::future<void>>`
   - Can fail if task queue is full, executor is shutting down, or system resources are exhausted

5. **IService::initialize()** → `VoidResult`
   - Provides detailed error information about initialization failures (replaces bool)

6. **IService::shutdown()** → `VoidResult`
   - Can fail during resource cleanup

7. **IConfigurable::configure()** → `VoidResult`
   - Can fail if configuration is invalid or cannot be applied

8. **IConfigurable::validate_configuration()** → `VoidResult`
   - Provides specific information about what makes the configuration invalid (replaces bool)

### monitorable_interface.h (1 method)

9. **monitorable_interface::reset_metrics()** → `VoidResult`
   - Can fail if metrics system state cannot be reset

## Backward Compatibility

- All changes are conditional on `BUILD_WITH_COMMON_SYSTEM` flag
- Legacy bool/void versions remain available when flag is disabled
- Deprecated attributes guide migration:
  ```cpp
  [[deprecated("Use VoidResult version when BUILD_WITH_COMMON_SYSTEM is enabled")]]
  virtual bool initialize() = 0;
  ```

## Benefits

- **Explicit error information** instead of silent failures
- **Better error propagation** across system boundaries
- **Consistent error handling** patterns
- **Improved debugging** with detailed failure reasons
- **Type-safe** error handling without exceptions

## Migration Example

```cpp
// Before (bool - no error details)
bool success = service->initialize();
if (!success) {
    // Why did it fail? Unknown!
}

// After (VoidResult - detailed error info)
auto result = service->initialize();
if (common::is_error(result)) {
    auto err = common::get_error(result);
    log_error("Init failed: {} (code: {})", err.message, err.code);
    return err;
}
```

## Test Plan

- [ ] Verify compilation with BUILD_WITH_COMMON_SYSTEM=ON
- [ ] Verify compilation with BUILD_WITH_COMMON_SYSTEM=OFF
- [ ] Test backward compatibility with existing code
- [ ] Update implementations to use new signatures

## Part of Phase 2

This is part of **Phase 2 Task 2.4: Result<T> Pattern Migration**

## Dependencies

- Requires: common_system PR #14 (Result<T> helper macros)

## Related Issues

- NEED_TO_FIX.md Phase 2 Task 2.4