### PR TITLE
Fix P0 issue: Prevent worker thread exception handling infinite loop

### DIFF
--- a/include/kcenon/thread/core/thread_base.h
+++ b/include/kcenon/thread/core/thread_base.h
@@ -303,12 +303,28 @@ namespace kcenon::thread
 		 *
 		 * If set, the worker thread can wake periodically (in addition to any other wake
 		 * conditions) to perform tasks at regular intervals.
-		 * 
+		 *
 		 * @note Access to this member must be synchronized using wake_interval_mutex_
 		 */
 		std::optional<std::chrono::milliseconds> wake_interval_;
 
 	private:
+		/**
+		 * @brief Counter for consecutive failures in do_work() execution.
+		 *
+		 * This counter is incremented each time do_work() throws an exception.
+		 * It is reset to 0 when do_work() completes successfully.
+		 * Used to implement exponential backoff and prevent infinite error loops.
+		 */
+		std::atomic<int> consecutive_failures_{0};
+
+		/**
+		 * @brief Maximum number of consecutive failures before stopping the thread.
+		 *
+		 * If do_work() throws exceptions this many times in a row, the thread
+		 * will stop automatically to prevent infinite error loops and resource exhaustion.
+		 */
+		static constexpr int max_consecutive_failures = 10;
 		/**
 		 * @brief Mutex for synchronizing access to the wake_interval_ member.
 		 * 


### PR DESCRIPTION
## Summary

This PR fixes a critical P0 issue where worker threads could enter an infinite error loop if `do_work()` throws exceptions repeatedly.

## Problem

If `do_work()` throws exceptions repeatedly (e.g., due to persistent resource exhaustion), the thread enters an infinite error loop causing:
- High CPU consumption (100%)
- Log flooding (thousands of error messages per second)
- System resource exhaustion

## Solution

Implemented consecutive failure tracking with exponential backoff and automatic shutdown:

1. **Failure Tracking**: Atomic counter tracks consecutive failures
2. **Exponential Backoff**: Progressive delays prevent CPU spinning (100ms → 200ms → 400ms → ... → max 10 seconds)
3. **Automatic Shutdown**: Thread stops after 10 consecutive failures
4. **Automatic Recovery**: Counter resets to 0 on successful execution

## Changes

### include/kcenon/thread/core/thread_base.h
- Added `consecutive_failures_` atomic<int> member
- Added `max_consecutive_failures` constant (set to 10)

### src/core/thread_base.cpp
- Modified exception handler to track failure count
- Added exponential backoff sleep between failures
- Added automatic thread shutdown after max failures
- Reset counter on successful execution

## Backoff Schedule

| Failure Count | Delay |
|---------------|-------|
| 1 | 100ms |
| 2 | 200ms |
| 3 | 400ms |
| 4 | 800ms |
| 5 | 1.6s |
| 6 | 3.2s |
| 7 | 6.4s |
| 8-9 | 10s (capped) |
| 10 | Thread stops |

## Testing

- ✅ All 56 thread_base unit tests pass
- ✅ Smoke and integration tests pass
- ✅ Build succeeds with no errors
- ✅ Total test time: 3.47s

## Thread Safety

- Uses `std::atomic` with `memory_order_relaxed` for the failure counter
- No locks required - atomic operations ensure thread-safe updates
- Counter is only accessed by the worker thread itself (no contention)

## Files Modified

- `include/kcenon/thread/core/thread_base.h` (+16 lines)
- `src/core/thread_base.cpp` (+24 lines, -3 lines)