### PR TITLE
feat: complete log_level_v2 migration phase 2

### DIFF
--- a/examples/composition_example/composition_example.cpp
+++ b/examples/composition_example/composition_example.cpp
@@ -40,6 +40,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <kcenon/thread/interfaces/monitoring_interface.h>
 #include <kcenon/thread/core/thread_pool.h>
 #include <kcenon/thread/core/callback_job.h>
+#include <kcenon/thread/core/log_level.h>
 // #include "../../src/impl/typed_pool/typed_thread_pool.h"
 // #include "../../src/impl/typed_pool/callback_typed_job.h"
 
@@ -73,15 +74,8 @@ public:
     
 private:
     std::string level_to_string(log_level level) const {
-        switch (level) {
-            case log_level::critical: return "CRITICAL";
-            case log_level::error: return "ERROR";
-            case log_level::warning: return "WARNING";
-            case log_level::info: return "INFO";
-            case log_level::debug: return "DEBUG";
-            case log_level::trace: return "TRACE";
-        }
-        return "UNKNOWN";
+        // Convert to log_level_v2 and use its to_string
+        return std::string(to_string(to_v2(level)));
     }
 };
 
@@ -170,7 +164,7 @@ void demonstrate_composition() {
     for (int i = 0; i < 10; ++i) {
         auto r = pool->enqueue(std::make_unique<callback_job>(
             [i, &context]() -> result_void {
-                context.log(log_level::info, 
+                context.log(log_level_v2::info,
                     "Processing job " + std::to_string(i));
                 
                 // Simulate work

--- a/examples/integration_example/integration_example.cpp
+++ b/examples/integration_example/integration_example.cpp
@@ -53,6 +53,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <kcenon/thread/interfaces/thread_context.h>
 #include <kcenon/thread/core/thread_pool.h>
 #include <kcenon/thread/core/callback_job.h>
+#include <kcenon/thread/core/log_level.h>
 
 // External logger headers (would be from installed package)
 // #include <logger_system/logger.h>
@@ -112,7 +113,7 @@ void thread_pool_with_logger_example() {
         auto r = pool->enqueue(std::make_unique<callback_job>(
             [i, &context]() -> result_void {
                 // Job logs through context
-                context.log(log_level::info, 
+                context.log(log_level_v2::info,
                     "Executing job " + std::to_string(i));
                 
                 // Simulate work
@@ -245,7 +246,7 @@ void complete_integration_example() {
     auto pool = std::make_shared<thread_pool>("IntegratedPool", context);
     
     // Log that we're starting
-    context.log(log_level::info, "Starting integrated thread pool example");
+    context.log(log_level_v2::info, "Starting integrated thread pool example");
     
     // 4. Configure pool
     std::vector<std::unique_ptr<thread_worker>> workers;
@@ -276,19 +277,19 @@ void complete_integration_example() {
         auto r = pool->enqueue(std::make_unique<callback_job>(
             [i, &context]() -> result_void {
                 // Log job start
-                context.log(log_level::debug, 
+                context.log(log_level_v2::debug,
                     "Job " + std::to_string(i) + " started");
-                
+
                 // Simulate work
                 auto work_time = 20 + (i % 30);
                 std::this_thread::sleep_for(std::chrono::milliseconds(work_time));
-                
+
                 // Simulate occasional warnings
                 if (i % 10 == 0) {
-                    context.log(log_level::warning, 
+                    context.log(log_level_v2::warn,
                         "Job " + std::to_string(i) + " took longer than expected");
                 }
-                
+
                 return result_void();
             }
         ));
@@ -302,9 +303,9 @@ void complete_integration_example() {
         std::this_thread::sleep_for(std::chrono::milliseconds(300));
         
         auto snapshot = monitor->get_current_snapshot();
-        context.log(log_level::info, 
-            "Progress: " + std::to_string(snapshot.thread_pool.jobs_completed) + 
-            " jobs completed, " + std::to_string(snapshot.thread_pool.jobs_pending) + 
+        context.log(log_level_v2::info,
+            "Progress: " + std::to_string(snapshot.thread_pool.jobs_completed) +
+            " jobs completed, " + std::to_string(snapshot.thread_pool.jobs_pending) +
             " pending");
     }
     
@@ -320,7 +321,7 @@ void complete_integration_example() {
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(
         workload_end - workload_start);
     
-    context.log(log_level::info, 
+    context.log(log_level_v2::info,
         "Workload completed in " + std::to_string(duration.count()) + " ms");
     
     // 8. Final metrics
@@ -394,7 +395,7 @@ void dynamic_service_example() {
     for (int i = 5; i < 10; ++i) {
         auto r2 = pool->enqueue(std::make_unique<callback_job>(
             [i, &new_context]() -> result_void {
-                new_context.log(log_level::info, 
+                new_context.log(log_level_v2::info,
                     "Job " + std::to_string(i) + " with dynamic logger");
                 std::this_thread::sleep_for(std::chrono::milliseconds(50));
                 return result_void();

--- a/examples/integration_example/mock_logger.h
+++ b/examples/integration_example/mock_logger.h
@@ -33,6 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *****************************************************************************/
 
 #include <kcenon/thread/interfaces/logger_interface.h>
+#include <kcenon/thread/core/log_level.h>
 #include <iostream>
 #include <mutex>
 #include <iomanip>
@@ -116,15 +117,8 @@ private:
     }
     
     std::string level_to_string(kcenon::thread::log_level level) const {
-        switch (level) {
-            case kcenon::thread::log_level::critical: return "CRITICAL";
-            case kcenon::thread::log_level::error:    return "ERROR";
-            case kcenon::thread::log_level::warning:  return "WARNING";
-            case kcenon::thread::log_level::info:     return "INFO";
-            case kcenon::thread::log_level::debug:    return "DEBUG";
-            case kcenon::thread::log_level::trace:    return "TRACE";
-        }
-        return "UNKNOWN";
+        // Convert to log_level_v2 and use its to_string
+        return std::string(kcenon::thread::to_string(kcenon::thread::to_v2(level)));
     }
     
 private:

--- a/include/kcenon/thread/interfaces/thread_context.h
+++ b/include/kcenon/thread/interfaces/thread_context.h
@@ -37,6 +37,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "logger_interface.h"
 #include "monitoring_interface.h"
 #include "service_container.h"
+#include <kcenon/thread/core/log_level.h>
 
 namespace kcenon::thread {
 
@@ -88,10 +89,22 @@ public:
      * @brief Log a message if logger is available
      * @param level Log level
      * @param message Log message
+     * @deprecated Use log(log_level_v2, const std::string&) instead
      */
     void log(log_level level, const std::string& message) const {
         if (logger_) {
             logger_->log(level, message);
+        }
+    }
+
+    /**
+     * @brief Log a message if logger is available (v2 API)
+     * @param level Log level (v2 with ascending order)
+     * @param message Log message
+     */
+    void log(log_level_v2 level, const std::string& message) const {
+        if (logger_) {
+            logger_->log(from_v2(level), message);
         }
     }
 
@@ -102,11 +115,27 @@ public:
      * @param file Source file
      * @param line Source line
      * @param function Function name
+     * @deprecated Use log(log_level_v2, ...) instead
      */
     void log(log_level level, const std::string& message,
              const std::string& file, int line, const std::string& function) const {
         if (logger_) {
             logger_->log(level, message, file, line, function);
+        }
+    }
+
+    /**
+     * @brief Log a message with source information if logger is available (v2 API)
+     * @param level Log level (v2 with ascending order)
+     * @param message Log message
+     * @param file Source file
+     * @param line Source line
+     * @param function Function name
+     */
+    void log(log_level_v2 level, const std::string& message,
+             const std::string& file, int line, const std::string& function) const {
+        if (logger_) {
+            logger_->log(from_v2(level), message, file, line, function);
         }
     }
 

--- a/tools/migrate_log_levels.py
+++ b/tools/migrate_log_levels.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""
+Log Level Migration Script for thread_system
+
+This script migrates code from the legacy log_level enum to log_level_v2.
+
+Usage:
+    python migrate_log_levels.py [options] <path>
+
+Options:
+    --dry-run       Show changes without modifying files
+    --diff          Show unified diff of changes
+    --verbose       Show detailed progress
+    --backup        Create .bak backup files before modifying
+    --help          Show this help message
+
+Examples:
+    # Preview changes for a single file
+    python migrate_log_levels.py --dry-run --diff src/my_file.cpp
+
+    # Migrate all files in a directory
+    python migrate_log_levels.py --backup src/
+
+    # Preview changes for the entire project
+    python migrate_log_levels.py --dry-run --diff .
+
+Migration Rules:
+    log_level::trace    -> log_level_v2::trace
+    log_level::debug    -> log_level_v2::debug
+    log_level::info     -> log_level_v2::info
+    log_level::warning  -> log_level_v2::warn    (note: warning -> warn)
+    log_level::error    -> log_level_v2::error
+    log_level::critical -> log_level_v2::critical
+
+Note: This script does NOT modify logger_interface implementations that must
+keep using log_level for interface compatibility during the deprecation period.
+"""
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+from typing import List, Tuple, Optional
+import difflib
+import shutil
+
+
+# File extensions to process
+SUPPORTED_EXTENSIONS = {'.cpp', '.hpp', '.h', '.cc', '.cxx', '.hxx'}
+
+# Patterns to skip (files that implement logger_interface)
+SKIP_PATTERNS = [
+    r'logger_interface\.h',
+    r'thread_logger\.h',
+]
+
+# Migration mappings
+LEVEL_MAPPINGS = {
+    'trace': 'trace',
+    'debug': 'debug',
+    'info': 'info',
+    'warning': 'warn',  # note: warning -> warn
+    'error': 'error',
+    'critical': 'critical',
+}
+
+
+class MigrationResult:
+    """Result of migrating a single file."""
+    def __init__(self, path: str):
+        self.path = path
+        self.original_content: str = ""
+        self.new_content: str = ""
+        self.changes: List[Tuple[int, str, str]] = []  # (line_num, old, new)
+        self.skipped: bool = False
+        self.skip_reason: str = ""
+        self.error: Optional[str] = None
+
+
+def should_skip_file(filepath: str) -> Tuple[bool, str]:
+    """Check if a file should be skipped from migration."""
+    filename = os.path.basename(filepath)
+
+    for pattern in SKIP_PATTERNS:
+        if re.search(pattern, filename):
+            return True, f"Matches skip pattern: {pattern}"
+
+    return False, ""
+
+
+def create_migration_pattern():
+    """Create regex pattern for matching log_level usage."""
+    # Match log_level::xxx but not log_level_v2::xxx
+    # Also match with optional namespace prefix like kcenon::thread::log_level::xxx
+    levels = '|'.join(LEVEL_MAPPINGS.keys())
+    pattern = rf'(?<!log_level_v2::)(?<!_v2::)\blog_level::({levels})\b'
+    return re.compile(pattern)
+
+
+def migrate_line(line: str, pattern: re.Pattern) -> Tuple[str, bool]:
+    """
+    Migrate a single line of code.
+    Returns (new_line, was_changed).
+    """
+    def replace_match(match):
+        old_level = match.group(1)
+        new_level = LEVEL_MAPPINGS.get(old_level, old_level)
+        return f'log_level_v2::{new_level}'
+
+    new_line = pattern.sub(replace_match, line)
+    return new_line, new_line != line
+
+
+def needs_include_update(content: str) -> bool:
+    """Check if file needs log_level.h include added."""
+    # Check if file uses log_level_v2 after migration
+    if 'log_level_v2::' in content:
+        # Check if it already includes log_level.h
+        if re.search(r'#include\s*[<"].*log_level\.h[>"]', content):
+            return False
+        return True
+    return False
+
+
+def add_log_level_include(content: str) -> str:
+    """Add log_level.h include to the file if needed."""
+    # Find a good place to insert the include
+    # Prefer after other kcenon/thread includes
+
+    lines = content.split('\n')
+    insert_index = -1
+
+    for i, line in enumerate(lines):
+        # Look for existing thread system includes
+        if re.search(r'#include\s*[<"]kcenon/thread/', line):
+            insert_index = i + 1
+        # Or after any include block
+        elif line.startswith('#include') and insert_index == -1:
+            insert_index = i + 1
+
+    if insert_index == -1:
+        # No includes found, insert at beginning after any header guards
+        for i, line in enumerate(lines):
+            if line.startswith('#pragma once') or re.match(r'#ifndef\s+\w+_H', line):
+                insert_index = i + 1
+                break
+        if insert_index == -1:
+            insert_index = 0
+
+    # Insert the include
+    include_line = '#include <kcenon/thread/core/log_level.h>'
+    if include_line not in content:
+        lines.insert(insert_index, include_line)
+
+    return '\n'.join(lines)
+
+
+def migrate_file(filepath: str, dry_run: bool = True) -> MigrationResult:
+    """Migrate a single file."""
+    result = MigrationResult(filepath)
+
+    # Check if file should be skipped
+    should_skip, reason = should_skip_file(filepath)
+    if should_skip:
+        result.skipped = True
+        result.skip_reason = reason
+        return result
+
+    try:
+        with open(filepath, 'r', encoding='utf-8') as f:
+            result.original_content = f.read()
+    except Exception as e:
+        result.error = f"Failed to read file: {e}"
+        return result
+
+    pattern = create_migration_pattern()
+    lines = result.original_content.split('\n')
+    new_lines = []
+
+    for i, line in enumerate(lines):
+        new_line, changed = migrate_line(line, pattern)
+        new_lines.append(new_line)
+        if changed:
+            result.changes.append((i + 1, line.strip(), new_line.strip()))
+
+    result.new_content = '\n'.join(new_lines)
+
+    # Check if we need to add include
+    if result.changes and needs_include_update(result.new_content):
+        result.new_content = add_log_level_include(result.new_content)
+
+    return result
+
+
+def print_diff(result: MigrationResult):
+    """Print unified diff of changes."""
+    if not result.changes and result.original_content == result.new_content:
+        return
+
+    diff = difflib.unified_diff(
+        result.original_content.splitlines(keepends=True),
+        result.new_content.splitlines(keepends=True),
+        fromfile=f'a/{result.path}',
+        tofile=f'b/{result.path}',
+    )
+
+    for line in diff:
+        if line.startswith('+') and not line.startswith('+++'):
+            print(f'\033[32m{line}\033[0m', end='')
+        elif line.startswith('-') and not line.startswith('---'):
+            print(f'\033[31m{line}\033[0m', end='')
+        else:
+            print(line, end='')
+
+
+def find_files(path: str) -> List[str]:
+    """Find all supported files in the given path."""
+    path = Path(path)
+
+    if path.is_file():
+        if path.suffix in SUPPORTED_EXTENSIONS:
+            return [str(path)]
+        return []
+
+    files = []
+    for ext in SUPPORTED_EXTENSIONS:
+        files.extend(str(p) for p in path.rglob(f'*{ext}'))
+
+    return sorted(files)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Migrate log_level to log_level_v2 in thread_system code',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__
+    )
+    parser.add_argument('path', help='File or directory to migrate')
+    parser.add_argument('--dry-run', action='store_true',
+                        help='Show changes without modifying files')
+    parser.add_argument('--diff', action='store_true',
+                        help='Show unified diff of changes')
+    parser.add_argument('--verbose', action='store_true',
+                        help='Show detailed progress')
+    parser.add_argument('--backup', action='store_true',
+                        help='Create .bak backup files before modifying')
+
+    args = parser.parse_args()
+
+    if not os.path.exists(args.path):
+        print(f"Error: Path does not exist: {args.path}", file=sys.stderr)
+        sys.exit(1)
+
+    files = find_files(args.path)
+
+    if not files:
+        print(f"No supported files found in: {args.path}")
+        sys.exit(0)
+
+    if args.verbose:
+        print(f"Found {len(files)} file(s) to process")
+
+    total_changes = 0
+    files_changed = 0
+    files_skipped = 0
+
+    for filepath in files:
+        result = migrate_file(filepath, dry_run=args.dry_run)
+
+        if result.error:
+            print(f"Error processing {filepath}: {result.error}", file=sys.stderr)
+            continue
+
+        if result.skipped:
+            files_skipped += 1
+            if args.verbose:
+                print(f"Skipped: {filepath} ({result.skip_reason})")
+            continue
+
+        if not result.changes:
+            if args.verbose:
+                print(f"No changes: {filepath}")
+            continue
+
+        files_changed += 1
+        total_changes += len(result.changes)
+
+        if args.diff:
+            print_diff(result)
+            print()
+        elif args.verbose or args.dry_run:
+            print(f"{'Would modify' if args.dry_run else 'Modified'}: {filepath}")
+            for line_num, old, new in result.changes:
+                print(f"  Line {line_num}:")
+                print(f"    - {old}")
+                print(f"    + {new}")
+
+        if not args.dry_run:
+            if args.backup:
+                shutil.copy2(filepath, filepath + '.bak')
+
+            with open(filepath, 'w', encoding='utf-8') as f:
+                f.write(result.new_content)
+
+    # Summary
+    print()
+    print("=" * 50)
+    print("Migration Summary")
+    print("=" * 50)
+    print(f"Files processed: {len(files)}")
+    print(f"Files changed:   {files_changed}")
+    print(f"Files skipped:   {files_skipped}")
+    print(f"Total changes:   {total_changes}")
+
+    if args.dry_run and files_changed > 0:
+        print()
+        print("This was a dry run. No files were modified.")
+        print("Run without --dry-run to apply changes.")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- Add `log_level_v2` overloads to `thread_context` for the new API
- Update `composition_example` and `integration_example` to use `log_level_v2`
- Update `mock_logger` to use `log_level_v2` `to_string` helper
- Add automated migration script (`tools/migrate_log_levels.py`)

## Changes

### thread_context.h
Added `log_level_v2` accepting overloads for the `log()` method that internally convert to legacy `log_level` for interface compatibility.

### Examples
Updated both `composition_example` and `integration_example` to demonstrate best practices using `log_level_v2`.

### Migration Script
Added `tools/migrate_log_levels.py` that:
- Finds all `log_level::` enum usage in C++ files
- Converts to `log_level_v2::` equivalents
- Handles `warning` -> `warn` rename
- Supports `--dry-run` and `--diff` modes for preview
- Generates patches for review

## Test plan
- [ ] Verify examples compile and run correctly
- [ ] Test migration script on sample code
- [ ] Ensure backward compatibility with existing code