### PR TITLE
refactor(thread_pool): add pool_policy interface and circuit_breaker_policy

### DIFF
--- a/include/kcenon/thread/core/thread_pool_impl.h
+++ b/include/kcenon/thread/core/thread_pool_impl.h
@@ -142,4 +142,18 @@ auto thread_pool::submit_any(std::vector<F>&& callables)
     return result_future.get();
 }
 
+template<typename T>
+auto thread_pool::find_policy(const std::string& name) -> T*
+{
+    std::scoped_lock<std::mutex> lock(policies_mutex_);
+
+    for (auto& policy : policies_) {
+        if (policy && policy->get_name() == name) {
+            return dynamic_cast<T*>(policy.get());
+        }
+    }
+
+    return nullptr;
+}
+
 } // namespace kcenon::thread

--- a/include/kcenon/thread/forward.h
+++ b/include/kcenon/thread/forward.h
@@ -99,6 +99,13 @@ struct worker_policy;
 enum class scheduling_policy;
 enum class worker_state;
 
+// ============================================================================
+// Pool policy types
+// ============================================================================
+
+class pool_policy;
+class circuit_breaker_policy;
+
 /// @brief Typed thread pool builder template
 template<typename JobType>
 class typed_thread_pool_builder;

--- a/include/kcenon/thread/pool_policies/circuit_breaker_policy.h
+++ b/include/kcenon/thread/pool_policies/circuit_breaker_policy.h
@@ -1,0 +1,211 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#pragma once
+
+#include "pool_policy.h"
+#include <kcenon/thread/resilience/circuit_breaker.h>
+#include <kcenon/thread/resilience/circuit_breaker_config.h>
+
+#include <atomic>
+#include <memory>
+#include <string>
+
+namespace kcenon::thread
+{
+	/**
+	 * @class circuit_breaker_policy
+	 * @brief Pool policy that implements circuit breaker pattern for failure protection.
+	 *
+	 * @ingroup pool_policies
+	 *
+	 * This policy wraps the circuit breaker functionality as a composable pool policy,
+	 * enabling circuit breaker protection without modifying the thread_pool class.
+	 *
+	 * ### Circuit Breaker Pattern
+	 * The circuit breaker monitors job failures and automatically opens when a
+	 * threshold is exceeded, preventing cascading failures:
+	 * - CLOSED: Normal operation, all jobs allowed
+	 * - OPEN: Failure threshold exceeded, jobs rejected immediately
+	 * - HALF_OPEN: Testing recovery, limited jobs allowed
+	 *
+	 * ### Thread Safety
+	 * All methods are thread-safe and can be called from any thread.
+	 *
+	 * ### Usage Example
+	 * @code
+	 * circuit_breaker_config config;
+	 * config.failure_threshold = 5;
+	 * config.open_duration = std::chrono::seconds{30};
+	 *
+	 * auto cb_policy = std::make_unique<circuit_breaker_policy>(config);
+	 * pool->add_policy(std::move(cb_policy));
+	 *
+	 * // Now all jobs are protected by the circuit breaker
+	 * // Jobs will be rejected when circuit is open
+	 * @endcode
+	 *
+	 * @see pool_policy
+	 * @see circuit_breaker
+	 * @see circuit_breaker_config
+	 */
+	class circuit_breaker_policy : public pool_policy
+	{
+	public:
+		/**
+		 * @brief Constructs a circuit breaker policy with the given configuration.
+		 * @param config Circuit breaker configuration.
+		 */
+		explicit circuit_breaker_policy(const circuit_breaker_config& config = {});
+
+		/**
+		 * @brief Constructs a circuit breaker policy with an existing circuit breaker.
+		 * @param cb Shared pointer to an existing circuit breaker.
+		 *
+		 * This allows sharing a circuit breaker across multiple pools or components.
+		 */
+		explicit circuit_breaker_policy(std::shared_ptr<circuit_breaker> cb);
+
+		/**
+		 * @brief Destructor.
+		 */
+		~circuit_breaker_policy() override = default;
+
+		// Non-copyable
+		circuit_breaker_policy(const circuit_breaker_policy&) = delete;
+		circuit_breaker_policy& operator=(const circuit_breaker_policy&) = delete;
+
+		// Movable
+		circuit_breaker_policy(circuit_breaker_policy&&) noexcept = default;
+		circuit_breaker_policy& operator=(circuit_breaker_policy&&) noexcept = default;
+
+		// ============================================
+		// pool_policy Interface
+		// ============================================
+
+		/**
+		 * @brief Checks circuit state before allowing job enqueue.
+		 * @param j Reference to the job being enqueued.
+		 * @return common::ok() if allowed, error if circuit is open.
+		 *
+		 * When the circuit is open, jobs are rejected immediately with
+		 * an error indicating the circuit breaker state.
+		 */
+		auto on_enqueue(job& j) -> common::VoidResult override;
+
+		/**
+		 * @brief Called when job starts executing.
+		 * @param j Reference to the job.
+		 *
+		 * Records the start time for latency tracking.
+		 */
+		void on_job_start(job& j) override;
+
+		/**
+		 * @brief Records job completion in the circuit breaker.
+		 * @param j Reference to the completed job.
+		 * @param success True if job succeeded.
+		 * @param error Exception pointer if job failed.
+		 *
+		 * This updates the circuit breaker state based on success/failure.
+		 */
+		void on_job_complete(job& j, bool success, const std::exception* error = nullptr) override;
+
+		/**
+		 * @brief Gets the policy name.
+		 * @return "circuit_breaker_policy"
+		 */
+		[[nodiscard]] auto get_name() const -> std::string override;
+
+		/**
+		 * @brief Checks if the policy is enabled.
+		 * @return True if enabled.
+		 */
+		[[nodiscard]] auto is_enabled() const -> bool override;
+
+		/**
+		 * @brief Enables or disables the policy.
+		 * @param enabled Whether to enable.
+		 */
+		void set_enabled(bool enabled) override;
+
+		// ============================================
+		// Circuit Breaker Specific Methods
+		// ============================================
+
+		/**
+		 * @brief Checks if the circuit is accepting work.
+		 * @return True if circuit is closed or half-open with capacity.
+		 */
+		[[nodiscard]] auto is_accepting_work() const -> bool;
+
+		/**
+		 * @brief Gets the current circuit state.
+		 * @return Current circuit_state.
+		 */
+		[[nodiscard]] auto get_state() const -> circuit_state;
+
+		/**
+		 * @brief Gets circuit breaker statistics.
+		 * @return Statistics structure with counters and state info.
+		 */
+		[[nodiscard]] auto get_stats() const -> circuit_breaker::stats;
+
+		/**
+		 * @brief Gets the underlying circuit breaker.
+		 * @return Shared pointer to the circuit breaker.
+		 *
+		 * Useful for sharing the circuit breaker with other components
+		 * or for advanced circuit breaker operations.
+		 */
+		[[nodiscard]] auto get_circuit_breaker() const -> std::shared_ptr<circuit_breaker>;
+
+		/**
+		 * @brief Manually trips (opens) the circuit.
+		 *
+		 * Use this for manual intervention or testing.
+		 */
+		void trip();
+
+		/**
+		 * @brief Manually resets (closes) the circuit.
+		 *
+		 * Use this for manual recovery or testing.
+		 */
+		void reset();
+
+	private:
+		std::shared_ptr<circuit_breaker> circuit_breaker_;
+		std::atomic<bool> enabled_{true};
+	};
+
+} // namespace kcenon::thread

