### PR TITLE
refactor(thread_pool): extract autoscaling_pool_policy from thread_pool

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -69,6 +69,10 @@ set(CORE_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/../include/kcenon/thread/scaling/autoscaler.h
     ${CMAKE_CURRENT_SOURCE_DIR}/../include/kcenon/thread/scaling/autoscaling_policy.h
     ${CMAKE_CURRENT_SOURCE_DIR}/../include/kcenon/thread/scaling/scaling_metrics.h
+    # Pool policies module
+    ${CMAKE_CURRENT_SOURCE_DIR}/../include/kcenon/thread/pool_policies/pool_policy.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/../include/kcenon/thread/pool_policies/circuit_breaker_policy.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/../include/kcenon/thread/pool_policies/autoscaling_pool_policy.h
 )
 
 # Explicit source file list (do not use GLOB - CMake won't detect new files automatically)
@@ -114,6 +118,9 @@ set(CORE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/../src/resilience/protected_job.cpp
     # Scaling implementation
     ${CMAKE_CURRENT_SOURCE_DIR}/../src/scaling/autoscaler.cpp
+    # Pool policies implementation
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/pool_policies/circuit_breaker_policy.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/pool_policies/autoscaling_pool_policy.cpp
 )
 
 add_library(${PROJECT_NAME} STATIC

--- a/include/kcenon/thread/core/thread_pool.h
+++ b/include/kcenon/thread/core/thread_pool.h
@@ -680,44 +680,62 @@ namespace kcenon::thread
 		[[nodiscard]] auto enqueue_protected(std::unique_ptr<job>&& job) -> common::VoidResult;
 
 		// =========================================================================
-		// Autoscaling
+		// Autoscaling (Deprecated - Use autoscaling_pool_policy instead)
 		// =========================================================================
 
 		/**
 		 * @brief Enable autoscaling with the specified policy.
 		 * @param policy Autoscaling policy configuration.
 		 *
+		 * @deprecated Use add_policy() with autoscaling_pool_policy instead:
+		 * @code
+		 * pool->add_policy(std::make_unique<autoscaling_pool_policy>(*pool, policy));
+		 * @endcode
+		 *
 		 * When enabled, the pool will automatically adjust worker count
 		 * based on load metrics (utilization, queue depth, latency).
 		 *
 		 * @see autoscaling_policy
+		 * @see autoscaling_pool_policy
 		 */
+		[[deprecated("Use add_policy() with autoscaling_pool_policy instead")]]
 		void enable_autoscaling(const autoscaling_policy& policy);
 
 		/**
 		 * @brief Disable autoscaling.
 		 *
+		 * @deprecated Use remove_policy("autoscaling_pool_policy") instead.
+		 *
 		 * Stops the autoscaler monitor thread. Worker count remains
 		 * at current level after disabling.
 		 */
+		[[deprecated("Use remove_policy(\"autoscaling_pool_policy\") instead")]]
 		void disable_autoscaling();
 
 		/**
 		 * @brief Get the autoscaler (if enabled).
 		 * @return Shared pointer to the autoscaler, or nullptr if not enabled.
+		 *
+		 * @deprecated Use find_policy<autoscaling_pool_policy>() and get_autoscaler() instead.
 		 */
+		[[deprecated("Use find_policy<autoscaling_pool_policy>() instead")]]
 		[[nodiscard]] auto get_autoscaler() -> std::shared_ptr<autoscaler>;
 
 		/**
 		 * @brief Check if autoscaling is enabled.
 		 * @return true if autoscaling is enabled.
+		 *
+		 * @deprecated Use find_policy<autoscaling_pool_policy>()->is_active() instead.
 		 */
+		[[deprecated("Use find_policy<autoscaling_pool_policy>()->is_active() instead")]]
 		[[nodiscard]] auto is_autoscaling_enabled() const -> bool;
 
 		/**
 		 * @brief Remove workers from the pool.
 		 * @param count Number of workers to remove.
 		 * @return Error if operation fails.
+		 *
+		 * @deprecated Use find_policy<autoscaling_pool_policy>()->get_autoscaler()->scale_down() instead.
 		 *
 		 * Gracefully stops and removes idle workers. If not enough
 		 * idle workers are available, waits briefly for workers to
@@ -728,6 +746,7 @@ namespace kcenon::thread
 		 * - Acquires workers_mutex_ for safe access
 		 * - Workers are stopped before removal
 		 */
+		[[deprecated("Use autoscaling_pool_policy with scale_to() instead")]]
 		[[nodiscard]] auto remove_workers(std::size_t count) -> common::VoidResult;
 
 		// =========================================================================

--- a/include/kcenon/thread/pool_policies/autoscaling_pool_policy.h
+++ b/include/kcenon/thread/pool_policies/autoscaling_pool_policy.h
@@ -1,0 +1,229 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#pragma once
+
+#include "pool_policy.h"
+#include <kcenon/thread/scaling/autoscaler.h>
+#include <kcenon/thread/scaling/autoscaling_policy.h>
+
+#include <atomic>
+#include <memory>
+#include <string>
+
+namespace kcenon::thread
+{
+	/**
+	 * @class autoscaling_pool_policy
+	 * @brief Pool policy that implements automatic scaling for dynamic worker management.
+	 *
+	 * @ingroup pool_policies
+	 *
+	 * This policy wraps the autoscaling functionality as a composable pool policy,
+	 * enabling automatic scaling without modifying the thread_pool class.
+	 *
+	 * ### Autoscaling Behavior
+	 * The autoscaler monitors thread pool metrics and adjusts worker count:
+	 * - Scale-up triggered when ANY threshold is exceeded (high utilization, queue depth, latency)
+	 * - Scale-down triggered when ALL conditions are met (low utilization, low queue depth, idle workers)
+	 *
+	 * ### Thread Safety
+	 * All methods are thread-safe and can be called from any thread.
+	 *
+	 * ### Usage Example
+	 * @code
+	 * autoscaling_policy config;
+	 * config.min_workers = 2;
+	 * config.max_workers = 16;
+	 * config.scaling_mode = autoscaling_policy::mode::automatic;
+	 *
+	 * auto as_policy = std::make_unique<autoscaling_pool_policy>(pool, config);
+	 * pool->add_policy(std::move(as_policy));
+	 *
+	 * // Now workers are automatically scaled based on load
+	 * @endcode
+	 *
+	 * @see pool_policy
+	 * @see autoscaler
+	 * @see autoscaling_policy
+	 */
+	class autoscaling_pool_policy : public pool_policy
+	{
+	public:
+		/**
+		 * @brief Constructs an autoscaling pool policy with the given configuration.
+		 * @param pool Reference to the thread pool to manage.
+		 * @param config Autoscaling policy configuration.
+		 */
+		explicit autoscaling_pool_policy(thread_pool& pool, const autoscaling_policy& config = {});
+
+		/**
+		 * @brief Constructs an autoscaling pool policy with an existing autoscaler.
+		 * @param scaler Shared pointer to an existing autoscaler.
+		 *
+		 * This allows sharing an autoscaler across multiple pools or components.
+		 */
+		explicit autoscaling_pool_policy(std::shared_ptr<autoscaler> scaler);
+
+		/**
+		 * @brief Destructor. Stops the autoscaler if running.
+		 */
+		~autoscaling_pool_policy() override;
+
+		// Non-copyable
+		autoscaling_pool_policy(const autoscaling_pool_policy&) = delete;
+		autoscaling_pool_policy& operator=(const autoscaling_pool_policy&) = delete;
+
+		// Non-movable (std::atomic is not movable)
+		autoscaling_pool_policy(autoscaling_pool_policy&&) = delete;
+		autoscaling_pool_policy& operator=(autoscaling_pool_policy&&) = delete;
+
+		// ============================================
+		// pool_policy Interface
+		// ============================================
+
+		/**
+		 * @brief Called before a job is enqueued.
+		 * @param j Reference to the job being enqueued.
+		 * @return common::ok() - autoscaling always allows jobs.
+		 *
+		 * Autoscaling does not reject jobs; it adjusts worker count to handle load.
+		 */
+		auto on_enqueue(job& j) -> common::VoidResult override;
+
+		/**
+		 * @brief Called when job starts executing.
+		 * @param j Reference to the job.
+		 *
+		 * Records job start for metrics collection.
+		 */
+		void on_job_start(job& j) override;
+
+		/**
+		 * @brief Called when a job completes.
+		 * @param j Reference to the completed job.
+		 * @param success True if job succeeded.
+		 * @param error Exception pointer if job failed.
+		 *
+		 * Records completion for metrics used in scaling decisions.
+		 */
+		void on_job_complete(job& j, bool success, const std::exception* error = nullptr) override;
+
+		/**
+		 * @brief Gets the policy name.
+		 * @return "autoscaling_pool_policy"
+		 */
+		[[nodiscard]] auto get_name() const -> std::string override;
+
+		/**
+		 * @brief Checks if the policy is enabled.
+		 * @return True if enabled.
+		 */
+		[[nodiscard]] auto is_enabled() const -> bool override;
+
+		/**
+		 * @brief Enables or disables the policy.
+		 * @param enabled Whether to enable.
+		 *
+		 * When disabled, the autoscaler is stopped. When enabled, it is started
+		 * (if the pool is running).
+		 */
+		void set_enabled(bool enabled) override;
+
+		// ============================================
+		// Autoscaling Specific Methods
+		// ============================================
+
+		/**
+		 * @brief Starts the autoscaler monitor thread.
+		 *
+		 * Should be called after the pool starts. This is automatically
+		 * managed if the policy is added before pool.start().
+		 */
+		void start();
+
+		/**
+		 * @brief Stops the autoscaler monitor thread.
+		 */
+		void stop();
+
+		/**
+		 * @brief Checks if the autoscaler is currently active.
+		 * @return True if the monitor thread is running.
+		 */
+		[[nodiscard]] auto is_active() const -> bool;
+
+		/**
+		 * @brief Gets the underlying autoscaler.
+		 * @return Shared pointer to the autoscaler.
+		 *
+		 * Useful for accessing detailed scaling controls and statistics.
+		 */
+		[[nodiscard]] auto get_autoscaler() const -> std::shared_ptr<autoscaler>;
+
+		/**
+		 * @brief Gets current autoscaling statistics.
+		 * @return Statistics about scaling operations.
+		 */
+		[[nodiscard]] auto get_stats() const -> autoscaling_stats;
+
+		/**
+		 * @brief Updates the autoscaling policy configuration.
+		 * @param config New policy configuration.
+		 */
+		void set_policy(const autoscaling_policy& config);
+
+		/**
+		 * @brief Gets the current autoscaling policy configuration.
+		 * @return Const reference to the policy.
+		 */
+		[[nodiscard]] auto get_policy() const -> const autoscaling_policy&;
+
+		/**
+		 * @brief Manually triggers a scaling evaluation.
+		 * @return The scaling decision that would be made.
+		 */
+		[[nodiscard]] auto evaluate_now() -> scaling_decision;
+
+		/**
+		 * @brief Manually scales to a specific worker count.
+		 * @param target_workers Desired number of workers.
+		 * @return Error if scaling fails.
+		 */
+		auto scale_to(std::size_t target_workers) -> common::VoidResult;
+
+	private:
+		std::shared_ptr<autoscaler> autoscaler_;
+		std::atomic<bool> enabled_{true};
+	};
+
+} // namespace kcenon::thread

--- a/include/kcenon/thread/pool_policies/circuit_breaker_policy.h
+++ b/include/kcenon/thread/pool_policies/circuit_breaker_policy.h
@@ -104,9 +104,9 @@ namespace kcenon::thread
 		circuit_breaker_policy(const circuit_breaker_policy&) = delete;
 		circuit_breaker_policy& operator=(const circuit_breaker_policy&) = delete;
 
-		// Movable
-		circuit_breaker_policy(circuit_breaker_policy&&) noexcept = default;
-		circuit_breaker_policy& operator=(circuit_breaker_policy&&) noexcept = default;
+		// Non-movable (std::atomic is not movable)
+		circuit_breaker_policy(circuit_breaker_policy&&) = delete;
+		circuit_breaker_policy& operator=(circuit_breaker_policy&&) = delete;
 
 		// ============================================
 		// pool_policy Interface

--- a/src/pool_policies/autoscaling_pool_policy.cpp
+++ b/src/pool_policies/autoscaling_pool_policy.cpp
@@ -1,0 +1,168 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#include <kcenon/thread/pool_policies/autoscaling_pool_policy.h>
+#include <kcenon/thread/core/job.h>
+
+namespace kcenon::thread
+{
+
+autoscaling_pool_policy::autoscaling_pool_policy(thread_pool& pool, const autoscaling_policy& config)
+    : autoscaler_(std::make_shared<autoscaler>(pool, config))
+{
+}
+
+autoscaling_pool_policy::autoscaling_pool_policy(std::shared_ptr<autoscaler> scaler)
+    : autoscaler_(std::move(scaler))
+{
+}
+
+autoscaling_pool_policy::~autoscaling_pool_policy()
+{
+    if (autoscaler_ && autoscaler_->is_active()) {
+        autoscaler_->stop();
+    }
+}
+
+auto autoscaling_pool_policy::on_enqueue(job& j) -> common::VoidResult
+{
+    (void)j;  // Autoscaling does not reject jobs
+    return common::ok();
+}
+
+void autoscaling_pool_policy::on_job_start(job& j)
+{
+    (void)j;  // Metrics are collected by the autoscaler's monitor thread
+}
+
+void autoscaling_pool_policy::on_job_complete(job& j, bool success, const std::exception* error)
+{
+    (void)j;
+    (void)success;
+    (void)error;
+    // Metrics are collected by the autoscaler's monitor thread
+}
+
+auto autoscaling_pool_policy::get_name() const -> std::string
+{
+    return "autoscaling_pool_policy";
+}
+
+auto autoscaling_pool_policy::is_enabled() const -> bool
+{
+    return enabled_.load(std::memory_order_acquire);
+}
+
+void autoscaling_pool_policy::set_enabled(bool enabled)
+{
+    bool was_enabled = enabled_.exchange(enabled, std::memory_order_acq_rel);
+
+    if (autoscaler_) {
+        if (enabled && !was_enabled) {
+            // Transitioning to enabled - start the autoscaler
+            if (!autoscaler_->is_active()) {
+                autoscaler_->start();
+            }
+        } else if (!enabled && was_enabled) {
+            // Transitioning to disabled - stop the autoscaler
+            if (autoscaler_->is_active()) {
+                autoscaler_->stop();
+            }
+        }
+    }
+}
+
+void autoscaling_pool_policy::start()
+{
+    if (autoscaler_ && enabled_.load(std::memory_order_acquire)) {
+        autoscaler_->start();
+    }
+}
+
+void autoscaling_pool_policy::stop()
+{
+    if (autoscaler_) {
+        autoscaler_->stop();
+    }
+}
+
+auto autoscaling_pool_policy::is_active() const -> bool
+{
+    return autoscaler_ && autoscaler_->is_active();
+}
+
+auto autoscaling_pool_policy::get_autoscaler() const -> std::shared_ptr<autoscaler>
+{
+    return autoscaler_;
+}
+
+auto autoscaling_pool_policy::get_stats() const -> autoscaling_stats
+{
+    if (autoscaler_) {
+        return autoscaler_->get_stats();
+    }
+    return autoscaling_stats{};
+}
+
+void autoscaling_pool_policy::set_policy(const autoscaling_policy& config)
+{
+    if (autoscaler_) {
+        autoscaler_->set_policy(config);
+    }
+}
+
+auto autoscaling_pool_policy::get_policy() const -> const autoscaling_policy&
+{
+    static autoscaling_policy default_policy;
+    if (autoscaler_) {
+        return autoscaler_->get_policy();
+    }
+    return default_policy;
+}
+
+auto autoscaling_pool_policy::evaluate_now() -> scaling_decision
+{
+    if (autoscaler_) {
+        return autoscaler_->evaluate_now();
+    }
+    return scaling_decision{};
+}
+
+auto autoscaling_pool_policy::scale_to(std::size_t target_workers) -> common::VoidResult
+{
+    if (autoscaler_) {
+        return autoscaler_->scale_to(target_workers);
+    }
+    return common::ok();
+}
+
+} // namespace kcenon::thread


### PR DESCRIPTION
## Summary
- Extract autoscaling functionality from `thread_pool` into a separate `autoscaling_pool_policy` class
- Deprecate existing autoscaling methods in `thread_pool` with clear migration messages
- Fix move constructor/assignment for both policy classes (std::atomic is not movable)

Closes #490

## Changes
- Add `autoscaling_pool_policy` class implementing `pool_policy` interface
- Deprecate `enable_autoscaling()`, `disable_autoscaling()`, `get_autoscaler()`, `is_autoscaling_enabled()`, and `remove_workers()` methods
- Update `CMakeLists.txt` to include new source files

## Migration Example
```cpp
// Before
pool->enable_autoscaling(policy);
auto scaler = pool->get_autoscaler();
pool->disable_autoscaling();

// After
pool->add_policy(std::make_unique<autoscaling_pool_policy>(*pool, policy));
auto* as_policy = pool->find_policy<autoscaling_pool_policy>("autoscaling_pool_policy");
auto scaler = as_policy->get_autoscaler();
pool->remove_policy("autoscaling_pool_policy");
```

## Test Plan
- [x] Build passes without errors
- [x] Smoke tests pass
- [x] Integration tests pass