### PR TITLE
fix(api): complete result_void to common::VoidResult migration

### DIFF
--- a/include/kcenon/thread/core/job.h
+++ b/include/kcenon/thread/core/job.h
@@ -66,9 +66,9 @@ namespace kcenon::thread
 	 *   manage lifetimes across multiple threads.
 	 *
 	 * ### Error Handling
-	 * - A job returns a @c result_void from @c do_work().
-	 *   - Returning @c result_void{} indicates success.
-	 *   - Returning an error indicates failure with a typed error code and message.
+	 * - A job returns a @c common::VoidResult from @c do_work().
+	 *   - Returning @c common::ok() indicates success.
+	 *   - Returning a @c common::error_info indicates failure with a typed error code and message.
 	 * - Error information can be used for logging, debugging, or to retry a job if desired.
 	 *
 	 * ### Usage Example

--- a/include/kcenon/thread/core/thread_pool.h
+++ b/include/kcenon/thread/core/thread_pool.h
@@ -328,7 +328,7 @@ namespace kcenon::thread
 		// ============================================================================
 		// These methods provide a simplified interface with bool return types
 		// for easier integration with code that doesn't use result<T> types.
-		// For detailed error information, prefer using the result_void methods above.
+		// For detailed error information, prefer using the common::VoidResult methods above.
 
 		/**
 		 * @brief Submit a task to the thread pool (simplified API)

--- a/include/kcenon/thread/impl/typed_pool/typed_job_interface.h
+++ b/include/kcenon/thread/impl/typed_pool/typed_job_interface.h
@@ -69,7 +69,7 @@ namespace kcenon::thread {
          * @brief Execute the job's work
          * @return Result indicating success or failure
          */
-        [[nodiscard]] virtual result_void execute() = 0;
+        [[nodiscard]] virtual common::VoidResult execute() = 0;
         
         /**
          * @brief Get a human-readable description of this job

--- a/include/kcenon/thread/impl/typed_pool/typed_job_queue.h
+++ b/include/kcenon/thread/impl/typed_pool/typed_job_queue.h
@@ -90,7 +90,7 @@ namespace kcenon::thread
 		 * to enqueue.
 		 *
 		 * @param jobs A vector of unique pointers to jobs to enqueue.
-		 * @return @c result_void containing an error if the operation fails, or a success value.
+		 * @return @c common::VoidResult containing an error if the operation fails, or a success value.
 		 */
 		// This method accepts job references (different from base class which takes rvalue
 		// references)

--- a/include/kcenon/thread/impl/typed_pool/typed_thread_pool.h
+++ b/include/kcenon/thread/impl/typed_pool/typed_thread_pool.h
@@ -191,7 +191,7 @@ namespace kcenon::thread
 		 * @brief Starts the thread pool by creating worker threads and
 		 * initializing internal structures.
 		 *
-		 * @return result_void
+		 * @return common::VoidResult
 		 *         - If an error occurs during start-up, the returned result
 		 *           will contain an error object.
 		 *         - If no error occurs, the result will be a success value.
@@ -290,7 +290,7 @@ namespace kcenon::thread
 		 *
 		 * @param job A unique pointer to the priority job to be added.
 		 *
-		 * @return result_void
+		 * @return common::VoidResult
 		 *         - Contains an error if the enqueue operation fails.
 		 *         - Otherwise, returns a success value.
 		 *

--- a/include/kcenon/thread/lockfree/lockfree_job_queue.h
+++ b/include/kcenon/thread/lockfree/lockfree_job_queue.h
@@ -107,7 +107,7 @@ public:
      * @brief Enqueues a job into the queue (thread-safe)
      *
      * @param job Unique pointer to the job to enqueue
-     * @return result_void Success or error
+     * @return common::VoidResult Success or error
      *
      * @note Wait-free operation (bounded number of steps)
      * @note Takes ownership of the job pointer

--- a/include/kcenon/thread/queue/adaptive_job_queue.h
+++ b/include/kcenon/thread/queue/adaptive_job_queue.h
@@ -223,7 +223,7 @@ public:
     /**
      * @brief Manually switch mode (only if policy is manual)
      * @param m Target mode to switch to
-     * @return result_void Success or error if policy is not manual
+     * @return common::VoidResult Success or error if policy is not manual
      */
     auto switch_mode(mode m) -> common::VoidResult;
 


### PR DESCRIPTION
## Summary

- Complete Phase 3 migration for Epic #308 by replacing remaining `result_void` references with `common::VoidResult`
- Update `typed_job_interface::execute()` return type from `result_void` to `common::VoidResult`
- Update documentation comments across public headers to use unified type names

## Background

During verification of Epic #308 completion, discovered that `typed_job_interface.h` still used `result_void` as a return type, which is not defined in the installed public headers. This caused a compilation issue when using only installed headers.

## Changes

| File | Change |
|------|--------|
| `typed_job_interface.h` | Changed `execute()` return type to `common::VoidResult` |
| `job.h` | Updated error handling documentation |
| `thread_pool.h` | Updated API documentation |
| `typed_job_queue.h` | Updated return type documentation |
| `typed_thread_pool.h` | Updated `start()` and `enqueue()` documentation |
| `lockfree_job_queue.h` | Updated `enqueue()` documentation |
| `adaptive_job_queue.h` | Updated `switch_mode()` documentation |

## Test Plan

- [x] Build passes on macOS (AppleClang 17)
- [x] Smoke tests pass
- [x] Integration tests pass
- [x] Verified no remaining `result_void` usage in public headers (except migration guide comment)

Closes #308