--- a/include/kcenon/thread/pool_policies/pool_policy.h
+++ b/include/kcenon/thread/pool_policies/pool_policy.h
@@ -1,0 +1,172 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#pragma once
+
+#include <kcenon/common/patterns/result.h>
+
+#include <memory>
+#include <string>
+
+namespace kcenon::thread
+{
+	// Forward declarations
+	class job;
+
+	/**
+	 * @class pool_policy
+	 * @brief Base interface for thread pool policies.
+	 *
+	 * @ingroup pool_policies
+	 *
+	 * Policies provide a way to extend thread pool behavior without modifying
+	 * the thread_pool class itself. This follows the Strategy pattern and
+	 * Single Responsibility Principle (SRP).
+	 *
+	 * ### Design Principles
+	 * - **Extensibility**: New behaviors can be added by implementing this interface
+	 * - **Composability**: Multiple policies can be combined in a thread pool
+	 * - **Non-intrusive**: Policies don't require changes to core thread_pool code
+	 * - **Testability**: Each policy can be unit tested independently
+	 *
+	 * ### Lifecycle Hooks
+	 * Policies receive callbacks at key points in the job lifecycle:
+	 * - `on_enqueue()`: Called before a job is added to the queue
+	 * - `on_job_start()`: Called when a worker begins executing a job
+	 * - `on_job_complete()`: Called when a job finishes (success or failure)
+	 *
+	 * ### Thread Safety
+	 * All methods must be thread-safe as they may be called from multiple workers.
+	 *
+	 * ### Usage Example
+	 * @code
+	 * class my_logging_policy : public pool_policy {
+	 * public:
+	 *     auto on_enqueue(job& j) -> common::VoidResult override {
+	 *         LOG_INFO("Job {} enqueued", j.get_name());
+	 *         return common::ok();
+	 *     }
+	 *
+	 *     void on_job_start(job& j) override {
+	 *         LOG_INFO("Job {} started", j.get_name());
+	 *     }
+	 *
+	 *     void on_job_complete(job& j, bool success, const std::exception* error) override {
+	 *         LOG_INFO("Job {} completed: {}", j.get_name(), success ? "success" : "failed");
+	 *     }
+	 *
+	 *     auto get_name() const -> std::string override { return "logging_policy"; }
+	 * };
+	 *
+	 * pool->add_policy(std::make_unique<my_logging_policy>());
+	 * @endcode
+	 *
+	 * @see circuit_breaker_policy
+	 */
+	class pool_policy
+	{
+	public:
+		/**
+		 * @brief Virtual destructor for proper cleanup.
+		 */
+		virtual ~pool_policy() = default;
+
+		/**
+		 * @brief Called before a job is enqueued.
+		 * @param j Reference to the job being enqueued.
+		 * @return common::VoidResult - ok() to allow, error to reject the job.
+		 *
+		 * Policies can use this to:
+		 * - Validate the job
+		 * - Apply transformations
+		 * - Reject jobs based on policy rules (e.g., circuit breaker open)
+		 *
+		 * Thread Safety:
+		 * - Must be thread-safe
+		 * - Called from the enqueueing thread
+		 */
+		virtual auto on_enqueue(job& j) -> common::VoidResult = 0;
+
+		/**
+		 * @brief Called when a worker starts executing a job.
+		 * @param j Reference to the job being started.
+		 *
+		 * Policies can use this to:
+		 * - Start timing
+		 * - Update metrics
+		 * - Log job start
+		 *
+		 * Thread Safety:
+		 * - Must be thread-safe
+		 * - Called from the worker thread
+		 */
+		virtual void on_job_start(job& j) = 0;
+
+		/**
+		 * @brief Called when a job completes (success or failure).
+		 * @param j Reference to the completed job.
+		 * @param success True if job completed successfully.
+		 * @param error Pointer to exception if job failed, nullptr otherwise.
+		 *
+		 * Policies can use this to:
+		 * - Record success/failure metrics
+		 * - Update circuit breaker state
+		 * - Log completion
+		 *
+		 * Thread Safety:
+		 * - Must be thread-safe
+		 * - Called from the worker thread
+		 */
+		virtual void on_job_complete(job& j, bool success, const std::exception* error = nullptr) = 0;
+
+		/**
+		 * @brief Gets the policy name for identification and logging.
+		 * @return Policy name string.
+		 */
+		[[nodiscard]] virtual auto get_name() const -> std::string = 0;
+
+		/**
+		 * @brief Checks if the policy is currently enabled.
+		 * @return True if policy is active.
+		 */
+		[[nodiscard]] virtual auto is_enabled() const -> bool { return true; }
+
+		/**
+		 * @brief Enables or disables the policy.
+		 * @param enabled Whether to enable the policy.
+		 *
+		 * Disabled policies have their hooks called but should no-op.
+		 */
+		virtual void set_enabled(bool enabled) { (void)enabled; }
+	};
+
+} // namespace kcenon::thread

