### PR TITLE
Refactor: Add support for centralized common_system in Sources directory

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -27,14 +27,30 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 
 # Add common_system support if available
 if(BUILD_WITH_COMMON_SYSTEM)
-    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../../common_system/include")
+    # Priority: Local Sources/ directory first, then relative paths
+    set(_THREAD_COMMON_SEARCH_PATHS
+        "/Users/dongcheolshin/Sources/common_system/include"      # macOS development (HIGHEST PRIORITY)
+        "/home/${USER}/Sources/common_system/include"              # Linux development
+        "${CMAKE_CURRENT_SOURCE_DIR}/../../common_system/include"  # Sibling directory (fallback)
+    )
+
+    set(_THREAD_COMMON_SYSTEM_PATH "")
+    foreach(_path ${_THREAD_COMMON_SEARCH_PATHS})
+        if(EXISTS "${_path}")
+            message(STATUS "Found common_system at: ${_path}")
+            set(_THREAD_COMMON_SYSTEM_PATH "${_path}")
+            break()
+        endif()
+    endforeach()
+
+    if(_THREAD_COMMON_SYSTEM_PATH)
         target_include_directories(${PROJECT_NAME} PUBLIC
-            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../common_system/include>
+            $<BUILD_INTERFACE:${_THREAD_COMMON_SYSTEM_PATH}>
         )
         target_compile_definitions(${PROJECT_NAME} PUBLIC BUILD_WITH_COMMON_SYSTEM)
-        message(STATUS "ThreadSystem: common_system support enabled")
+        message(STATUS "ThreadSystem: common_system support enabled from ${_THREAD_COMMON_SYSTEM_PATH}")
     else()
-        message(WARNING "ThreadSystem: BUILD_WITH_COMMON_SYSTEM is ON but common_system not found")
+        message(WARNING "ThreadSystem: BUILD_WITH_COMMON_SYSTEM is ON but common_system not found in any search path")
     endif()
 endif()
 


### PR DESCRIPTION
## Summary

This PR updates thread_system to support using common_system from a centralized Sources directory when BUILD_WITH_COMMON_SYSTEM is enabled.

## Changes

- Update core/CMakeLists.txt to search for common_system in centralized locations
- Add prioritized search path system:
  1. `/Users/dongcheolshin/Sources/common_system/include` (macOS development - highest priority)
  2. `/home/${USER}/Sources/common_system/include` (Linux development)
  3. `${CMAKE_CURRENT_SOURCE_DIR}/../../common_system/include` (sibling directory fallback)
- Maintain backward compatibility with relative paths for CI/CD
- Add warning message when BUILD_WITH_COMMON_SYSTEM is ON but common_system not found

## Benefits

- **Single Source of Truth**: common_system maintained in one central location
- **Easier Integration**: Projects using thread_system can share the same common_system instance
- **Better Maintainability**: Clearer dependency structure across all projects
- **CI/CD Compatible**: Maintains fallback paths for existing workflows
- **Optional Integration**: Only affects builds with BUILD_WITH_COMMON_SYSTEM=ON

## Testing

- ✅ CMake configuration successfully finds common_system when BUILD_WITH_COMMON_SYSTEM=ON
- ✅ Appropriate warning shown when common_system not found
- ✅ All existing functionality preserved
- ✅ Backward compatibility maintained

## Migration Guide

When building with common_system support, ensure the following structure:
```
/Users/dongcheolshin/Sources/
├── common_system/
├── thread_system/
└── [other projects]
```

For Linux users, the equivalent is `/home/${USER}/Sources/`.

Build with:
```bash
cmake -DBUILD_WITH_COMMON_SYSTEM=ON ..
```