### PR TITLE
fix(cmake): resolve utilities target not found after installation

### DIFF
--- a/cmake/ThreadSystemConfig.cmake.in
+++ b/cmake/ThreadSystemConfig.cmake.in
@@ -19,25 +19,56 @@ else()
     find_dependency(fmt CONFIG QUIET)
 endif()
 
-find_dependency(Iconv)
+find_dependency(Iconv QUIET)
 
 # Include the targets file
 include("${CMAKE_CURRENT_LIST_DIR}/ThreadSystemTargets.cmake")
 
-# Set up convenience variables
-set(ThreadSystem_LIBRARIES 
-    ThreadSystem::utilities
-    ThreadSystem::thread_base
-    ThreadSystem::logger
-    ThreadSystem::thread_pool
-    ThreadSystem::typed_thread_pool
-)
+# Determine available target structure
+# New unified build exports ThreadSystem::ThreadSystem as a single library
+# Legacy build exports individual component libraries
+if(TARGET ThreadSystem::ThreadSystem)
+    # Unified library mode - create component aliases for compatibility
+    set(_THREAD_SYSTEM_UNIFIED_MODE TRUE)
+    set(_THREAD_SYSTEM_MAIN_TARGET ThreadSystem::ThreadSystem)
 
-# Verify that all targets exist
-foreach(target ${ThreadSystem_LIBRARIES})
-    if(NOT TARGET ${target})
-        message(FATAL_ERROR "ThreadSystem target '${target}' not found")
+    # Create component aliases pointing to the unified library
+    if(NOT TARGET ThreadSystem::utilities)
+        add_library(ThreadSystem::utilities ALIAS ThreadSystem::ThreadSystem)
     endif()
-endforeach()
+    if(NOT TARGET ThreadSystem::thread_base)
+        add_library(ThreadSystem::thread_base ALIAS ThreadSystem::ThreadSystem)
+    endif()
+    if(NOT TARGET ThreadSystem::interfaces)
+        add_library(ThreadSystem::interfaces ALIAS ThreadSystem::ThreadSystem)
+    endif()
+    if(NOT TARGET ThreadSystem::thread_pool)
+        add_library(ThreadSystem::thread_pool ALIAS ThreadSystem::ThreadSystem)
+    endif()
+    if(NOT TARGET ThreadSystem::typed_thread_pool)
+        add_library(ThreadSystem::typed_thread_pool ALIAS ThreadSystem::ThreadSystem)
+    endif()
+    if(NOT TARGET ThreadSystem::logger)
+        add_library(ThreadSystem::logger ALIAS ThreadSystem::ThreadSystem)
+    endif()
+
+    # Set convenience variable to main target
+    set(ThreadSystem_LIBRARIES ThreadSystem::ThreadSystem)
+else()
+    # Legacy component mode - individual libraries
+    set(_THREAD_SYSTEM_UNIFIED_MODE FALSE)
+    set(ThreadSystem_LIBRARIES "")
+
+    # Collect available component targets
+    foreach(_component utilities thread_base interfaces thread_pool typed_thread_pool logger)
+        if(TARGET ThreadSystem::${_component})
+            list(APPEND ThreadSystem_LIBRARIES ThreadSystem::${_component})
+        endif()
+    endforeach()
+
+    if(NOT ThreadSystem_LIBRARIES)
+        message(FATAL_ERROR "No ThreadSystem targets found. Installation may be corrupted.")
+    endif()
+endif()
 
 check_required_components(ThreadSystem)

--- a/cmake/thread_system-config.cmake.in
+++ b/cmake/thread_system-config.cmake.in
@@ -16,8 +16,8 @@ if(DEFINED USE_STD_FORMAT)
         find_dependency(fmt CONFIG REQUIRED)
     endif()
 else()
-    # Default case: require fmt for compatibility
-    find_dependency(fmt REQUIRED)
+    # Default case: try to find fmt if available (don't require it)
+    find_dependency(fmt CONFIG QUIET)
 endif()
 
 # Additional dependencies for full functionality
@@ -26,53 +26,93 @@ find_dependency(Iconv QUIET)
 # Include the targets file with standardized naming
 include("${CMAKE_CURRENT_LIST_DIR}/thread_system-targets.cmake")
 
-# Component-wise target exports as required by T2.1
-set(thread_system_COMPONENT_TARGETS
-    thread_system::thread_pool
-    thread_system::service_container
-    thread_system::utilities
-    thread_system::thread_base
-    thread_system::lockfree
-)
+# Determine available target structure
+# New unified build exports thread_system::ThreadSystem as a single library
+# Legacy build exports individual component libraries
+if(TARGET thread_system::ThreadSystem)
+    # Unified library mode - create component aliases for compatibility
+    set(_THREAD_SYSTEM_UNIFIED_MODE TRUE)
+    set(_THREAD_SYSTEM_MAIN_TARGET thread_system::ThreadSystem)
 
