### PR TITLE
Add unified aliases and fix template instantiation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,6 +196,17 @@ else()
     add_subdirectory(interfaces)
     add_subdirectory(utilities)
     add_subdirectory(core)
+    # Provide unified aliases for parent projects when building as a submodule.
+    # This allows dependents to link against ThreadSystem/thread_system even
+    # though only the legacy targets (thread_base/utilities/interfaces) exist.
+    if(TARGET thread_base)
+        if(NOT TARGET ThreadSystem)
+            add_library(ThreadSystem ALIAS thread_base)
+        endif()
+        if(NOT TARGET thread_system)
+            add_library(thread_system ALIAS thread_base)
+        endif()
+    endif()
     message(STATUS "ThreadSystem building as submodule - samples and tests disabled")
 endif()
 

--- a/src/impl/typed_pool/callback_typed_job.cpp
+++ b/src/impl/typed_pool/callback_typed_job.cpp
@@ -34,33 +34,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace kcenon::thread
 {
-	template <typename job_type>
-	callback_typed_job_t<job_type>::callback_typed_job_t(
-		const std::function<result_void(void)>& callback,
-		job_type priority,
-		const std::string& name)
-		: typed_job_t<job_type>(priority, name)
-		, callback_(callback)
-	{
-	}
-
-	template <typename job_type>
-	callback_typed_job_t<job_type>::~callback_typed_job_t()
-	{
-	}
-
-	template <typename job_type>
-	auto callback_typed_job_t<job_type>::do_work() -> result_void
-	{
-		if (!callback_)
-		{
-			return result_void(error(error_code::invalid_argument, "Callback is null"));
-		}
-
-		return callback_();
-	}
-
 	// Explicit template instantiation for job_types
 	template class callback_typed_job_t<job_types>;
-
 } // namespace kcenon::thread

--- a/src/impl/typed_pool/callback_typed_job.h
+++ b/src/impl/typed_pool/callback_typed_job.h
@@ -114,5 +114,32 @@ namespace kcenon::thread
 	 * priority type.
 	 */
 	using callback_typed_job = callback_typed_job_t<job_types>;
-} // namespace kcenon::thread
 
+	// Template definitions are provided in-header to support external priority types.
+	template <typename job_type>
+	callback_typed_job_t<job_type>::callback_typed_job_t(
+		const std::function<result_void(void)>& callback,
+		job_type priority,
+		const std::string& name)
+		: typed_job_t<job_type>(priority, name)
+		, callback_(callback)
+	{
+	}
+
+	template <typename job_type>
+	callback_typed_job_t<job_type>::~callback_typed_job_t() = default;
+
+	template <typename job_type>
+	auto callback_typed_job_t<job_type>::do_work() -> result_void
+	{
+		if (!callback_)
+		{
+			return result_void(error(error_code::invalid_argument, "Callback is null"));
+		}
+
+		return callback_();
+	}
+
+	// Keep a single explicit instantiation for the default job_types in the .cpp translation unit.
+	extern template class callback_typed_job_t<job_types>;
+} // namespace kcenon::thread


### PR DESCRIPTION
## Summary

**CMake changes:**
- Add `ThreadSystem` and `thread_system` aliases pointing to `thread_base` when building as a submodule
- Allows parent projects to link using either legacy or modern target names

**Template changes:**
- Move `callback_typed_job` template definitions from .cpp to .h header
- Use `extern template` to keep explicit instantiation in translation unit
- Enables external code to use custom priority types without modifying library source

## Test plan
- [ ] Build thread_system standalone
- [ ] Build as submodule in unified workspace
- [ ] Verify linking works with both `ThreadSystem` and `thread_system` target names
- [ ] Test custom priority type instantiation in external project