### PR TITLE
feat(diagnostics): implement job inspection for active and pending jobs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Issue #388**: Phase 1.3.3 - Job Inspection Implementation
+  - Implemented job tracking with unique IDs:
+    - Added `job_id_` member and `get_job_id()` to `job` class
+    - Added `enqueue_time_` member and `get_enqueue_time()` for wait time calculation
+    - Atomic ID generation via `next_job_id_` static counter
+  - Implemented `get_active_jobs()` in `thread_pool_diagnostics`:
+    - Returns `job_info` for all currently executing jobs
+    - Includes job ID, name, start time, execution time, and worker thread ID
+  - Implemented `get_pending_jobs()` in `thread_pool_diagnostics`:
+    - Returns `job_info` for jobs waiting in queue
+    - Includes wait time calculation from enqueue time
+    - Configurable limit parameter (default: 100)
+  - Added `inspect_pending_jobs()` to `job_queue`:
+    - Thread-safe queue inspection without removing jobs
+    - Creates job_info snapshots with timing information
+  - Updated `get_current_job_info()` in `thread_worker`:
+    - Now uses actual job_id from job class
+    - Accurate enqueue_time and wait_time calculation
+
 - **Issue #377**: Phase 2.1 - Future/Promise Integration for Async Result Returns
   - New `future_job<R>` template class:
     - Wraps callables with `std::promise<R>` for async result retrieval

--- a/docs/CHANGELOG_KO.md
+++ b/docs/CHANGELOG_KO.md
@@ -8,6 +8,25 @@
 ## [Unreleased]
 
 ### 추가
+- **이슈 #388**: Phase 1.3.3 - Job Inspection 구현
+  - 고유 ID를 사용한 작업 추적 구현:
+    - `job` 클래스에 `job_id_` 멤버 및 `get_job_id()` 추가
+    - 대기 시간 계산을 위한 `enqueue_time_` 멤버 및 `get_enqueue_time()` 추가
+    - `next_job_id_` 정적 카운터를 통한 원자적 ID 생성
+  - `thread_pool_diagnostics`에 `get_active_jobs()` 구현:
+    - 현재 실행 중인 모든 작업에 대한 `job_info` 반환
+    - 작업 ID, 이름, 시작 시간, 실행 시간, 워커 스레드 ID 포함
+  - `thread_pool_diagnostics`에 `get_pending_jobs()` 구현:
+    - 큐에서 대기 중인 작업에 대한 `job_info` 반환
+    - 큐 등록 시간부터의 대기 시간 계산 포함
+    - 구성 가능한 limit 매개변수 (기본값: 100)
+  - `job_queue`에 `inspect_pending_jobs()` 추가:
+    - 작업을 제거하지 않고 큐를 스레드 안전하게 검사
+    - 타이밍 정보가 포함된 job_info 스냅샷 생성
+  - `thread_worker`의 `get_current_job_info()` 업데이트:
+    - 이제 job 클래스의 실제 job_id 사용
+    - 정확한 enqueue_time 및 wait_time 계산
+
 - **이슈 #377**: Phase 2.1 - 비동기 결과 반환을 위한 Future/Promise 통합
   - 새로운 `future_job<R>` 템플릿 클래스:
     - `std::promise<R>`로 callable을 래핑하여 비동기 결과 검색 가능

--- a/include/kcenon/thread/core/job_queue.h
+++ b/include/kcenon/thread/core/job_queue.h
@@ -39,6 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "error_handling.h"
 #include <kcenon/thread/interfaces/scheduler_interface.h>
 #include <kcenon/thread/interfaces/queue_capabilities_interface.h>
+#include <kcenon/thread/diagnostics/job_info.h>
 
 #include <mutex>
 #include <deque>
@@ -49,6 +50,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <type_traits>
 #include <condition_variable>
 #include <memory>