-# Phase 2 T2.2: Direct target mapping with thread_system:: namespace
-# The targets are now directly available with thread_system:: namespace from targets file
-
-# Legacy compatibility - create ThreadSystem:: aliases for backward compatibility  
-if(TARGET thread_system::thread_pool AND NOT TARGET ThreadSystem::thread_pool)
-    add_library(ThreadSystem::thread_pool ALIAS thread_system::thread_pool)
-endif()
-
-if(TARGET thread_system::utilities AND NOT TARGET ThreadSystem::utilities)
-    add_library(ThreadSystem::utilities ALIAS thread_system::utilities)
-endif()
-
-if(TARGET thread_system::thread_base AND NOT TARGET ThreadSystem::thread_base)
-    add_library(ThreadSystem::thread_base ALIAS thread_system::thread_base)
-endif()
-
-if(TARGET thread_system::lockfree AND NOT TARGET ThreadSystem::lockfree)
-    add_library(ThreadSystem::lockfree ALIAS thread_system::lockfree)
-endif()
-
-# Service container is an alias to thread_base (contains service_registry)
-if(TARGET thread_system::thread_base AND NOT TARGET thread_system::service_container)
-    add_library(thread_system::service_container ALIAS thread_system::thread_base)
-endif()
-
-# Set up convenience variables for all components
-set(thread_system_LIBRARIES ${thread_system_COMPONENT_TARGETS})
-
-# Verify that all required targets exist
-foreach(target ${thread_system_COMPONENT_TARGETS})
-    if(NOT TARGET ${target})
-        # Check if legacy target exists
-        string(REPLACE "thread_system::" "ThreadSystem::" legacy_target ${target})
-        if(NOT TARGET ${legacy_target})
-            message(WARNING "thread_system target '${target}' not found. Some functionality may be limited.")
-        endif()
+    # Create component aliases pointing to the unified library
+    if(NOT TARGET thread_system::utilities)
+        add_library(thread_system::utilities ALIAS thread_system::ThreadSystem)
     endif()
-endforeach()
+    if(NOT TARGET thread_system::thread_base)
+        add_library(thread_system::thread_base ALIAS thread_system::ThreadSystem)
+    endif()
+    if(NOT TARGET thread_system::interfaces)
+        add_library(thread_system::interfaces ALIAS thread_system::ThreadSystem)
+    endif()
+    if(NOT TARGET thread_system::thread_pool)
+        add_library(thread_system::thread_pool ALIAS thread_system::ThreadSystem)
+    endif()
+    if(NOT TARGET thread_system::typed_thread_pool)
+        add_library(thread_system::typed_thread_pool ALIAS thread_system::ThreadSystem)
+    endif()
+    if(NOT TARGET thread_system::lockfree)
+        add_library(thread_system::lockfree ALIAS thread_system::ThreadSystem)
+    endif()
+    if(NOT TARGET thread_system::service_container)
+        add_library(thread_system::service_container ALIAS thread_system::ThreadSystem)
+    endif()
+
+    # Component-wise target exports for compatibility
+    set(thread_system_COMPONENT_TARGETS
+        thread_system::utilities
+        thread_system::thread_base
+        thread_system::thread_pool
+        thread_system::service_container
+        thread_system::lockfree
+    )
+
+    # Set main library variable
+    set(thread_system_LIBRARIES thread_system::ThreadSystem)
+else()
+    # Legacy component mode - individual libraries
+    set(_THREAD_SYSTEM_UNIFIED_MODE FALSE)
+
+    # Component-wise target exports as required by T2.1
+    set(thread_system_COMPONENT_TARGETS "")
+
+    foreach(_component utilities thread_base thread_pool service_container lockfree)
+        if(TARGET thread_system::${_component})
+            list(APPEND thread_system_COMPONENT_TARGETS thread_system::${_component})
+        endif()
+    endforeach()
+
+    # Service container is an alias to thread_base (contains service_registry)
+    if(TARGET thread_system::thread_base AND NOT TARGET thread_system::service_container)
+        add_library(thread_system::service_container ALIAS thread_system::thread_base)
+        list(APPEND thread_system_COMPONENT_TARGETS thread_system::service_container)
+    endif()
+
+    # Set up convenience variables for all components
+    set(thread_system_LIBRARIES ${thread_system_COMPONENT_TARGETS})
+
+    if(NOT thread_system_LIBRARIES)
+        message(FATAL_ERROR "No thread_system targets found. Installation may be corrupted.")
+    endif()
+endif()
+
+# Legacy compatibility - create ThreadSystem:: aliases for backward compatibility
+# Note: In unified mode, we must alias from the main target, not from component aliases
+# (CMake doesn't allow creating aliases of aliases)
+if(_THREAD_SYSTEM_UNIFIED_MODE)
+    # Create ThreadSystem:: aliases from the main target
+    foreach(_component utilities thread_base thread_pool lockfree interfaces typed_thread_pool)
+        if(NOT TARGET ThreadSystem::${_component})
+            add_library(ThreadSystem::${_component} ALIAS thread_system::ThreadSystem)
+        endif()
+    endforeach()
+else()
+    # In legacy mode, create aliases from actual component targets
+    foreach(_component utilities thread_base thread_pool lockfree)
+        if(TARGET thread_system::${_component} AND NOT TARGET ThreadSystem::${_component})
+            add_library(ThreadSystem::${_component} ALIAS thread_system::${_component})
+        endif()
+    endforeach()
+endif()
 
 # Component handling for find_package with COMPONENTS
 set(thread_system_FOUND TRUE)
