### PR TITLE
refactor(error_handling): replace 'using namespace' with explicit declarations

### DIFF
--- a/include/kcenon/thread/core/error_handling.h
+++ b/include/kcenon/thread/core/error_handling.h
@@ -734,9 +734,12 @@ std::pair<std::optional<T>, std::optional<std::string>> result_to_pair(const res
 #ifdef THREAD_HAS_COMMON_RESULT
 namespace detail {
 
-// Use unqualified 'common::' to support both old (namespace common)
-// and new (namespace kcenon::common) versions via backward compatibility alias
-using namespace common;
+// Explicit using declarations for common_system types
+// This avoids namespace pollution while maintaining compatibility
+using kcenon::common::error_info;
+using kcenon::common::Result;
+using kcenon::common::VoidResult;
+using kcenon::common::ok;
 
 /**
  * @brief Convert thread::error to common::error_info


### PR DESCRIPTION
## Summary

- Replace `using namespace common;` with explicit using declarations for specific types in `error_handling.h`
- Eliminates namespace pollution in header files
- Follows C++ Core Guidelines SF.7

## Changes

**File**: `include/kcenon/thread/core/error_handling.h`

**Before**:
```cpp
namespace detail {
// Use unqualified 'common::' to support both old (namespace common)
// and new (namespace kcenon::common) versions via backward compatibility alias
using namespace common;
```

**After**:
```cpp
namespace detail {
// Explicit using declarations for common_system types
// This avoids namespace pollution while maintaining compatibility
using kcenon::common::error_info;
using kcenon::common::Result;
using kcenon::common::VoidResult;
using kcenon::common::ok;
```

## Test Plan

- [x] Build passes with `./scripts/build.sh`
- [x] All 9 smoke tests pass
- [x] All 71 integration tests pass
- [x] No API changes - internal refactoring only

## Related Issues

Fixes #280