### PR TITLE
Fix(core): Enhance hazard pointer safety and resource management

### DIFF
--- a/unittest/thread_base_test/hazard_pointer_exhaustion_test.cpp
+++ b/unittest/thread_base_test/hazard_pointer_exhaustion_test.cpp
@@ -1,0 +1,30 @@
+#include <gtest/gtest.h>
+#include <kcenon/thread/core/hazard_pointer.h>
+#include <vector>
+#include <stdexcept>
+
+namespace kcenon::thread {
+
+TEST(HazardPointerExhaustionTest, ThrowsOnExhaustion) {
+    std::vector<hazard_pointer> pointers;
+    // Get the limit
+    constexpr size_t limit = detail::thread_hazard_list::MAX_HAZARDS_PER_THREAD;
+
+    // Acquire all available slots
+    for (size_t i = 0; i < limit; ++i) {
+        ASSERT_NO_THROW({
+            pointers.push_back(hazard_pointer());
+        });
+    }
+
+    // Verify that we actually have 'limit' active pointers
+    // (This step implicitly checks if the previous loop succeeded)
+    ASSERT_EQ(pointers.size(), limit);
+
+    // Try to acquire one more, expecting exception
+    EXPECT_THROW({
+        hazard_pointer hp;
+    }, std::runtime_error);
+}
+
+} // namespace kcenon::thread


### PR DESCRIPTION
- Implement reuse of inactive hazard pointer lists to prevent memory leaks
- Throw exception when hazard pointer slots are exhausted instead of silent failure
- Protect tail pointer in lockfree queue enqueue to prevent potential UAF
- Add unit test for hazard pointer slot exhaustion