### PR TITLE
test(lockfree): add explicit unit tests for lockfree_job_queue capabilities

### DIFF
--- a/tests/unit/interfaces_test/queue_capabilities_test.cpp
+++ b/tests/unit/interfaces_test/queue_capabilities_test.cpp
@@ -36,6 +36,8 @@ BSD 3-Clause License
 #include <kcenon/thread/interfaces/queue_capabilities.h>
 #include <kcenon/thread/interfaces/queue_capabilities_interface.h>
 #include <kcenon/thread/core/job_queue.h>
+#include <kcenon/thread/lockfree/lockfree_job_queue.h>
+#include <kcenon/thread/core/callback_job.h>
 
 using namespace kcenon::thread;
 
@@ -292,4 +294,148 @@ TEST(job_queue_capabilities_test, capabilities_are_consistent)
     auto caps2 = queue->get_capabilities();
 
     EXPECT_EQ(caps1, caps2);
+}
+
+// =============================================================================
+// Phase 3: lockfree_job_queue capabilities tests
+// =============================================================================
+
+// Test lockfree_job_queue returns correct capabilities
+TEST(lockfree_queue_capabilities_test, get_capabilities_returns_correct_values)
+{
+    lockfree_job_queue queue;
+    auto caps = queue.get_capabilities();
+
+    // Lock-free queues have approximate size
+    EXPECT_FALSE(caps.exact_size);
+
+    // Empty check is non-atomic
+    EXPECT_FALSE(caps.atomic_empty_check);
+
+    // Is lock-free
+    EXPECT_TRUE(caps.lock_free);
+
+    // Not wait-free (dequeue is lock-free, not wait-free)
+    EXPECT_FALSE(caps.wait_free);
+
+    // No batch operations
+    EXPECT_FALSE(caps.supports_batch);
+
+    // No blocking wait (spin-wait only)
+    EXPECT_FALSE(caps.supports_blocking_wait);
+
+    // No stop() method
+    EXPECT_FALSE(caps.supports_stop);
+}
+
+// Test lockfree_job_queue convenience methods work correctly
+TEST(lockfree_queue_capabilities_test, convenience_methods_work)
+{
+    lockfree_job_queue queue;
+
+    EXPECT_FALSE(queue.has_exact_size());
+    EXPECT_FALSE(queue.has_atomic_empty());
+    EXPECT_TRUE(queue.is_lock_free());
+    EXPECT_FALSE(queue.is_wait_free());
+    EXPECT_FALSE(queue.supports_batch());
+    EXPECT_FALSE(queue.supports_blocking_wait());
+    EXPECT_FALSE(queue.supports_stop());
+}
+
+// Test lockfree_job_queue can be cast to interfaces
+TEST(lockfree_queue_capabilities_test, dynamic_cast_to_interface)
+{
+    lockfree_job_queue queue;
+
+    // Should be castable to queue_capabilities_interface
+    auto* cap_interface = dynamic_cast<queue_capabilities_interface*>(&queue);
+    ASSERT_NE(cap_interface, nullptr);
+
+    // And to scheduler_interface
+    auto* sched_interface = dynamic_cast<scheduler_interface*>(&queue);
+    ASSERT_NE(sched_interface, nullptr);
+}
+
+// Test lockfree_job_queue capabilities are consistent across multiple calls
+TEST(lockfree_queue_capabilities_test, capabilities_are_consistent)
+{
+    lockfree_job_queue queue;
+
+    // Get capabilities multiple times - should be consistent
+    auto caps1 = queue.get_capabilities();
+    auto caps2 = queue.get_capabilities();
+
+    EXPECT_EQ(caps1.exact_size, caps2.exact_size);
+    EXPECT_EQ(caps1.atomic_empty_check, caps2.atomic_empty_check);
+    EXPECT_EQ(caps1.lock_free, caps2.lock_free);
+    EXPECT_EQ(caps1.wait_free, caps2.wait_free);
+    EXPECT_EQ(caps1.supports_batch, caps2.supports_batch);
+    EXPECT_EQ(caps1.supports_blocking_wait, caps2.supports_blocking_wait);
+    EXPECT_EQ(caps1.supports_stop, caps2.supports_stop);
+
+    // Also use the equality operator
+    EXPECT_EQ(caps1, caps2);
+}
+
+// Test lockfree_job_queue scheduler interface still works
+TEST(lockfree_queue_capabilities_test, scheduler_interface_still_works)
+{
+    lockfree_job_queue queue;
+    scheduler_interface* scheduler = &queue;
+
+    // Schedule via interface
+    auto result = scheduler->schedule(
+        std::make_unique<callback_job>(
+            []() -> std::optional<std::string> { return std::nullopt; }));
+    EXPECT_FALSE(result.has_error());
+
+    // Get via interface
+    auto job = scheduler->get_next_job();
+    EXPECT_TRUE(job.has_value());
+    EXPECT_NE(job.value(), nullptr);
+}
+
+// =============================================================================
+// Phase 4: Comparison tests between queue types
+// =============================================================================
+
+// Test lockfree vs mutex-based queue capabilities
+TEST(queue_capabilities_comparison_test, lockfree_vs_mutex_capabilities)
+{
+    auto mutex_queue = std::make_shared<job_queue>();
+    lockfree_job_queue lockfree_queue;
+
+    auto mutex_caps = mutex_queue->get_capabilities();
+    auto lockfree_caps = lockfree_queue.get_capabilities();
+
+    // Mutex queue has exact size, lockfree doesn't
+    EXPECT_TRUE(mutex_caps.exact_size);
+    EXPECT_FALSE(lockfree_caps.exact_size);
+
+    // Mutex queue has atomic empty check, lockfree doesn't
+    EXPECT_TRUE(mutex_caps.atomic_empty_check);
+    EXPECT_FALSE(lockfree_caps.atomic_empty_check);
+
+    // Lockfree is lock-free, mutex isn't
+    EXPECT_FALSE(mutex_caps.lock_free);
+    EXPECT_TRUE(lockfree_caps.lock_free);
+
+    // Neither is wait-free
+    EXPECT_FALSE(mutex_caps.wait_free);
+    EXPECT_FALSE(lockfree_caps.wait_free);
+
+    // Mutex supports batch, lockfree doesn't
+    EXPECT_TRUE(mutex_caps.supports_batch);
+    EXPECT_FALSE(lockfree_caps.supports_batch);
+
+    // Mutex supports blocking wait, lockfree doesn't
+    EXPECT_TRUE(mutex_caps.supports_blocking_wait);
+    EXPECT_FALSE(lockfree_caps.supports_blocking_wait);
+
+    // Mutex supports stop, lockfree doesn't
+    EXPECT_TRUE(mutex_caps.supports_stop);
+    EXPECT_FALSE(lockfree_caps.supports_stop);
+
+    // Capabilities should not be equal
+    EXPECT_NE(mutex_caps, lockfree_caps);
 }


### PR DESCRIPTION
## Summary

- Add 6 new test cases for `lockfree_job_queue` capability interface verification
- Extend existing `queue_capabilities_test.cpp` with lock-free specific tests
- Include comparison tests between mutex-based and lock-free queue capabilities

## Test Cases Added

1. **get_capabilities_returns_correct_values**: Verify all capability values
   - `exact_size = false` (approximate size)
   - `atomic_empty_check = false` (non-atomic)
   - `lock_free = true`
   - `wait_free = false`
   - `supports_batch = false`
   - `supports_blocking_wait = false`
   - `supports_stop = false`

2. **convenience_methods_work**: Test all convenience methods
   - `has_exact_size()`, `has_atomic_empty()`, `is_lock_free()`, etc.

3. **dynamic_cast_to_interface**: Verify interface castability
   - Cast to `queue_capabilities_interface`
   - Cast to `scheduler_interface`

4. **capabilities_are_consistent**: Multiple calls return same values

5. **scheduler_interface_still_works**: Verify schedule/get_next_job work

6. **lockfree_vs_mutex_capabilities**: Compare with `job_queue` capabilities

## Test Results

All 62 tests pass (including 6 new tests):
```
[  PASSED  ] 62 tests.
```

Closes #250