### PR TITLE
refactor(thread_pool): add deprecation attributes to simplified API methods

### DIFF
--- a/include/kcenon/thread/core/thread_pool.h
+++ b/include/kcenon/thread/core/thread_pool.h
@@ -532,13 +532,17 @@ namespace kcenon::thread
 		 * @param task The task to be executed
 		 * @return true if task was successfully submitted, false otherwise
 		 * @note For detailed error information, use enqueue() instead
+		 * @deprecated Use enqueue() with a job wrapper instead. This method will be removed in v2.0.
 		 */
+		[[deprecated("Use enqueue() with a job wrapper instead. This method will be removed in v2.0.")]]
 		auto submit_task(std::function<void()> task) -> bool;
 
 		/**
 		 * @brief Get the number of worker threads in the pool
 		 * @return Number of active worker threads
+		 * @deprecated Use metrics().worker_count or get_active_worker_count() instead. This method will be removed in v2.0.
 		 */
+		[[deprecated("Use metrics().worker_count or get_active_worker_count() instead. This method will be removed in v2.0.")]]
 		auto get_thread_count() const -> std::size_t;
 
 		/**
@@ -546,7 +550,9 @@ namespace kcenon::thread
 		 * @param immediate If true, stop immediately; if false, wait for current tasks to complete
 		 * @return true if shutdown was successful, false otherwise
 		 * @note For detailed error information, use stop() instead
+		 * @deprecated Use stop() instead. This method will be removed in v2.0.
 		 */
+		[[deprecated("Use stop() instead. This method will be removed in v2.0.")]]
 		auto shutdown_pool(bool immediate = false) -> bool;
 
 		/**


### PR DESCRIPTION
Closes #476

## Summary
- Mark `submit_task()` as deprecated with migration hint to `enqueue()`
- Mark `get_thread_count()` as deprecated with migration hint to `metrics().worker_count`
- Mark `shutdown_pool()` as deprecated with migration hint to `stop()`

## Background
This is Phase 1 of the API simplification effort (Part of #475). The goal is to reduce the thread_pool API surface from 40+ methods to ~15 core methods by:
1. Identifying and deprecating duplicate functionality
2. Providing clear migration paths for users

## Deprecated Methods

| Method | Replacement | Reason |
|--------|-------------|--------|
| `submit_task()` | `enqueue()` + job wrapper | Duplicate functionality |
| `get_thread_count()` | `metrics().worker_count` or `get_active_worker_count()` | Duplicate functionality |
| `shutdown_pool()` | `stop()` | Duplicate functionality |

## Migration Guide

### Before
```cpp
pool->submit_task([]{ /* work */ });
auto count = pool->get_thread_count();
pool->shutdown_pool(true);
```

### After
```cpp
pool->enqueue(std::make_unique<callback_job>([]{ /* work */ }));
auto count = pool->metrics().worker_count.load();
pool->stop(true);
```

## Test Plan
- [x] All smoke tests pass
- [x] All integration tests pass
- [x] Build succeeds with deprecation warnings for deprecated methods