@@ -80,31 +120,23 @@ set(thread_system_FOUND TRUE)
 # Handle specific components if requested
 if(thread_system_FIND_COMPONENTS)
     foreach(component ${thread_system_FIND_COMPONENTS})
-        if(component STREQUAL "thread_pool")
-            if(TARGET thread_system::thread_pool OR TARGET ThreadSystem::thread_pool)
-                set(thread_system_${component}_FOUND TRUE)
-            else()
-                set(thread_system_${component}_FOUND FALSE)
-                set(thread_system_FOUND FALSE)
-            endif()
-        elseif(component STREQUAL "service_container")
-            # Service container is part of thread_base module
-            if(TARGET thread_system::service_container OR TARGET ThreadSystem::thread_base)
-                set(thread_system_${component}_FOUND TRUE)
-            else()
-                set(thread_system_${component}_FOUND FALSE)
-                set(thread_system_FOUND FALSE)
-            endif()
-        elseif(component STREQUAL "thread_utilities" OR component STREQUAL "utilities")
-            if(TARGET thread_system::utilities OR TARGET ThreadSystem::utilities)
-                set(thread_system_${component}_FOUND TRUE)
-            else()
-                set(thread_system_${component}_FOUND FALSE)
-                set(thread_system_FOUND FALSE)
-            endif()
+        set(_component_found FALSE)
+
+        # Check for the component target (with unified mode fallback)
+        if(TARGET thread_system::${component})
+            set(_component_found TRUE)
+        elseif(_THREAD_SYSTEM_UNIFIED_MODE AND TARGET thread_system::ThreadSystem)
+            # In unified mode, all components are available through the main target
+            set(_component_found TRUE)
+        endif()
+
+        if(_component_found)
+            set(thread_system_${component}_FOUND TRUE)
         else()
-            message(WARNING "Unknown thread_system component: ${component}")
             set(thread_system_${component}_FOUND FALSE)
+            if(thread_system_FIND_REQUIRED_${component})
+                set(thread_system_FOUND FALSE)
+            endif()
         endif()
     endforeach()
 endif()


### PR DESCRIPTION
## Summary
- Fix CMake config error where `ThreadSystem::utilities` target was not found after installation
- Support both unified library mode (single `ThreadSystem` target) and legacy component mode
- Create proper component aliases in config files for backward compatibility

## Problem
When `thread_system` was built and installed with unified library structure, downstream projects failed with:
```
CMake Error: ThreadSystem target 'ThreadSystem::utilities' not found
```

This occurred because:
1. New build structure exports single `ThreadSystem::ThreadSystem` target
2. Config files expected individual component targets (`ThreadSystem::utilities`, `ThreadSystem::thread_base`, etc.)

## Solution
Updated both config files to:
1. Detect whether unified or legacy mode is active
2. Create component aliases pointing to main target in unified mode
3. Handle CMake's alias-of-alias restriction properly

## Test plan
- [x] Build and install thread_system with `-DBUILD_TESTS=OFF -DBUILD_SAMPLES=OFF`
- [x] Verify `find_package(ThreadSystem)` works correctly
- [x] Verify `find_package(thread_system)` works correctly
- [x] Verify all component targets (`ThreadSystem::utilities`, `thread_system::thread_base`, etc.) are available

Fixes #221