### PR TITLE
feat(#310): Remove legacy result/error types from public API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,25 @@ on:
     branches: [ main ]
 
 jobs:
+  # Guard against re-introduction of legacy error types in public API
+  api-guard:
+    name: API Guard - No Legacy Types
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Check for legacy types in public headers
+      run: |
+        echo "=== Checking for legacy thread::result/thread::error in include/ ==="
+        # These types were removed in v3.0, use common::Result<T> and common::VoidResult instead
+        if grep -rn '\bkcenon::thread::result\b\|\bkcenon::thread::error\b' include/; then
+          echo "::error::Legacy types found in public headers!"
+          echo "Use kcenon::common::Result<T> or kcenon::common::VoidResult instead"
+          exit 1
+        fi
+        echo "No legacy types found in public headers"
+
   build:
     name: ${{ matrix.os }} / ${{ matrix.compiler }}
     runs-on: ${{ matrix.os }}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+- **Issue #310 - Phase 3**: Remove legacy error types from public API
+  - Removed `kcenon::thread::result<T>` class from public headers
+  - Removed `kcenon::thread::result_void` class from public headers
+  - Removed `kcenon::thread::error` class from public headers
+  - All public APIs now exclusively use `kcenon::common::Result<T>` and `kcenon::common::VoidResult`
+  - Added helper functions: `to_error_info()`, `make_error_result()`, `get_error_code()`
+  - `error_code` enum and `std::error_code` integration preserved
+  - Added CI guard to prevent re-introduction of legacy types
+  - Updated all tests to use unified common::Result types
+  - See docs/advanced/ERROR_SYSTEM_MIGRATION_GUIDE.md for migration instructions
+
 ### Changed
 - **Issue #303 - Phase 2a**: Replace internal result<T> with common::Result<T> in core headers
   - Updated all core library headers and implementation files to use `kcenon::common::Result<T>` internally

--- a/integration_tests/integration/error_recovery_test.cpp
+++ b/integration_tests/integration/error_recovery_test.cpp
@@ -291,18 +291,18 @@ TEST_F(ErrorHandlingTest, NullJobHandling) {
 }
 
 TEST_F(ErrorHandlingTest, ErrorCodeValidation) {
-    using kcenon::thread::error;
     using kcenon::thread::error_code;
+    using kcenon::thread::to_error_info;
+    using kcenon::thread::get_error_code;
 
-    error err1(error_code::queue_full, "Queue is full");
-    EXPECT_EQ(err1.code(), error_code::queue_full);
-    EXPECT_FALSE(err1.message().empty());
+    auto err1 = to_error_info(error_code::queue_full, "Queue is full");
+    EXPECT_EQ(get_error_code(err1), error_code::queue_full);
+    EXPECT_FALSE(err1.message.empty());
 
-    error err2(error_code::thread_start_failure);
-    EXPECT_EQ(err2.code(), error_code::thread_start_failure);
+    auto err2 = to_error_info(error_code::thread_start_failure);
+    EXPECT_EQ(get_error_code(err2), error_code::thread_start_failure);
 
-    // Test error to string conversion
-    std::string err_str = err1.to_string();
-    EXPECT_FALSE(err_str.empty());
-    EXPECT_NE(err_str.find("Queue is full"), std::string::npos);
+    // Test error message
+    EXPECT_FALSE(err1.message.empty());
+    EXPECT_NE(err1.message.find("Queue is full"), std::string::npos);
 }

--- a/tests/unit/thread_base_test/error_handling_test.cpp
+++ b/tests/unit/thread_base_test/error_handling_test.cpp
@@ -1,7 +1,7 @@
 /*****************************************************************************
 BSD 3-Clause License
 
-Copyright (c) 2025, 🍀☀🌕🌥 🌊
+Copyright (c) 2025, DongCheol Shin
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -62,148 +62,87 @@ TEST_F(ErrorHandlingTest, ErrorCodeToString) {
     EXPECT_FALSE(error_code_to_string(error_code::resource_allocation_failed).empty());
     EXPECT_FALSE(error_code_to_string(error_code::mutex_error).empty());
     EXPECT_FALSE(error_code_to_string(error_code::io_error).empty());
-    
+
     // Test unknown error code
     auto unknown_code = static_cast<error_code>(9999);
     EXPECT_FALSE(error_code_to_string(unknown_code).empty());
 }
 
-TEST_F(ErrorHandlingTest, ResultVoidSuccess) {
-    result_void success_result;
+TEST_F(ErrorHandlingTest, VoidResultSuccess) {
+    common::VoidResult success_result = common::ok();
 
-    EXPECT_FALSE(success_result.has_error());
-    EXPECT_TRUE(static_cast<bool>(success_result));
-    // Test compatibility methods
-    EXPECT_TRUE(success_result.has_value());
     EXPECT_TRUE(success_result.is_ok());
-    EXPECT_FALSE(success_result.is_error());
+    EXPECT_FALSE(success_result.is_err());
 }
 
-TEST_F(ErrorHandlingTest, ResultVoidError) {
-    error test_error{error_code::unknown_error, "Test error message"};
-    result_void error_result{test_error};
+TEST_F(ErrorHandlingTest, VoidResultError) {
+    common::VoidResult error_result = make_error_result(error_code::unknown_error, "Test error message");
 
-    EXPECT_TRUE(error_result.has_error());
-    EXPECT_FALSE(static_cast<bool>(error_result));
-    EXPECT_EQ(error_result.get_error().code(), error_code::unknown_error);
-    EXPECT_EQ(error_result.get_error().message(), "Test error message");
-    // Test compatibility methods
-    EXPECT_FALSE(error_result.has_value());
+    EXPECT_TRUE(error_result.is_err());
     EXPECT_FALSE(error_result.is_ok());
-    EXPECT_TRUE(error_result.is_error());
+    EXPECT_EQ(get_error_code(error_result.error()), error_code::unknown_error);
+    EXPECT_EQ(error_result.error().message, "Test error message");
 }
 
-TEST_F(ErrorHandlingTest, ResultVoidAPICompatibility) {
-    // Test that result_void API is compatible with result<T> and common::Result
-    result_void success;
-    result_void failure{error{error_code::unknown_error, "Error"}};
+TEST_F(ErrorHandlingTest, VoidResultAPICompatibility) {
+    // Test that VoidResult API is consistent
+    common::VoidResult success = common::ok();
+    common::VoidResult failure = make_error_result(error_code::unknown_error, "Error");
 
-    // Verify all three methods are consistent for success case
-    EXPECT_EQ(success.has_value(), !success.has_error());
-    EXPECT_EQ(success.is_ok(), !success.has_error());
-    EXPECT_EQ(success.is_error(), success.has_error());
+    // Verify methods are consistent for success case
+    EXPECT_TRUE(success.is_ok());
+    EXPECT_FALSE(success.is_err());
 
-    // Verify all three methods are consistent for error case
-    EXPECT_EQ(failure.has_value(), !failure.has_error());
-    EXPECT_EQ(failure.is_ok(), !failure.has_error());
-    EXPECT_EQ(failure.is_error(), failure.has_error());
+    // Verify methods are consistent for error case
+    EXPECT_FALSE(failure.is_ok());
+    EXPECT_TRUE(failure.is_err());
 }
 
 TEST_F(ErrorHandlingTest, ResultWithValue) {
     // Success case
-    result<int> success_result{42};
+    common::Result<int> success_result = common::Result<int>::ok(42);
 
-    EXPECT_TRUE(success_result.has_value());
-    EXPECT_TRUE(static_cast<bool>(success_result));
-    EXPECT_EQ(success_result.value(), 42);
-    // Test compatibility methods
     EXPECT_TRUE(success_result.is_ok());
-    EXPECT_FALSE(success_result.is_error());
+    EXPECT_FALSE(success_result.is_err());
+    EXPECT_EQ(success_result.value(), 42);
 
     // Error case
-    result<int> error_result{error{error_code::invalid_argument, "Invalid value"}};
+    common::Result<int> error_result = make_error_result<int>(error_code::invalid_argument, "Invalid value");
 
-    EXPECT_FALSE(error_result.has_value());
-    EXPECT_FALSE(static_cast<bool>(error_result));
-    EXPECT_EQ(error_result.get_error().code(), error_code::invalid_argument);
-    // Test compatibility methods
     EXPECT_FALSE(error_result.is_ok());
-    EXPECT_TRUE(error_result.is_error());
-}
-
-TEST_F(ErrorHandlingTest, ResultVoidSpecialization) {
-    // Test result<void> specialization
-    result<void> success;
-    result<void> failure{error{error_code::unknown_error, "Error"}};
-
-    // Success case
-    EXPECT_TRUE(success.has_value());
-    EXPECT_TRUE(success.is_ok());
-    EXPECT_FALSE(success.is_error());
-    EXPECT_TRUE(static_cast<bool>(success));
-
-    // Error case
-    EXPECT_FALSE(failure.has_value());
-    EXPECT_FALSE(failure.is_ok());
-    EXPECT_TRUE(failure.is_error());
-    EXPECT_FALSE(static_cast<bool>(failure));
+    EXPECT_TRUE(error_result.is_err());
+    EXPECT_EQ(get_error_code(error_result.error()), error_code::invalid_argument);
 }
 
 TEST_F(ErrorHandlingTest, ResultValueOr) {
-    result<int> success_result{42};
+    common::Result<int> success_result = common::Result<int>::ok(42);
     EXPECT_EQ(success_result.value_or(0), 42);
-    
-    result<int> error_result{error{error_code::unknown_error, "Error"}};
+
+    common::Result<int> error_result = make_error_result<int>(error_code::unknown_error, "Error");
     EXPECT_EQ(error_result.value_or(99), 99);
 }
 
-TEST_F(ErrorHandlingTest, ResultAndThenBasic) {
-    result<int> success_result{42};
-    
-    auto transformed = success_result.and_then([](int value) -> result<int> {
-        return value * 2;
-    });
-    
-    EXPECT_TRUE(transformed.has_value());
-    EXPECT_EQ(transformed.value(), 84);
-    
-    result<int> error_result{error{error_code::unknown_error, "Error"}};
-    
-    auto error_transformed = error_result.and_then([](int value) -> result<int> {
-        return value * 2;
-    });
-    
-    EXPECT_FALSE(error_transformed.has_value());
-    EXPECT_EQ(error_transformed.get_error().code(), error_code::unknown_error);
+TEST_F(ErrorHandlingTest, ToErrorInfoConversion) {
+    // Test to_error_info helper function
+    auto info = to_error_info(error_code::queue_full, "Queue is at capacity");
+    EXPECT_EQ(info.code, static_cast<int>(error_code::queue_full));
+    EXPECT_EQ(info.message, "Queue is at capacity");
+    EXPECT_EQ(info.module, "thread_system");
+
+    // Test with default message
+    auto info_default = to_error_info(error_code::queue_empty);
+    EXPECT_EQ(info_default.code, static_cast<int>(error_code::queue_empty));
+    EXPECT_EQ(info_default.message, error_code_to_string(error_code::queue_empty));
 }
 
-TEST_F(ErrorHandlingTest, ResultAndThen) {
-    result<int> success_result{42};
-    
-    auto chained = success_result.and_then([](int value) -> result<std::string> {
-        if (value > 0) {
-            return std::to_string(value);
-        }
-        return error{error_code::invalid_argument, "Negative value"};
-    });
-    
-    EXPECT_TRUE(chained.has_value());
-    EXPECT_EQ(chained.value(), "42");
-}
+TEST_F(ErrorHandlingTest, GetErrorCodeFromInfo) {
+    common::error_info info{
+        static_cast<int>(error_code::job_execution_failed),
+        "Job failed",
+        "thread_system"
+    };
 
-TEST_F(ErrorHandlingTest, ResultValueOrThrow) {
-    result<int> success_result{42};
-    
-    EXPECT_NO_THROW({
-        int value = success_result.value_or_throw();
-        EXPECT_EQ(value, 42);
-    });
-    
-    result<int> error_result{error{error_code::unknown_error, "Test error"}};
-    
-    EXPECT_THROW({
-        [[maybe_unused]] auto val = error_result.value_or_throw();
-    }, std::runtime_error);
+    EXPECT_EQ(get_error_code(info), error_code::job_execution_failed);
 }
 
 TEST_F(ErrorHandlingTest, JobQueueErrorStates) {
@@ -226,7 +165,7 @@ TEST_F(ErrorHandlingTest, JobExecutionErrors) {
 
     // Job that returns an error
     auto error_job = std::make_unique<callback_job>([]() -> common::VoidResult {
-        return common::error_info{error_code::job_execution_failed, "Simulated failure", "error_handling_test"};
+        return make_error_result(error_code::job_execution_failed, "Simulated failure");
     });
 
     auto enqueue_result = queue->enqueue(std::move(error_job));
@@ -250,31 +189,31 @@ TEST_F(ErrorHandlingTest, ThreadBaseStartStop) {
         test_thread() : thread_base("test_thread") {}
         std::atomic<int> work_count{0};
         std::atomic<bool> error_occurred{false};
-        
+
     protected:
         common::VoidResult do_work() override {
             work_count.fetch_add(1);
             if (work_count.load() >= 3) {
                 error_occurred.store(true);
-                return common::error_info{error_code::unknown_error, "Test error", "error_handling_test"};
+                return make_error_result(error_code::unknown_error, "Test error");
             }
             std::this_thread::sleep_for(std::chrono::milliseconds(5));
             return common::ok();
         }
     };
-    
+
     auto worker = std::make_unique<test_thread>();
     worker->set_wake_interval(std::chrono::milliseconds(10));
-    
+
     // Start the thread
     worker->start();
-    
+
     // Let it run for a bit - ensure enough time for at least 3 iterations
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    
+
     // Stop the thread
     worker->stop();
-    
+
     // Verify it executed multiple times
     EXPECT_GT(worker->work_count.load(), 0);
     EXPECT_GE(worker->work_count.load(), 3);  // Should have run at least 3 times
@@ -284,21 +223,21 @@ TEST_F(ErrorHandlingTest, ThreadBaseStartStop) {
 TEST_F(ErrorHandlingTest, ConcurrentErrorHandling) {
     const int thread_count = 4;
     const int errors_per_thread = 10;
-    
+
     std::atomic<int> total_errors{0};
     std::atomic<int> total_successes{0};
-    
+
     std::vector<std::thread> threads;
-    
+
     for (int t = 0; t < thread_count; ++t) {
-        threads.emplace_back([t, &total_errors, &total_successes]() {
+        threads.emplace_back([&total_errors, &total_successes]() {
             for (int i = 0; i < errors_per_thread * 2; ++i) {
                 // Alternate between success and error
-                result<int> res = (i % 2 == 0) 
-                    ? result<int>{i}
-                    : result<int>{error{error_code::unknown_error, "Error"}};
-                
-                if (!res.has_value()) {
+                common::Result<int> res = (i % 2 == 0)
+                    ? common::Result<int>::ok(i)
+                    : make_error_result<int>(error_code::unknown_error, "Error");
+
+                if (res.is_err()) {
                     total_errors.fetch_add(1);
                 } else {
                     total_successes.fetch_add(1);
@@ -306,80 +245,61 @@ TEST_F(ErrorHandlingTest, ConcurrentErrorHandling) {
             }
         });
     }
-    
+
     for (auto& t : threads) {
         t.join();
     }
-    
+
     EXPECT_EQ(total_errors.load(), thread_count * errors_per_thread);
     EXPECT_EQ(total_successes.load(), thread_count * errors_per_thread);
 }
 
-TEST_F(ErrorHandlingTest, ErrorChaining) {
-    // Test chaining multiple operations that might fail
-    auto chain_result = result<int>{42}
-        .and_then([](int value) -> result<std::string> {
-            if (value > 0) {
-                return std::to_string(value);
-            }
-            return error{error_code::invalid_argument, "Negative value"};
-        })
-        .and_then([](const std::string& str) -> result<size_t> {
-            return str.length();
-        });
-    
-    EXPECT_TRUE(chain_result.has_value());
-    EXPECT_EQ(chain_result.value(), 2u); // "42" has length 2
-    
-    // Test with error in the middle
-    auto error_chain = result<int>{-1}
-        .and_then([](int value) -> result<std::string> {
-            if (value > 0) {
-                return std::to_string(value);
-            }
-            return error{error_code::invalid_argument, "Negative value"};
-        })
-        .and_then([](const std::string& str) -> result<size_t> {
-            return str.length();
-        });
-    
-    EXPECT_FALSE(error_chain.has_value());
-    EXPECT_EQ(error_chain.get_error().code(), error_code::invalid_argument);
-}
-
 TEST_F(ErrorHandlingTest, ResourceAllocationErrors) {
     // Simulate resource allocation failure scenarios
-    std::vector<result<std::unique_ptr<int>>> allocations;
-    
+    std::vector<common::Result<std::unique_ptr<int>>> allocations;
+
     for (int i = 0; i < 10; ++i) {
         if (i == 5) {
             // Simulate allocation failure
             allocations.push_back(
-                result<std::unique_ptr<int>>{
-                    error{error_code::resource_allocation_failed, "Out of memory"}
-                }
+                make_error_result<std::unique_ptr<int>>(error_code::resource_allocation_failed, "Out of memory")
             );
         } else {
             allocations.push_back(
-                result<std::unique_ptr<int>>{std::make_unique<int>(i)}
+                common::Result<std::unique_ptr<int>>::ok(std::make_unique<int>(i))
             );
         }
     }
-    
+
     int success_count = 0;
     int error_count = 0;
-    
+
     for (const auto& alloc : allocations) {
-        if (alloc.has_value()) {
+        if (alloc.is_ok()) {
             success_count++;
         } else {
             error_count++;
-            EXPECT_EQ(alloc.get_error().code(), error_code::resource_allocation_failed);
+            EXPECT_EQ(get_error_code(alloc.error()), error_code::resource_allocation_failed);
         }
     }
-    
+
     EXPECT_EQ(success_count, 9);
     EXPECT_EQ(error_count, 1);
+}
+
+TEST_F(ErrorHandlingTest, StdErrorCodeIntegration) {
+    // Test std::error_code integration
+    std::error_code ec = make_error_code(error_code::queue_full);
+    EXPECT_EQ(ec.value(), static_cast<int>(error_code::queue_full));
+    EXPECT_EQ(ec.category().name(), std::string("thread_system"));
+    EXPECT_FALSE(ec.message().empty());
+
+    // Test error_condition equivalence
+    std::error_code timeout_ec = make_error_code(error_code::operation_timeout);
+    EXPECT_TRUE(timeout_ec == std::errc::timed_out);
+
+    std::error_code arg_ec = make_error_code(error_code::invalid_argument);
+    EXPECT_TRUE(arg_ec == std::errc::invalid_argument);
 }
 
 } // namespace test


### PR DESCRIPTION
## Summary

Phase 3 of the Result<T> unification effort. This PR removes the deprecated `thread::result<T>`, `thread::result_void`, and `thread::error` types from the public API.

### Changes
- Remove legacy type classes from `include/kcenon/thread/core/error_handling.h`
- Preserve `thread::error_code` enum and `std::error_code` integration
- Add helper functions for migration: `to_error_info()`, `make_error_result<T>()`, `get_error_code()`
- Update `common_executor_adapter.h` to use `common::VoidResult` exclusively
- Migrate all test files to use unified `common::Result` types
- Add CI guard job to prevent re-introduction of legacy types

### Breaking Changes
- `kcenon::thread::result<T>` removed - use `kcenon::common::Result<T>`
- `kcenon::thread::result_void` removed - use `kcenon::common::VoidResult`
- `kcenon::thread::error` removed - use `kcenon::thread::to_error_info()`

### Migration
See `docs/advanced/ERROR_SYSTEM_MIGRATION_GUIDE.md` for complete migration instructions.

### Acceptance Criteria
- [x] `rg -n '\bkcenon::thread::result\b|\bkcenon::thread::error\b' include/` returns no matches
- [x] Build + tests pass locally
- [x] CI guard added to prevent re-introduction
- [x] Documentation updated

## Test plan
- [x] Build passes with `cmake --build build`
- [x] All 11 tests pass with `ctest`
- [x] Smoke tests pass
- [x] Integration tests pass
- [x] CI guard job prevents legacy type usage

Closes #310
Part of Epic #308