--- a/src/pool_policies/circuit_breaker_policy.cpp
+++ b/src/pool_policies/circuit_breaker_policy.cpp
@@ -1,0 +1,148 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#include <kcenon/thread/pool_policies/circuit_breaker_policy.h>
+#include <kcenon/thread/core/error_handling.h>
+#include <kcenon/thread/core/job.h>
+
+namespace kcenon::thread
+{
+
+circuit_breaker_policy::circuit_breaker_policy(const circuit_breaker_config& config)
+    : circuit_breaker_(std::make_shared<circuit_breaker>(config))
+{
+}
+
+circuit_breaker_policy::circuit_breaker_policy(std::shared_ptr<circuit_breaker> cb)
+    : circuit_breaker_(std::move(cb))
+{
+    if (!circuit_breaker_) {
+        // Create default circuit breaker if nullptr passed
+        circuit_breaker_ = std::make_shared<circuit_breaker>();
+    }
+}
+
+auto circuit_breaker_policy::on_enqueue(job& j) -> common::VoidResult
+{
+    (void)j;  // Job not used, policy applies to all jobs equally
+
+    if (!enabled_.load(std::memory_order_acquire)) {
+        return common::ok();
+    }
+
+    // Check if circuit breaker allows the request
+    if (!circuit_breaker_->allow_request()) {
+        auto state = circuit_breaker_->get_state();
+        if (state == circuit_state::open) {
+            return make_error_result(error_code::circuit_open,
+                                     "Circuit breaker is open, job rejected");
+        }
+        // half_open state but at capacity
+        return make_error_result(error_code::circuit_half_open,
+                                 "Circuit breaker is half-open and at capacity");
+    }
+
+    return common::ok();
+}
+
+void circuit_breaker_policy::on_job_start(job& j)
+{
+    (void)j;  // Currently no action needed on job start
+    // Could be extended to track timing in the future
+}
+
+void circuit_breaker_policy::on_job_complete(job& j, bool success, const std::exception* error)
+{
+    (void)j;  // Job not used, policy applies to all jobs equally
+
+    if (!enabled_.load(std::memory_order_acquire)) {
+        return;
+    }
+
+    if (success) {
+        circuit_breaker_->record_success();
+    } else {
+        circuit_breaker_->record_failure(error);
+    }
+}
+
+auto circuit_breaker_policy::get_name() const -> std::string
+{
+    return "circuit_breaker_policy";
+}
+
+auto circuit_breaker_policy::is_enabled() const -> bool
+{
+    return enabled_.load(std::memory_order_acquire);
+}
+
+void circuit_breaker_policy::set_enabled(bool enabled)
+{
+    enabled_.store(enabled, std::memory_order_release);
+}
+
+auto circuit_breaker_policy::is_accepting_work() const -> bool
+{
+    if (!enabled_.load(std::memory_order_acquire)) {
+        return true;  // If disabled, always accept
+    }
+
+    auto state = circuit_breaker_->get_state();
+    return state != circuit_state::open;
+}
+
+auto circuit_breaker_policy::get_state() const -> circuit_state
+{
+    return circuit_breaker_->get_state();
+}
+
+auto circuit_breaker_policy::get_stats() const -> circuit_breaker::stats
+{
+    return circuit_breaker_->get_stats();
+}
+
+auto circuit_breaker_policy::get_circuit_breaker() const -> std::shared_ptr<circuit_breaker>
+{
+    return circuit_breaker_;
+}
+
+void circuit_breaker_policy::trip()
+{
+    circuit_breaker_->trip();
+}
+
+void circuit_breaker_policy::reset()
+{
+    circuit_breaker_->reset();
+}
+
+} // namespace kcenon::thread


### PR DESCRIPTION
## Summary

- Add `pool_policy` interface for composable thread pool behavior extension
- Add `circuit_breaker_policy` as the first policy implementation
- Add `add_policy()`, `get_policies()`, `find_policy()`, `remove_policy()` methods to `thread_pool`
- Deprecate existing circuit breaker methods in favor of policy-based approach

Closes #489
Part of #488

## Test Plan

- [x] Build succeeds with `cmake --build build --config Release`
- [x] All existing tests pass (SmokeTests, IntegrationTests, PerformanceTests)
- [x] Manual verification of policy API usage