### PR TITLE
refactor(thread_pool): deprecate direct IExecutor inheritance

### DIFF
--- a/include/kcenon/thread/core/thread_pool.h
+++ b/include/kcenon/thread/core/thread_pool.h
@@ -163,11 +163,24 @@ namespace kcenon::thread
 	 * - Very large thread pools (significantly more threads than cores) may degrade
 	 *   performance due to context switching overhead.
 	 *
+	 * ### IExecutor Interface (Deprecated)
+	 * Direct inheritance from common::interfaces::IExecutor is deprecated and will be
+	 * removed in v2.0. For IExecutor compatibility, use thread_pool_executor_adapter:
+	 * @code
+	 * #include <kcenon/thread/adapters/common_executor_adapter.h>
+	 *
+	 * auto pool = std::make_shared<thread_pool>("my_pool");
+	 * auto executor = std::make_shared<adapters::thread_pool_executor_adapter>(pool);
+	 * @endcode
+	 *
 	 * @see thread_worker The worker thread class used by the pool
 	 * @see job_queue The shared queue for storing pending jobs
+	 * @see adapters::thread_pool_executor_adapter For IExecutor compatibility
 	 * @see typed_kcenon::thread::typed_thread_pool For a priority-based version
 	 */
 	class thread_pool : public std::enable_shared_from_this<thread_pool>
+// DEPRECATED: Direct IExecutor inheritance will be removed in v2.0.
+// Use thread_pool_executor_adapter from <kcenon/thread/adapters/common_executor_adapter.h>
 #if KCENON_HAS_COMMON_EXECUTOR
 	                   , public common_ns::interfaces::IExecutor
 #endif
@@ -247,12 +260,27 @@ namespace kcenon::thread
 	// ============================================================================
 	// IExecutor interface implementation (common_system)
 	// ============================================================================
+	// DEPRECATED: Direct IExecutor inheritance is deprecated.
+	// Use thread_pool_executor_adapter from <kcenon/thread/adapters/common_executor_adapter.h>
+	// for IExecutor compatibility. This interface will be removed in v2.0.
+	//
+	// Migration example:
+	//   // Old way (deprecated):
+	//   auto pool = std::make_shared<thread_pool>("my_pool");
+	//   IExecutor* executor = pool.get();
+	//
+	//   // New way (recommended):
+	//   auto pool = std::make_shared<thread_pool>("my_pool");
+	//   auto executor = std::make_shared<adapters::thread_pool_executor_adapter>(pool);
+	// ============================================================================
 
 	/**
 	 * @brief Submit a task for immediate execution (IExecutor)
 	 * @param task The function to execute
 	 * @return Future representing the task result
+	 * @deprecated Use thread_pool_executor_adapter instead. This method will be removed in v2.0.
 	 */
+	[[deprecated("Use thread_pool_executor_adapter from <kcenon/thread/adapters/common_executor_adapter.h> instead. This method will be removed in v2.0.")]]
 	std::future<void> submit(std::function<void()> task);
 
 	/**
@@ -260,7 +288,9 @@ namespace kcenon::thread
 	 * @param task The function to execute
 	 * @param delay The delay before execution
 	 * @return Future representing the task result
+	 * @deprecated Use thread_pool_executor_adapter instead. This method will be removed in v2.0.
 	 */
+	[[deprecated("Use thread_pool_executor_adapter from <kcenon/thread/adapters/common_executor_adapter.h> instead. This method will be removed in v2.0.")]]
 	std::future<void> submit_delayed(
 		std::function<void()> task,
 		std::chrono::milliseconds delay);
@@ -269,7 +299,9 @@ namespace kcenon::thread
 	 * @brief Execute a job with Result-based error handling (IExecutor)
 	 * @param job The job to execute
 	 * @return Result containing future or error
+	 * @deprecated Use thread_pool_executor_adapter instead. This method will be removed in v2.0.
 	 */
+	[[deprecated("Use thread_pool_executor_adapter from <kcenon/thread/adapters/common_executor_adapter.h> instead. This method will be removed in v2.0.")]]
 	common_ns::Result<std::future<void>> execute(
 		std::unique_ptr<common_ns::interfaces::IJob>&& job) override;
 
@@ -278,7 +310,9 @@ namespace kcenon::thread
 	 * @param job The job to execute
 	 * @param delay The delay before execution
 	 * @return Result containing future or error
+	 * @deprecated Use thread_pool_executor_adapter instead. This method will be removed in v2.0.
 	 */
