### PR TITLE
refactor(thread_pool): extract work_stealing_policy from thread_pool

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -73,6 +73,7 @@ set(CORE_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/../include/kcenon/thread/pool_policies/pool_policy.h
     ${CMAKE_CURRENT_SOURCE_DIR}/../include/kcenon/thread/pool_policies/circuit_breaker_policy.h
     ${CMAKE_CURRENT_SOURCE_DIR}/../include/kcenon/thread/pool_policies/autoscaling_pool_policy.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/../include/kcenon/thread/pool_policies/work_stealing_pool_policy.h
 )
 
 # Explicit source file list (do not use GLOB - CMake won't detect new files automatically)
@@ -121,6 +122,7 @@ set(CORE_SOURCES
     # Pool policies implementation
     ${CMAKE_CURRENT_SOURCE_DIR}/../src/pool_policies/circuit_breaker_policy.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../src/pool_policies/autoscaling_pool_policy.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/pool_policies/work_stealing_pool_policy.cpp
 )
 
 add_library(${PROJECT_NAME} STATIC

--- a/include/kcenon/thread/core/thread_pool.h
+++ b/include/kcenon/thread/core/thread_pool.h
@@ -524,35 +524,58 @@ namespace kcenon::thread
 		 */
 		auto get_active_worker_count() const -> std::size_t;
 
+		// =========================================================================
+		// Work-Stealing (Deprecated - Use work_stealing_pool_policy instead)
+		// =========================================================================
+
 		/**
 		 * @brief Set the worker policy for all workers in the pool.
 		 * @param policy The worker policy configuration.
+		 *
+		 * @deprecated Use add_policy() with work_stealing_pool_policy instead:
+		 * @code
+		 * pool->add_policy(std::make_unique<work_stealing_pool_policy>(policy));
+		 * @endcode
 		 *
 		 * This should be called before start() to configure work-stealing
 		 * and other worker behaviors. If called after start(), only affects
 		 * newly added workers.
 		 */
+		[[deprecated("Use add_policy() with work_stealing_pool_policy instead")]]
 		void set_worker_policy(const worker_policy& policy);
 
 		/**
 		 * @brief Get the current worker policy.
 		 * @return The worker policy configuration.
+		 *
+		 * @deprecated Use find_policy<work_stealing_pool_policy>()->get_policy() instead.
 		 */
+		[[deprecated("Use find_policy<work_stealing_pool_policy>()->get_policy() instead")]]
 		[[nodiscard]] const worker_policy& get_worker_policy() const;
 
 		/**
 		 * @brief Enable or disable work-stealing at runtime.
 		 * @param enable Whether to enable work-stealing.
 		 *
+		 * @deprecated Use find_policy<work_stealing_pool_policy>()->set_enabled() instead:
+		 * @code
+		 * auto* ws = pool->find_policy<work_stealing_pool_policy>("work_stealing_pool_policy");
+		 * if (ws) ws->set_enabled(true);
+		 * @endcode
+		 *
 		 * This method allows toggling work-stealing behavior after pool creation.
 		 * Changes take effect for subsequent job executions.
 		 */
+		[[deprecated("Use find_policy<work_stealing_pool_policy>()->set_enabled() instead")]]
 		void enable_work_stealing(bool enable);
 
 		/**
 		 * @brief Check if work-stealing is currently enabled.
 		 * @return true if work-stealing is enabled, false otherwise.
+		 *
+		 * @deprecated Use find_policy<work_stealing_pool_policy>()->is_enabled() instead.
 		 */
+		[[deprecated("Use find_policy<work_stealing_pool_policy>()->is_enabled() instead")]]
 		[[nodiscard]] bool is_work_stealing_enabled() const;
 
 		// =========================================================================

--- a/include/kcenon/thread/pool_policies/work_stealing_pool_policy.h
+++ b/include/kcenon/thread/pool_policies/work_stealing_pool_policy.h
@@ -1,0 +1,247 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#pragma once
+
+#include "pool_policy.h"
+#include <kcenon/thread/core/worker_policy.h>
+
+#include <atomic>
+#include <memory>
+#include <string>
+
+namespace kcenon::thread
+{
+	// Forward declarations
+	class thread_pool;
+
+	/**
+	 * @class work_stealing_pool_policy
+	 * @brief Pool policy that implements work-stealing behavior for load balancing.
+	 *
+	 * @ingroup pool_policies
+	 *
+	 * This policy wraps the work-stealing functionality as a composable pool policy,
+	 * enabling work-stealing configuration without modifying the thread_pool class.
+	 *
+	 * ### Work-Stealing Pattern
+	 * Work-stealing enables idle workers to "steal" jobs from busy workers' local
+	 * queues, improving load balancing and throughput:
+	 * - Workers first check their local queue for work
+	 * - If empty, they attempt to steal from other workers
+	 * - Victim selection can be random, round-robin, or adaptive
+	 *
+	 * ### Thread Safety
+	 * All methods are thread-safe and can be called from any thread.
+	 *
+	 * ### Usage Example
+	 * @code
+	 * worker_policy config;
+	 * config.enable_work_stealing = true;
+	 * config.victim_selection = steal_policy::adaptive;
+	 * config.max_steal_attempts = 5;
+	 *
+	 * auto pool = std::make_shared<thread_pool>("my_pool");
+	 * auto ws_policy = std::make_unique<work_stealing_pool_policy>(config);
+	 * pool->add_policy(std::move(ws_policy));
+	 *
+	 * pool->start();
+	 * @endcode
+	 *
+	 * @see pool_policy
+	 * @see worker_policy
+	 */
+	class work_stealing_pool_policy : public pool_policy
+	{
+	public:
+		/**
+		 * @brief Constructs a work-stealing policy with the given configuration.
+		 * @param config Worker policy configuration containing work-stealing settings.
+		 */
+		explicit work_stealing_pool_policy(const worker_policy& config = {});
+
+		/**
+		 * @brief Destructor.
+		 */
+		~work_stealing_pool_policy() override = default;
+
+		// Non-copyable
+		work_stealing_pool_policy(const work_stealing_pool_policy&) = delete;
+		work_stealing_pool_policy& operator=(const work_stealing_pool_policy&) = delete;
+
+		// Non-movable (std::atomic is not movable)
+		work_stealing_pool_policy(work_stealing_pool_policy&&) = delete;
+		work_stealing_pool_policy& operator=(work_stealing_pool_policy&&) = delete;
+
+		// ============================================
+		// pool_policy Interface
+		// ============================================
+
+		/**
+		 * @brief Called before a job is enqueued.
+		 * @param j Reference to the job being enqueued.
+		 * @return common::ok() - work stealing does not reject jobs.
+		 *
+		 * Work-stealing policy does not modify enqueue behavior.
+		 * Jobs are always accepted.
+		 */
+		auto on_enqueue(job& j) -> common::VoidResult override;
+
+		/**
+		 * @brief Called when job starts executing.
+		 * @param j Reference to the job.
+		 *
+		 * Can be used to track job execution for steal decisions.
+		 */
+		void on_job_start(job& j) override;
+
+		/**
+		 * @brief Called when a job completes.
+		 * @param j Reference to the completed job.
+		 * @param success True if job succeeded.
+		 * @param error Exception pointer if job failed.
+		 *
+		 * Updates internal statistics for adaptive stealing.
+		 */
+		void on_job_complete(job& j, bool success, const std::exception* error = nullptr) override;
+
+		/**
+		 * @brief Gets the policy name.
+		 * @return "work_stealing_pool_policy"
+		 */
+		[[nodiscard]] auto get_name() const -> std::string override;
+
+		/**
+		 * @brief Checks if the policy is enabled.
+		 * @return True if work-stealing is enabled.
+		 */
+		[[nodiscard]] auto is_enabled() const -> bool override;
+
+		/**
+		 * @brief Enables or disables the policy.
+		 * @param enabled Whether to enable work-stealing.
+		 */
+		void set_enabled(bool enabled) override;
+
+		// ============================================
+		// Work-Stealing Specific Methods
+		// ============================================
+
+		/**
+		 * @brief Gets the current worker policy configuration.
+		 * @return Const reference to the worker policy.
+		 */
+		[[nodiscard]] auto get_policy() const -> const worker_policy&;
+
+		/**
+		 * @brief Updates the worker policy configuration.
+		 * @param config New worker policy configuration.
+		 *
+		 * Note: Changes take effect for subsequent operations.
+		 */
+		void set_policy(const worker_policy& config);
+
+		/**
+		 * @brief Gets the steal policy (victim selection strategy).
+		 * @return Current steal policy.
+		 */
+		[[nodiscard]] auto get_steal_policy() const -> steal_policy;
+
+		/**
+		 * @brief Sets the steal policy (victim selection strategy).
+		 * @param policy New steal policy.
+		 */
+		void set_steal_policy(steal_policy policy);
+
+		/**
+		 * @brief Gets the maximum steal attempts per steal cycle.
+		 * @return Maximum steal attempts.
+		 */
+		[[nodiscard]] auto get_max_steal_attempts() const -> std::size_t;
+
+		/**
+		 * @brief Sets the maximum steal attempts per steal cycle.
+		 * @param attempts New maximum steal attempts.
+		 */
+		void set_max_steal_attempts(std::size_t attempts);
+
+		/**
+		 * @brief Gets the steal backoff duration.
+		 * @return Backoff duration between steal attempts.
+		 */
+		[[nodiscard]] auto get_steal_backoff() const -> std::chrono::microseconds;
+
+		/**
+		 * @brief Sets the steal backoff duration.
+		 * @param backoff New backoff duration.
+		 */
+		void set_steal_backoff(std::chrono::microseconds backoff);
+
+		/**
+		 * @brief Gets the total number of successful steals.
+		 * @return Number of successful steal operations.
+		 */
+		[[nodiscard]] auto get_successful_steals() const -> std::uint64_t;
+
+		/**
+		 * @brief Gets the total number of failed steal attempts.
+		 * @return Number of failed steal attempts.
+		 */
+		[[nodiscard]] auto get_failed_steals() const -> std::uint64_t;
+
+		/**
+		 * @brief Resets the steal statistics.
+		 */
+		void reset_stats();
+
+		/**
+		 * @brief Records a successful steal operation.
+		 *
+		 * Call this from the thread_pool when a steal succeeds.
+		 */
+		void record_successful_steal();
+
+		/**
+		 * @brief Records a failed steal attempt.
+		 *
+		 * Call this from the thread_pool when a steal fails.
+		 */
+		void record_failed_steal();
+
+	private:
+		worker_policy policy_;
+		std::atomic<bool> enabled_;
+		std::atomic<std::uint64_t> successful_steals_{0};
+		std::atomic<std::uint64_t> failed_steals_{0};
+	};
+
+} // namespace kcenon::thread

--- a/src/impl/thread_pool/thread_pool.cpp
+++ b/src/impl/thread_pool/thread_pool.cpp
@@ -817,8 +817,19 @@ auto thread_pool::get_active_worker_count() const -> std::size_t {
 }
 
 // ============================================================================
-// Work-Stealing Support
+// Work-Stealing Support (Deprecated)
 // ============================================================================
+
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable: 4996)
+#endif
 
 void thread_pool::set_worker_policy(const worker_policy& policy) {
     worker_policy_ = policy;
@@ -860,6 +871,14 @@ void thread_pool::enable_work_stealing(bool enable) {
 bool thread_pool::is_work_stealing_enabled() const {
     return worker_policy_.enable_work_stealing;
 }
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
 std::function<job*(std::size_t)> thread_pool::create_steal_function() {
     // Capture 'this' to access workers

--- a/src/pool_policies/work_stealing_pool_policy.cpp
+++ b/src/pool_policies/work_stealing_pool_policy.cpp
@@ -1,0 +1,147 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#include <kcenon/thread/pool_policies/work_stealing_pool_policy.h>
+#include <kcenon/thread/core/job.h>
+
+namespace kcenon::thread
+{
+
+work_stealing_pool_policy::work_stealing_pool_policy(const worker_policy& config)
+    : policy_(config)
+    , enabled_(config.enable_work_stealing)
+{
+}
+
+auto work_stealing_pool_policy::on_enqueue(job& j) -> common::VoidResult
+{
+    (void)j;  // Job not used, work-stealing doesn't affect enqueue
+    return common::ok();
+}
+
+void work_stealing_pool_policy::on_job_start(job& j)
+{
+    (void)j;  // Currently no action needed on job start
+}
+
+void work_stealing_pool_policy::on_job_complete(job& j, bool success, const std::exception* error)
+{
+    (void)j;      // Job not used for work-stealing statistics
+    (void)success;
+    (void)error;
+    // Statistics are tracked through record_successful_steal/record_failed_steal
+}
+
+auto work_stealing_pool_policy::get_name() const -> std::string
+{
+    return "work_stealing_pool_policy";
+}
+
+auto work_stealing_pool_policy::is_enabled() const -> bool
+{
+    return enabled_.load(std::memory_order_acquire);
+}
+
+void work_stealing_pool_policy::set_enabled(bool enabled)
+{
+    enabled_.store(enabled, std::memory_order_release);
+    policy_.enable_work_stealing = enabled;
+}
+
+auto work_stealing_pool_policy::get_policy() const -> const worker_policy&
+{
+    return policy_;
+}
+
+void work_stealing_pool_policy::set_policy(const worker_policy& config)
+{
+    policy_ = config;
+    enabled_.store(config.enable_work_stealing, std::memory_order_release);
+}
+
+auto work_stealing_pool_policy::get_steal_policy() const -> steal_policy
+{
+    return policy_.victim_selection;
+}
+
+void work_stealing_pool_policy::set_steal_policy(steal_policy policy)
+{
+    policy_.victim_selection = policy;
+}
+
+auto work_stealing_pool_policy::get_max_steal_attempts() const -> std::size_t
+{
+    return policy_.max_steal_attempts;
+}
+
+void work_stealing_pool_policy::set_max_steal_attempts(std::size_t attempts)
+{
+    policy_.max_steal_attempts = attempts;
+}
+
+auto work_stealing_pool_policy::get_steal_backoff() const -> std::chrono::microseconds
+{
+    return policy_.steal_backoff;
+}
+
+void work_stealing_pool_policy::set_steal_backoff(std::chrono::microseconds backoff)
+{
+    policy_.steal_backoff = backoff;
+}
+
+auto work_stealing_pool_policy::get_successful_steals() const -> std::uint64_t
+{
+    return successful_steals_.load(std::memory_order_acquire);
+}
+
+auto work_stealing_pool_policy::get_failed_steals() const -> std::uint64_t
+{
+    return failed_steals_.load(std::memory_order_acquire);
+}
+
+void work_stealing_pool_policy::reset_stats()
+{
+    successful_steals_.store(0, std::memory_order_release);
+    failed_steals_.store(0, std::memory_order_release);
+}
+
+void work_stealing_pool_policy::record_successful_steal()
+{
+    successful_steals_.fetch_add(1, std::memory_order_relaxed);
+}
+
+void work_stealing_pool_policy::record_failed_steal()
+{
+    failed_steals_.fetch_add(1, std::memory_order_relaxed);
+}
+
+} // namespace kcenon::thread

--- a/tests/unit/thread_pool_test/work_stealing_pool_policy_test.cpp
+++ b/tests/unit/thread_pool_test/work_stealing_pool_policy_test.cpp
@@ -1,0 +1,469 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+/**
+ * @file work_stealing_pool_policy_test.cpp
+ * @brief Unit tests for work_stealing_pool_policy (Issue #491)
+ *
+ * This file tests the work_stealing_pool_policy class which extracts
+ * work-stealing functionality from thread_pool into a composable policy.
+ */
+
+#include "gtest/gtest.h"
+
+#include <kcenon/thread/pool_policies/work_stealing_pool_policy.h>
+#include <kcenon/thread/core/thread_pool.h>
+#include <kcenon/thread/core/thread_worker.h>
+#include <kcenon/thread/core/callback_job.h>
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+using namespace kcenon::thread;
+using namespace kcenon;
+
+// ============================================================================
+// Construction Tests
+// ============================================================================
+
+TEST(WorkStealingPoolPolicyTest, DefaultConstruction) {
+    work_stealing_pool_policy policy;
+
+    EXPECT_EQ(policy.get_name(), "work_stealing_pool_policy");
+    // Default worker_policy has work_stealing disabled
+    EXPECT_FALSE(policy.is_enabled());
+}
+
+TEST(WorkStealingPoolPolicyTest, ConstructWithConfig) {
+    worker_policy config;
+    config.enable_work_stealing = true;
+    config.victim_selection = steal_policy::adaptive;
+    config.max_steal_attempts = 10;
+    config.steal_backoff = std::chrono::microseconds{100};
+
+    work_stealing_pool_policy policy(config);
+
+    EXPECT_TRUE(policy.is_enabled());
+    EXPECT_EQ(policy.get_steal_policy(), steal_policy::adaptive);
+    EXPECT_EQ(policy.get_max_steal_attempts(), 10);
+    EXPECT_EQ(policy.get_steal_backoff(), std::chrono::microseconds{100});
+}
+
+TEST(WorkStealingPoolPolicyTest, ConstructWithHighPerformanceConfig) {
+    work_stealing_pool_policy policy(worker_policy::high_performance());
+
+    EXPECT_TRUE(policy.is_enabled());
+}
+
+TEST(WorkStealingPoolPolicyTest, ConstructWithPowerEfficientConfig) {
+    work_stealing_pool_policy policy(worker_policy::power_efficient());
+
+    EXPECT_FALSE(policy.is_enabled());
+}
+
+// ============================================================================
+// Enable/Disable Tests
+// ============================================================================
+
+TEST(WorkStealingPoolPolicyTest, EnableDisable) {
+    work_stealing_pool_policy policy;
+
+    EXPECT_FALSE(policy.is_enabled());
+
+    policy.set_enabled(true);
+    EXPECT_TRUE(policy.is_enabled());
+
+    policy.set_enabled(false);
+    EXPECT_FALSE(policy.is_enabled());
+}
+
+TEST(WorkStealingPoolPolicyTest, EnableDisablePolicySync) {
+    worker_policy config;
+    config.enable_work_stealing = true;
+
+    work_stealing_pool_policy policy(config);
+    EXPECT_TRUE(policy.is_enabled());
+    EXPECT_TRUE(policy.get_policy().enable_work_stealing);
+
+    policy.set_enabled(false);
+    EXPECT_FALSE(policy.is_enabled());
+    EXPECT_FALSE(policy.get_policy().enable_work_stealing);
+}
+
+// ============================================================================
+// Configuration Tests
+// ============================================================================
+
+TEST(WorkStealingPoolPolicyTest, SetPolicy) {
+    work_stealing_pool_policy policy;
+
+    worker_policy new_config;
+    new_config.enable_work_stealing = true;
+    new_config.victim_selection = steal_policy::round_robin;
+    new_config.max_steal_attempts = 7;
+
+    policy.set_policy(new_config);
+
+    EXPECT_TRUE(policy.is_enabled());
+    EXPECT_EQ(policy.get_steal_policy(), steal_policy::round_robin);
+    EXPECT_EQ(policy.get_max_steal_attempts(), 7);
+}
+
+TEST(WorkStealingPoolPolicyTest, SetStealPolicy) {
+    work_stealing_pool_policy policy;
+
+    policy.set_steal_policy(steal_policy::adaptive);
+    EXPECT_EQ(policy.get_steal_policy(), steal_policy::adaptive);
+
+    policy.set_steal_policy(steal_policy::round_robin);
+    EXPECT_EQ(policy.get_steal_policy(), steal_policy::round_robin);
+
+    policy.set_steal_policy(steal_policy::random);
+    EXPECT_EQ(policy.get_steal_policy(), steal_policy::random);
+}
+
+TEST(WorkStealingPoolPolicyTest, SetMaxStealAttempts) {
+    work_stealing_pool_policy policy;
+
+    policy.set_max_steal_attempts(5);
+    EXPECT_EQ(policy.get_max_steal_attempts(), 5);
+
+    policy.set_max_steal_attempts(100);
+    EXPECT_EQ(policy.get_max_steal_attempts(), 100);
+}
+
+TEST(WorkStealingPoolPolicyTest, SetStealBackoff) {
+    work_stealing_pool_policy policy;
+
+    policy.set_steal_backoff(std::chrono::microseconds{200});
+    EXPECT_EQ(policy.get_steal_backoff(), std::chrono::microseconds{200});
+
+    policy.set_steal_backoff(std::chrono::microseconds{0});
+    EXPECT_EQ(policy.get_steal_backoff(), std::chrono::microseconds{0});
+}
+
+// ============================================================================
+// Statistics Tests
+// ============================================================================
+
+TEST(WorkStealingPoolPolicyTest, InitialStatsAreZero) {
+    work_stealing_pool_policy policy;
+
+    EXPECT_EQ(policy.get_successful_steals(), 0);
+    EXPECT_EQ(policy.get_failed_steals(), 0);
+}
+
+TEST(WorkStealingPoolPolicyTest, RecordSuccessfulSteals) {
+    work_stealing_pool_policy policy;
+
+    policy.record_successful_steal();
+    EXPECT_EQ(policy.get_successful_steals(), 1);
+
+    policy.record_successful_steal();
+    policy.record_successful_steal();
+    EXPECT_EQ(policy.get_successful_steals(), 3);
+}
+
+TEST(WorkStealingPoolPolicyTest, RecordFailedSteals) {
+    work_stealing_pool_policy policy;
+
+    policy.record_failed_steal();
+    EXPECT_EQ(policy.get_failed_steals(), 1);
+
+    policy.record_failed_steal();
+    policy.record_failed_steal();
+    EXPECT_EQ(policy.get_failed_steals(), 3);
+}
+
+TEST(WorkStealingPoolPolicyTest, ResetStats) {
+    work_stealing_pool_policy policy;
+
+    policy.record_successful_steal();
+    policy.record_successful_steal();
+    policy.record_failed_steal();
+
+    EXPECT_EQ(policy.get_successful_steals(), 2);
+    EXPECT_EQ(policy.get_failed_steals(), 1);
+
+    policy.reset_stats();
+
+    EXPECT_EQ(policy.get_successful_steals(), 0);
+    EXPECT_EQ(policy.get_failed_steals(), 0);
+}
+
+// ============================================================================
+// Pool Policy Interface Tests
+// ============================================================================
+
+TEST(WorkStealingPoolPolicyTest, OnEnqueueDoesNotRejectJobs) {
+    work_stealing_pool_policy policy;
+
+    auto job = std::make_unique<callback_job>(
+        []() -> common::VoidResult { return common::ok(); },
+        "test_job"
+    );
+
+    auto result = policy.on_enqueue(*job);
+    EXPECT_FALSE(result.is_err());
+}
+
+TEST(WorkStealingPoolPolicyTest, OnJobStartAndCompleteDoNotThrow) {
+    work_stealing_pool_policy policy;
+
+    auto job = std::make_unique<callback_job>(
+        []() -> common::VoidResult { return common::ok(); },
+        "test_job"
+    );
+
+    // These should not throw
+    EXPECT_NO_THROW(policy.on_job_start(*job));
+    EXPECT_NO_THROW(policy.on_job_complete(*job, true));
+    EXPECT_NO_THROW(policy.on_job_complete(*job, false));
+    EXPECT_NO_THROW(policy.on_job_complete(*job, false, nullptr));
+}
+
+// ============================================================================
+// Thread Pool Integration Tests
+// ============================================================================
+
+class WorkStealingPoolPolicyIntegrationTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        pool_ = std::make_shared<thread_pool>("TestPool");
+    }
+
+    void TearDown() override {
+        if (pool_) {
+            pool_->stop();
+        }
+    }
+
+    std::shared_ptr<thread_pool> pool_;
+};
+
+TEST_F(WorkStealingPoolPolicyIntegrationTest, AddPolicyToPool) {
+    worker_policy config;
+    config.enable_work_stealing = true;
+
+    auto policy = std::make_unique<work_stealing_pool_policy>(config);
+    pool_->add_policy(std::move(policy));
+
+    // Find the policy
+    auto* ws = pool_->find_policy<work_stealing_pool_policy>("work_stealing_pool_policy");
+    ASSERT_NE(ws, nullptr);
+    EXPECT_TRUE(ws->is_enabled());
+}
+
+TEST_F(WorkStealingPoolPolicyIntegrationTest, RemovePolicyFromPool) {
+    auto policy = std::make_unique<work_stealing_pool_policy>();
+    pool_->add_policy(std::move(policy));
+
+    // Verify it exists
+    auto* ws = pool_->find_policy<work_stealing_pool_policy>("work_stealing_pool_policy");
+    ASSERT_NE(ws, nullptr);
+
+    // Remove it
+    bool removed = pool_->remove_policy("work_stealing_pool_policy");
+    EXPECT_TRUE(removed);
+
+    // Verify it's gone
+    ws = pool_->find_policy<work_stealing_pool_policy>("work_stealing_pool_policy");
+    EXPECT_EQ(ws, nullptr);
+}
+
+TEST_F(WorkStealingPoolPolicyIntegrationTest, PolicyWorksDuringJobExecution) {
+    // Add workers
+    for (int i = 0; i < 4; ++i) {
+        pool_->enqueue(std::make_unique<thread_worker>());
+    }
+
+    // Add work-stealing policy
+    worker_policy config;
+    config.enable_work_stealing = true;
+    auto policy = std::make_unique<work_stealing_pool_policy>(config);
+    pool_->add_policy(std::move(policy));
+
+    // Start pool
+    auto start_result = pool_->start();
+    EXPECT_FALSE(start_result.is_err());
+
+    // Submit jobs
+    std::atomic<int> completed{0};
+    constexpr int job_count = 50;
+
+    for (int i = 0; i < job_count; ++i) {
+        auto job = std::make_unique<callback_job>(
+            [&completed]() -> common::VoidResult {
+                std::this_thread::sleep_for(std::chrono::microseconds(50));
+                completed.fetch_add(1, std::memory_order_relaxed);
+                return common::ok();
+            },
+            "test_job_" + std::to_string(i)
+        );
+        pool_->enqueue(std::move(job));
+    }
+
+    // Wait for completion
+    constexpr int max_wait_ms = 5000;
+    int waited = 0;
+    while (completed.load() < job_count && waited < max_wait_ms) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        waited += 10;
+    }
+
+    EXPECT_EQ(completed.load(), job_count);
+
+    // Verify policy is still accessible
+    auto* ws = pool_->find_policy<work_stealing_pool_policy>("work_stealing_pool_policy");
+    ASSERT_NE(ws, nullptr);
+    EXPECT_TRUE(ws->is_enabled());
+}
+
+TEST_F(WorkStealingPoolPolicyIntegrationTest, ConfigureViaPolicy) {
+    // Add policy with specific configuration
+    worker_policy config;
+    config.enable_work_stealing = true;
+    config.victim_selection = steal_policy::adaptive;
+    config.max_steal_attempts = 10;
+
+    auto policy = std::make_unique<work_stealing_pool_policy>(config);
+    pool_->add_policy(std::move(policy));
+
+    // Add workers and start
+    for (int i = 0; i < 2; ++i) {
+        pool_->enqueue(std::make_unique<thread_worker>());
+    }
+    pool_->start();
+
+    // Verify configuration through policy
+    auto* ws = pool_->find_policy<work_stealing_pool_policy>("work_stealing_pool_policy");
+    ASSERT_NE(ws, nullptr);
+    EXPECT_EQ(ws->get_steal_policy(), steal_policy::adaptive);
+    EXPECT_EQ(ws->get_max_steal_attempts(), 10);
+}
+
+TEST_F(WorkStealingPoolPolicyIntegrationTest, DisablePolicyAtRuntime) {
+    // Add workers
+    for (int i = 0; i < 2; ++i) {
+        pool_->enqueue(std::make_unique<thread_worker>());
+    }
+
+    // Add enabled policy
+    worker_policy config;
+    config.enable_work_stealing = true;
+    auto policy = std::make_unique<work_stealing_pool_policy>(config);
+    pool_->add_policy(std::move(policy));
+
+    // Start pool
+    pool_->start();
+
+    // Disable policy at runtime
+    auto* ws = pool_->find_policy<work_stealing_pool_policy>("work_stealing_pool_policy");
+    ASSERT_NE(ws, nullptr);
+
+    ws->set_enabled(false);
+    EXPECT_FALSE(ws->is_enabled());
+
+    // Re-enable
+    ws->set_enabled(true);
+    EXPECT_TRUE(ws->is_enabled());
+}
+
+// ============================================================================
+// Thread Safety Tests
+// ============================================================================
+
+TEST(WorkStealingPoolPolicyTest, ConcurrentStatUpdates) {
+    work_stealing_pool_policy policy;
+
+    std::vector<std::thread> threads;
+    constexpr int thread_count = 4;
+    constexpr int updates_per_thread = 1000;
+
+    for (int i = 0; i < thread_count; ++i) {
+        threads.emplace_back([&policy, i]() {
+            for (int j = 0; j < updates_per_thread; ++j) {
+                if (i % 2 == 0) {
+                    policy.record_successful_steal();
+                } else {
+                    policy.record_failed_steal();
+                }
+            }
+        });
+    }
+
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    // Half threads recorded successful, half recorded failed
+    EXPECT_EQ(policy.get_successful_steals(), (thread_count / 2) * updates_per_thread);
+    EXPECT_EQ(policy.get_failed_steals(), (thread_count / 2) * updates_per_thread);
+}
+
+TEST(WorkStealingPoolPolicyTest, ConcurrentEnableDisable) {
+    work_stealing_pool_policy policy;
+
+    std::atomic<bool> stop{false};
+    std::vector<std::thread> threads;
+
+    // Reader threads
+    for (int i = 0; i < 2; ++i) {
+        threads.emplace_back([&policy, &stop]() {
+            while (!stop.load()) {
+                [[maybe_unused]] bool enabled = policy.is_enabled();
+                std::this_thread::yield();
+            }
+        });
+    }
+
+    // Writer threads
+    for (int i = 0; i < 2; ++i) {
+        threads.emplace_back([&policy, &stop, i]() {
+            while (!stop.load()) {
+                policy.set_enabled(i % 2 == 0);
+                std::this_thread::yield();
+            }
+        });
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    stop.store(true);
+
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    // Should not crash or have undefined behavior
+    SUCCEED();
+}


### PR DESCRIPTION
## Summary
- Extract work-stealing functionality from `thread_pool` into a separate `work_stealing_pool_policy` class
- Deprecate existing work-stealing methods in `thread_pool` (`set_worker_policy`, `get_worker_policy`, `enable_work_stealing`, `is_work_stealing_enabled`)
- Add unit tests for `work_stealing_pool_policy`

## Changes
### New Files
- `include/kcenon/thread/pool_policies/work_stealing_pool_policy.h` - Policy class header
- `src/pool_policies/work_stealing_pool_policy.cpp` - Policy class implementation
- `tests/unit/thread_pool_test/work_stealing_pool_policy_test.cpp` - Unit tests

### Modified Files
- `include/kcenon/thread/core/thread_pool.h` - Add deprecation attributes to work-stealing methods
- `src/impl/thread_pool/thread_pool.cpp` - Add pragma to suppress deprecation warnings in implementation
- `core/CMakeLists.txt` - Add new source files to build

## Migration Guide
```cpp
// Before (deprecated)
pool->set_worker_policy(policy);
pool->enable_work_stealing(true);
bool enabled = pool->is_work_stealing_enabled();

// After (recommended)
pool->add_policy(std::make_unique<work_stealing_pool_policy>(policy));
auto* ws = pool->find_policy<work_stealing_pool_policy>("work_stealing_pool_policy");
ws->set_enabled(true);
bool enabled = ws->is_enabled();
```

## Test Plan
- [x] All smoke tests pass
- [x] All integration tests pass
- [x] Unit tests for `work_stealing_pool_policy` added

Closes #491