+#include <functional>
 
 namespace kcenon::thread
 {
@@ -337,6 +339,28 @@ namespace kcenon::thread
 		 * @return true if queue is at max_size, false otherwise
 		 */
 		[[nodiscard]] auto is_full() const -> bool;
+
+		// ============================================
+		// Diagnostics support
+		// ============================================
+
+		/**
+		 * @brief Inspects pending jobs in the queue without removing them.
+		 * @param limit Maximum number of jobs to inspect (0 = all).
+		 * @return Vector of job_info for pending jobs.
+		 *
+		 * Thread Safety:
+		 * - Acquires mutex for safe inspection
+		 * - Returns snapshot of current queue state
+		 * - No performance impact on normal queue operations
+		 *
+		 * Use Cases:
+		 * - Diagnostics and monitoring
+		 * - Queue depth analysis
+		 * - Job wait time tracking
+		 */
+		[[nodiscard]] virtual auto inspect_pending_jobs(std::size_t limit = 100) const
+			-> std::vector<diagnostics::job_info>;
 
 	protected:
 		/**

--- a/src/core/job.cpp
+++ b/src/core/job.cpp
@@ -59,6 +59,9 @@ using namespace utility_module;
 
 namespace kcenon::thread
 {
+	// Initialize static member for job ID generation
+	std::atomic<std::uint64_t> job::next_job_id_{0};
+
 	/**
 	 * @brief Constructs a basic job with name only.
 	 * 
@@ -75,7 +78,13 @@ namespace kcenon::thread
 	 * 
 	 * @param name Descriptive name for debugging and logging
 	 */
-	job::job(const std::string& name) : name_(name), data_(std::vector<uint8_t>()) {}
+	job::job(const std::string& name)
+		: name_(name)
+		, data_(std::vector<uint8_t>())
+		, job_id_(next_job_id_.fetch_add(1, std::memory_order_relaxed))
+		, enqueue_time_(std::chrono::steady_clock::now())
+	{
+	}
 
 	/**
 	 * @brief Constructs a data-processing job with binary data.
@@ -99,7 +108,11 @@ namespace kcenon::thread
 	 * @param data Binary data to be processed by this job
 	 * @param name Descriptive name for debugging and logging
 	 */
-	job::job(const std::vector<uint8_t>& data, const std::string& name) : name_(name), data_(data)
+	job::job(const std::vector<uint8_t>& data, const std::string& name)
+		: name_(name)
+		, data_(data)
+		, job_id_(next_job_id_.fetch_add(1, std::memory_order_relaxed))
+		, enqueue_time_(std::chrono::steady_clock::now())
 	{
 	}
 

--- a/src/diagnostics/thread_pool_diagnostics.cpp
+++ b/src/diagnostics/thread_pool_diagnostics.cpp
@@ -121,18 +121,32 @@ namespace kcenon::thread::diagnostics
 	auto thread_pool_diagnostics::get_active_jobs() const -> std::vector<job_info>
 	{
 		std::vector<job_info> result;
-		// Active jobs tracking would require modifications to thread_worker
-		// For now, return empty vector
+
+		// Get thread states which include current job info
+		auto threads = dump_thread_states();
+
+		for (const auto& thread : threads)
+		{
+			if (thread.current_job.has_value())
+			{
+				result.push_back(thread.current_job.value());
+			}
+		}
+
 		return result;
 	}
 
 	auto thread_pool_diagnostics::get_pending_jobs(std::size_t limit) const
 	    -> std::vector<job_info>
 	{
-		std::vector<job_info> result;
-		// Pending jobs would require access to job_queue internals
-		// For now, return empty vector
-		return result;
+		// Delegate to job_queue's inspect_pending_jobs
+		auto queue = pool_.get_job_queue();
+		if (!queue)
+		{
+			return {};
+		}
+
+		return queue->inspect_pending_jobs(limit);
 	}
 
 	auto thread_pool_diagnostics::get_recent_jobs(std::size_t limit) const

--- a/src/impl/thread_pool/thread_worker.cpp
+++ b/src/impl/thread_pool/thread_worker.cpp
@@ -764,20 +764,21 @@ std::unique_ptr<job> thread_worker::try_steal_work()
 		}
 
 		diagnostics::job_info info;
-		// Note: job_id is not available in the current job class
-		// Using 0 as placeholder until job class is enhanced with ID support
-		info.job_id = 0;
+		info.job_id = job_ptr->get_job_id();
 		info.job_name = job_ptr->get_name();
 		info.status = diagnostics::job_status::running;
 		info.start_time = current_job_start_time_;
-		info.enqueue_time = current_job_start_time_; // Approximation
+		info.enqueue_time = job_ptr->get_enqueue_time();
 		info.executed_by = std::this_thread::get_id();
 
 		auto now = std::chrono::steady_clock::now();
 		info.execution_time = std::chrono::duration_cast<std::chrono::nanoseconds>(
 			now - current_job_start_time_
 		);
-		info.wait_time = std::chrono::nanoseconds{0};
+		// Calculate wait time from enqueue to start
+		info.wait_time = std::chrono::duration_cast<std::chrono::nanoseconds>(
+			current_job_start_time_ - job_ptr->get_enqueue_time()
+		);
 
 		return info;
 	}


### PR DESCRIPTION
## Summary
- Add job_id and enqueue_time tracking to job class for diagnostics
- Implement get_active_jobs() to return currently executing jobs with timing info
- Implement get_pending_jobs() to inspect queue without removing jobs

## Changes
### Core Changes
- **job.h/job.cpp**: Added `job_id_`, `enqueue_time_`, `get_job_id()`, `get_enqueue_time()`, and static counter `next_job_id_`
- **job_queue.h/job_queue.cpp**: Added `inspect_pending_jobs()` method for thread-safe queue inspection
- **thread_pool_diagnostics.cpp**: Implemented `get_active_jobs()` and `get_pending_jobs()`
- **thread_worker.cpp**: Updated `get_current_job_info()` to use actual job_id and enqueue_time

### Documentation
- Updated CHANGELOG.md and CHANGELOG_KO.md

## Test plan
- [x] Build passes without errors
- [x] Integration tests pass (IntegrationTests)
- [x] 55/56 unit tests pass (1 pre-existing failure unrelated to this change)

Resolves #388