+	[[deprecated("Use thread_pool_executor_adapter from <kcenon/thread/adapters/common_executor_adapter.h> instead. This method will be removed in v2.0.")]]
 	common_ns::Result<std::future<void>> execute_delayed(
 		std::unique_ptr<common_ns::interfaces::IJob>&& job,
 		std::chrono::milliseconds delay) override;
@@ -286,19 +320,25 @@ namespace kcenon::thread
 	/**
 	 * @brief Get the number of worker threads (IExecutor)
 	 * @return Number of available workers
+	 * @deprecated Use thread_pool_executor_adapter instead. This method will be removed in v2.0.
 	 */
+	[[deprecated("Use thread_pool_executor_adapter from <kcenon/thread/adapters/common_executor_adapter.h> instead. This method will be removed in v2.0.")]]
 	size_t worker_count() const override;
 
 	/**
 	 * @brief Get the number of pending tasks (IExecutor)
 	 * @return Number of tasks waiting to be executed
+	 * @deprecated Use thread_pool_executor_adapter instead. This method will be removed in v2.0.
 	 */
+	[[deprecated("Use thread_pool_executor_adapter from <kcenon/thread/adapters/common_executor_adapter.h> instead. This method will be removed in v2.0.")]]
 	size_t pending_tasks() const override;
 
 	/**
 	 * @brief Shutdown the executor gracefully (IExecutor)
 	 * @param wait_for_completion Wait for all pending tasks to complete
+	 * @deprecated Use thread_pool_executor_adapter instead. This method will be removed in v2.0.
 	 */
+	[[deprecated("Use thread_pool_executor_adapter from <kcenon/thread/adapters/common_executor_adapter.h> instead. This method will be removed in v2.0.")]]
 	void shutdown(bool wait_for_completion) override;
 #endif // KCENON_HAS_COMMON_EXECUTOR
 

--- a/src/impl/thread_pool/thread_pool.cpp
+++ b/src/impl/thread_pool/thread_pool.cpp
@@ -844,8 +844,21 @@ auto thread_pool::get_active_worker_count() const -> std::size_t {
 
 #if KCENON_HAS_COMMON_EXECUTOR
 // ============================================================================
-// IExecutor interface implementation
+// IExecutor interface implementation (DEPRECATED)
 // ============================================================================
+// These methods are deprecated and will be removed in v2.0.
+// Use thread_pool_executor_adapter from <kcenon/thread/adapters/common_executor_adapter.h>
+// for IExecutor compatibility.
+// ============================================================================
+
+// Suppress deprecation warnings for the implementation of deprecated methods
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable: 4996)
+#endif
 
 std::future<void> thread_pool::submit(std::function<void()> task) {
     auto promise = std::make_shared<std::promise<void>>();
@@ -988,6 +1001,13 @@ size_t thread_pool::pending_tasks() const {
 void thread_pool::shutdown(bool wait_for_completion) {
     stop(!wait_for_completion);  // immediately_stop = !wait_for_completion
 }
+
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
 #endif  // KCENON_HAS_COMMON_EXECUTOR
 
 // ============================================================================


### PR DESCRIPTION
Closes #481

## Summary
- Mark IExecutor interface methods in thread_pool as deprecated
- Users should migrate to `thread_pool_executor_adapter` for IExecutor compatibility
- Direct IExecutor inheritance will be removed in v2.0

## Changes
- Add `[[deprecated]]` attributes to all IExecutor methods in `thread_pool.h`
- Add deprecation comments to IExecutor inheritance declaration
- Update `thread_pool` class documentation with migration guide
- Improve `common_executor_adapter.h` documentation with examples
- Fix adapter to use `get_active_worker_count()` instead of deprecated `get_thread_count()`
- Add pragma directives in `.cpp` to suppress warnings in deprecated method implementations

## Migration Guide
```cpp
// Old way (deprecated):
auto pool = std::make_shared<thread_pool>("my_pool");
IExecutor* executor = pool.get();
executor->execute(std::move(job));

// New way (recommended):
#include <kcenon/thread/adapters/common_executor_adapter.h>

auto pool = std::make_shared<thread_pool>("my_pool");
auto executor = std::make_shared<adapters::thread_pool_executor_adapter>(pool);
executor->execute(std::move(job));
```

## Test Plan
- [x] Build succeeds with deprecation warnings displayed correctly
- [x] All existing tests pass (smoke, integration, performance)
- [x] Verify deprecation warnings appear when using deprecated methods