### PR TITLE
feat(queue): add template enqueue<T> and deprecate typed_* variants (Phase 3)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Issue #358 / #362**: Queue consolidation - Phase 3
+  - Add template `enqueue<T>()` method to `job_queue` for type-safe job submission
+  - Add template `enqueue<T>()` method to `adaptive_job_queue` for type-safe job submission
+  - Enables submitting job subclasses without explicit casting
+
 ### Changed
 - **Issue #358**: Queue consolidation - Phase 1 & 2
   - Move `concurrent_queue<T>` and `lockfree_job_queue` to `detail::` namespace (internal implementation)
@@ -21,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `concurrent_queue<T>` - Use `adaptive_job_queue` or `job_queue` instead
   - `bounded_job_queue` - Use `job_queue` with `max_size` parameter instead
   - `queue_factory::create_lockfree_queue()` - Use `create_adaptive_queue(policy::performance_first)` instead
+- **Issue #358 / #362**: Typed queue deprecations
+  - `typed_job_queue_t<T>` - Use `job_queue` or `adaptive_job_queue` with template `enqueue<T>()` instead
+  - `typed_lockfree_job_queue_t<T>` - Use `adaptive_job_queue` with `policy::performance_first` instead
+  - `adaptive_typed_job_queue_t<T>` - Use `adaptive_job_queue` with template `enqueue<T>()` instead
 
 ### Changed
 - **Issue #340**: Rename `lockfree_queue<T>` to `concurrent_queue<T>`

--- a/include/kcenon/thread/impl/typed_pool/adaptive_typed_job_queue.h
+++ b/include/kcenon/thread/impl/typed_pool/adaptive_typed_job_queue.h
@@ -49,13 +49,27 @@ namespace kcenon::thread
 	/**
 	 * @class adaptive_typed_job_queue_t
 	 * @brief Adaptive priority queue that switches between mutex-based and lock-free implementations
-	 * 
+	 *
+	 * @deprecated Use adaptive_job_queue with template enqueue<T>() method instead.
+	 * This class will be removed in a future major version.
+	 *
+	 * Migration example:
+	 * @code
+	 * // Old code:
+	 * auto queue = std::make_shared<adaptive_typed_job_queue_t<my_job_type>>();
+	 *
+	 * // New code:
+	 * auto queue = std::make_unique<adaptive_job_queue>(adaptive_job_queue::policy::balanced);
+	 * queue->enqueue<my_job>(std::make_unique<my_job>());
+	 * @endcode
+	 *
 	 * This queue monitors performance metrics and automatically switches between
 	 * a traditional mutex-based typed queue and a lock-free typed queue based on
 	 * contention levels and performance characteristics.
 	 */
 	template <typename job_type = job_types>
