### PR TITLE
docs(quick-start): add common_system dependency documentation

### DIFF
--- a/docs/guides/QUICK_START.md
+++ b/docs/guides/QUICK_START.md
@@ -11,15 +11,22 @@ Get up and running with Thread System in 5 minutes.
 - CMake 3.16 or later
 - C++20 capable compiler (GCC 11+, Clang 14+, MSVC 2022+)
 - Git
+- **[common_system](https://github.com/kcenon/common_system)** - Required dependency (must be cloned alongside thread_system)
 
 ## Installation
 
-### 1. Clone the Repository
+### 1. Clone the Repositories
 
 ```bash
+# Clone common_system first (required dependency)
+git clone https://github.com/kcenon/common_system.git
+
+# Clone thread_system alongside common_system
 git clone https://github.com/kcenon/thread_system.git
 cd thread_system
 ```
+
+> **Note:** Both repositories must be in the same parent directory for the build to work correctly.
 
 ### 2. Install Dependencies
 

--- a/docs/guides/QUICK_START_KO.md
+++ b/docs/guides/QUICK_START_KO.md
@@ -11,15 +11,22 @@ Thread System을 5분 안에 시작해보세요.
 - CMake 3.16 이상
 - C++20 지원 컴파일러 (GCC 11+, Clang 14+, MSVC 2022+)
 - Git
+- **[common_system](https://github.com/kcenon/common_system)** - 필수 종속성 (thread_system과 같은 위치에 클론 필요)
 
 ## 설치
 
 ### 1. 저장소 복제
 
 ```bash
+# common_system 먼저 클론 (필수 종속성)
+git clone https://github.com/kcenon/common_system.git
+
+# thread_system을 common_system과 같은 위치에 클론
 git clone https://github.com/kcenon/thread_system.git
 cd thread_system
 ```
+
+> **참고:** 빌드가 올바르게 작동하려면 두 저장소가 같은 부모 디렉토리에 있어야 합니다.
 
 ### 2. 의존성 설치
 


### PR DESCRIPTION
## Summary

- Add `common_system` as a required prerequisite in QUICK_START.md
- Update clone instructions to include common_system repository
- Add note explaining that both repositories must be in the same parent directory
- Update Korean version (QUICK_START_KO.md) with the same changes

## Changes

### QUICK_START.md
- Added common_system to prerequisites list with link to repository
- Updated "Clone the Repository" section to "Clone the Repositories"
- Added common_system clone command before thread_system
- Added note about directory structure requirement

### QUICK_START_KO.md
- Same changes as English version, translated to Korean

## Test Plan

- [x] Verified build examples work correctly
- [x] Verified documentation links are valid
- [x] Reviewed Korean translation accuracy

## Related Issues

Closes #285