-	class adaptive_typed_job_queue_t : public typed_job_queue_t<job_type>
+	class [[deprecated("Use adaptive_job_queue with template enqueue<T>() instead")]]
+	adaptive_typed_job_queue_t : public typed_job_queue_t<job_type>
 	{
 	public:
 		/**

--- a/include/kcenon/thread/impl/typed_pool/typed_job_queue.h
+++ b/include/kcenon/thread/impl/typed_pool/typed_job_queue.h
@@ -50,6 +50,21 @@ namespace kcenon::thread
 	 * @class typed_job_queue_t
 	 * @brief A template-based queue that manages jobs with distinct priority levels.
 	 *
+	 * @deprecated Use job_queue or adaptive_job_queue with template enqueue<T>() method instead.
+	 * This class will be removed in a future major version.
+	 *
+	 * Migration example:
+	 * @code
+	 * // Old code:
+	 * auto queue = std::make_shared<typed_job_queue_t<my_job_type>>();
+	 * queue->enqueue(std::make_unique<my_typed_job>(priority));
+	 *
+	 * // New code:
+	 * auto queue = std::make_shared<job_queue>();
+	 * queue->enqueue<my_job>(std::make_unique<my_job>());
+	 * // Or use adaptive_job_queue for performance-critical code
+	 * @endcode
+	 *
 	 * This class inherits from @c job_queue and provides functionality to enqueue and
 	 * dequeue priority-based jobs. Internally, it maintains multiple queues (one per
 	 * priority level) and tracks their sizes.
@@ -57,7 +72,9 @@ namespace kcenon::thread
 	 * @tparam job_type The type used to represent job priority levels. Defaults to
 	 *         @c job_types.
 	 */
-	template <typename job_type = job_types> class typed_job_queue_t : public job_queue
+	template <typename job_type = job_types>
+	class [[deprecated("Use job_queue or adaptive_job_queue with template enqueue<T>() instead")]]
+	typed_job_queue_t : public job_queue
 	{
 	public:
 		/**

--- a/include/kcenon/thread/impl/typed_pool/typed_lockfree_job_queue.h
+++ b/include/kcenon/thread/impl/typed_pool/typed_lockfree_job_queue.h
@@ -104,6 +104,19 @@ namespace kcenon::thread
 	 * @class typed_lockfree_job_queue_t
 	 * @brief High-performance lock-free priority-based job queue
 	 *
+	 * @deprecated Use adaptive_job_queue with policy::performance_first and template enqueue<T>() instead.
+	 * This class will be removed in a future major version.
+	 *
+	 * Migration example:
+	 * @code
+	 * // Old code:
+	 * auto queue = std::make_unique<typed_lockfree_job_queue_t<my_job_type>>();
+	 *
+	 * // New code:
+	 * auto queue = std::make_unique<adaptive_job_queue>(adaptive_job_queue::policy::performance_first);
+	 * queue->enqueue<my_job>(std::make_unique<my_job>());
+	 * @endcode
+	 *
 	 * This class provides a lock-free implementation of a typed job queue that
 	 * manages jobs with distinct priority levels. It maintains separate lock-free
 	 * queues for each job type/priority, ensuring thread-safe operations with
@@ -138,7 +151,8 @@ namespace kcenon::thread
 	 * @see hazard_pointer.h for memory reclamation details
 	 */
 	template <typename job_type = job_types>
-	class typed_lockfree_job_queue_t : public job_queue
+	class [[deprecated("Use adaptive_job_queue with policy::performance_first and template enqueue<T>() instead")]]
+	typed_lockfree_job_queue_t : public job_queue
 	{
 	public:
 		/**


### PR DESCRIPTION
## Summary
- Add template `enqueue<T>()` method to `job_queue` for type-safe job submission
- Add template `enqueue<T>()` method to `adaptive_job_queue`
- Deprecate `typed_job_queue_t<T>` with migration path to `job_queue`
- Deprecate `typed_lockfree_job_queue_t<T>` with migration to `adaptive_job_queue`
- Deprecate `adaptive_typed_job_queue_t<T>` with migration to `adaptive_job_queue`
- Update CHANGELOG.md with Phase 3 changes

## Related Issues
- Resolves #362 ([REFACTOR] Phase 3: Add template enqueue and deprecate typed_* variants)
- Related to #358 ([REFACTOR] Consolidate queue implementations from 8 to 2)

## Migration Guide

### Old code using typed_job_queue_t
```cpp
// Before
auto queue = std::make_shared<typed_job_queue_t<my_job_type>>();
queue->enqueue(std::make_unique<my_typed_job>(priority));

// After
auto queue = std::make_shared<job_queue>();
queue->enqueue<my_job>(std::make_unique<my_job>());
```

### Old code using typed_lockfree_job_queue_t
```cpp
// Before
auto queue = std::make_unique<typed_lockfree_job_queue_t<my_job_type>>();

// After
auto queue = std::make_unique<adaptive_job_queue>(adaptive_job_queue::policy::performance_first);
queue->enqueue<my_job>(std::make_unique<my_job>());
```

## Test plan
- [x] Build passes
- [x] All smoke tests pass
- [x] All integration tests pass
- [x] Deprecation warnings appear for typed_* classes