### PR TITLE
refactor(thread_pool): consolidate submit methods with unified API

### DIFF
--- a/include/kcenon/thread/core/submit_options.h
+++ b/include/kcenon/thread/core/submit_options.h
@@ -1,0 +1,152 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024, 🍀☀🌕🌥 🌊
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#pragma once
+
+/**
+ * @file submit_options.h
+ * @brief Options struct for unified submit() API
+ * @date 2026-01-18
+ *
+ * This file defines the submit_options struct used by the unified submit() methods
+ * in thread_pool. It provides a flexible way to configure job submission behavior.
+ */
+
+#include <string>
+#include <optional>
+#include <chrono>
+
+namespace kcenon::thread {
+
+/**
+ * @brief Options for submitting jobs to the thread pool.
+ *
+ * This struct provides a unified way to configure job submission behavior,
+ * replacing the need for multiple submit method variants.
+ *
+ * ### Basic Usage
+ * @code
+ * // Default options (equivalent to submit_async)
+ * auto future = pool->submit([]{ return 42; });
+ *
+ * // With job name
+ * auto future = pool->submit([]{ return 42; }, {.name = "compute_task"});
+ * @endcode
+ *
+ * ### Batch Usage
+ * @code
+ * std::vector<std::function<int()>> tasks = {...};
+ *
+ * // Get futures for each task
+ * auto futures = pool->submit(std::move(tasks));
+ *
+ * // Wait for all and get results
+ * auto results = pool->submit(std::move(tasks), {.wait_all = true});
+ *
+ * // Get first completed result
+ * auto result = pool->submit(std::move(tasks), {.wait_any = true});
+ * @endcode
+ */
+struct submit_options {
+    /**
+     * @brief Optional name for the job (useful for debugging/tracing).
+     *
+     * When empty, a default name like "async_job" is used.
+     */
+    std::string name;
+
+    /**
+     * @brief If true, wait for all tasks and return results directly.
+     *
+     * Only applicable for batch submissions. When set:
+     * - submit() blocks until all tasks complete
+     * - Returns std::vector<R> instead of std::vector<std::future<R>>
+     *
+     * @note Mutually exclusive with wait_any
+     */
+    bool wait_all = false;
+
+    /**
+     * @brief If true, return the first completed result.
+     *
+     * Only applicable for batch submissions. When set:
+     * - submit() blocks until any task completes
+     * - Returns R instead of std::vector<std::future<R>>
+     *
+     * @note Mutually exclusive with wait_all
+     */
+    bool wait_any = false;
+
+    /**
+     * @brief Default constructor with all defaults.
+     */
+    submit_options() = default;
+
+    /**
+     * @brief Construct with job name only.
+     * @param job_name Name for the job.
+     */
+    explicit submit_options(std::string job_name) : name(std::move(job_name)) {}
+
+    /**
+     * @brief Create options for a named job.
+     * @param job_name Name for the job.
+     * @return submit_options with name set.
+     */
+    static submit_options named(std::string job_name) {
+        submit_options opts;
+        opts.name = std::move(job_name);
+        return opts;
+    }
+
+    /**
+     * @brief Create options for wait_all batch operation.
+     * @return submit_options with wait_all = true.
+     */
+    static submit_options all() {
+        submit_options opts;
+        opts.wait_all = true;
+        return opts;
+    }
+
+    /**
+     * @brief Create options for wait_any batch operation.
+     * @return submit_options with wait_any = true.
+     */
+    static submit_options any() {
+        submit_options opts;
+        opts.wait_any = true;
+        return opts;
+    }
+};
+
+}  // namespace kcenon::thread

--- a/tests/unit/thread_pool_test/unified_submit_test.cpp
+++ b/tests/unit/thread_pool_test/unified_submit_test.cpp
@@ -1,0 +1,281 @@
+/**
+ * @file unified_submit_test.cpp
+ * @brief Unit tests for Unified Submit API (Issue #492)
+ *
+ * Tests cover:
+ * - submit_options struct
+ * - Unified submit() method for single tasks
+ * - Unified submit() method for batch tasks
+ * - submit_wait_all() method
+ * - submit_wait_any() method
+ */
+
+#include <gtest/gtest.h>
+
+#include <kcenon/thread/core/thread_pool.h>
+#include <kcenon/thread/core/thread_worker.h>
+#include <kcenon/thread/core/submit_options.h>
+
+#include <atomic>
+#include <chrono>
+#include <functional>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace kcenon::thread::test {
+
+class UnifiedSubmitTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        pool_ = std::make_shared<thread_pool>("test_pool");
+
+        for (int i = 0; i < 4; ++i) {
+            auto worker = std::make_unique<thread_worker>();
+            pool_->enqueue(std::move(worker));
+        }
+
+        pool_->start();
+    }
+
+    void TearDown() override {
+        if (pool_) {
+            pool_->stop();
+        }
+    }
+
+    std::shared_ptr<thread_pool> pool_;
+};
+
+// ============================================================================
+// submit_options tests
+// ============================================================================
+
+TEST(SubmitOptionsTest, DefaultConstructor) {
+    submit_options opts;
+    EXPECT_TRUE(opts.name.empty());
+    EXPECT_FALSE(opts.wait_all);
+    EXPECT_FALSE(opts.wait_any);
+}
+
+TEST(SubmitOptionsTest, ExplicitNameConstructor) {
+    submit_options opts("my_job");
+    EXPECT_EQ(opts.name, "my_job");
+    EXPECT_FALSE(opts.wait_all);
+    EXPECT_FALSE(opts.wait_any);
+}
+
+TEST(SubmitOptionsTest, NamedFactory) {
+    auto opts = submit_options::named("task_name");
+    EXPECT_EQ(opts.name, "task_name");
+    EXPECT_FALSE(opts.wait_all);
+    EXPECT_FALSE(opts.wait_any);
+}
+
+TEST(SubmitOptionsTest, AllFactory) {
+    auto opts = submit_options::all();
+    EXPECT_TRUE(opts.name.empty());
+    EXPECT_TRUE(opts.wait_all);
+    EXPECT_FALSE(opts.wait_any);
+}
+
+TEST(SubmitOptionsTest, AnyFactory) {
+    auto opts = submit_options::any();
+    EXPECT_TRUE(opts.name.empty());
+    EXPECT_FALSE(opts.wait_all);
+    EXPECT_TRUE(opts.wait_any);
+}
+
+// ============================================================================
+// Unified submit() single task tests
+// ============================================================================
+
+TEST_F(UnifiedSubmitTest, SubmitSingleReturnsCorrectResult) {
+    auto future = pool_->submit([] { return 42; });
+    EXPECT_EQ(future.get(), 42);
+}
+
+TEST_F(UnifiedSubmitTest, SubmitSingleWithDefaultOptions) {
+    auto future = pool_->submit([] { return 100; }, submit_options{});
+    EXPECT_EQ(future.get(), 100);
+}
+
+TEST_F(UnifiedSubmitTest, SubmitSingleWithNamedJob) {
+    auto future = pool_->submit([] { return 200; }, submit_options::named("compute_task"));
+    EXPECT_EQ(future.get(), 200);
+}
+
+TEST_F(UnifiedSubmitTest, SubmitSingleWithDesignatedInitializer) {
+    submit_options opts;
+    opts.name = "designated_task";
+    auto future = pool_->submit([] { return 300; }, opts);
+    EXPECT_EQ(future.get(), 300);
+}
+
+TEST_F(UnifiedSubmitTest, SubmitSingleMultipleConcurrent) {
+    std::vector<std::future<int>> futures;
+    for (int i = 0; i < 10; ++i) {
+        futures.push_back(pool_->submit([i] { return i * i; }));
+    }
+
+    for (int i = 0; i < 10; ++i) {
+        EXPECT_EQ(futures[i].get(), i * i);
+    }
+}
+
+TEST_F(UnifiedSubmitTest, SubmitSinglePropagatesException) {
+    auto future = pool_->submit([]() -> int { throw std::logic_error("test exception"); });
+
+    EXPECT_THROW(future.get(), std::logic_error);
+}
+
+TEST_F(UnifiedSubmitTest, SubmitSingleWithVoidReturn) {
+    std::atomic<int> counter{0};
+
+    auto future = pool_->submit([&counter] { counter.fetch_add(1); });
+
+    future.get();
+    EXPECT_EQ(counter.load(), 1);
+}
+
+// ============================================================================
+// Unified submit() batch tests
+// ============================================================================
+
+TEST_F(UnifiedSubmitTest, SubmitBatchReturnsFutures) {
+    std::vector<std::function<int()>> tasks;
+    for (int i = 0; i < 5; ++i) {
+        tasks.push_back([i] { return i + 1; });
+    }
+
+    auto futures = pool_->submit(std::move(tasks));
+
+    EXPECT_EQ(futures.size(), 5u);
+    for (int i = 0; i < 5; ++i) {
+        EXPECT_EQ(futures[i].get(), i + 1);
+    }
+}
+
+TEST_F(UnifiedSubmitTest, SubmitBatchWithOptions) {
+    std::vector<std::function<int()>> tasks;
+    for (int i = 0; i < 3; ++i) {
+        tasks.push_back([i] { return i * 10; });
+    }
+
+    auto futures = pool_->submit(std::move(tasks), submit_options::named("batch_job"));
+
+    EXPECT_EQ(futures.size(), 3u);
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_EQ(futures[i].get(), i * 10);
+    }
+}
+
+// ============================================================================
+// submit_wait_all() tests
+// ============================================================================
+
+TEST_F(UnifiedSubmitTest, SubmitWaitAllBlocksAndReturnsResults) {
+    std::vector<std::function<int()>> tasks;
+    for (int i = 0; i < 5; ++i) {
+        tasks.push_back([i] { return i * 2; });
+    }
+
+    auto results = pool_->submit_wait_all(std::move(tasks));
+
+    EXPECT_EQ(results.size(), 5u);
+    for (int i = 0; i < 5; ++i) {
+        EXPECT_EQ(results[i], i * 2);
+    }
+}
+
+TEST_F(UnifiedSubmitTest, SubmitWaitAllWithNamedOptions) {
+    std::vector<std::function<int()>> tasks;
+    for (int i = 0; i < 3; ++i) {
+        tasks.push_back([i] { return i + 100; });
+    }
+
+    auto results = pool_->submit_wait_all(std::move(tasks), submit_options::named("wait_all_job"));
+
+    EXPECT_EQ(results.size(), 3u);
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_EQ(results[i], i + 100);
+    }
+}
+
+TEST_F(UnifiedSubmitTest, SubmitWaitAllEmptyVector) {
+    std::vector<std::function<int()>> empty_tasks;
+    auto results = pool_->submit_wait_all(std::move(empty_tasks));
+    EXPECT_TRUE(results.empty());
+}
+
+// ============================================================================
+// submit_wait_any() tests
+// ============================================================================
+
+TEST_F(UnifiedSubmitTest, SubmitWaitAnyReturnsFirstResult) {
+    std::vector<std::function<int()>> tasks;
+
+    tasks.push_back([] {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        return 1;
+    });
+
+    tasks.push_back([] { return 2; });
+
+    auto result = pool_->submit_wait_any(std::move(tasks));
+
+    EXPECT_TRUE(result == 1 || result == 2);
+}
+
+TEST_F(UnifiedSubmitTest, SubmitWaitAnyThrowsOnEmptyVector) {
+    std::vector<std::function<int()>> empty_tasks;
+    EXPECT_THROW(pool_->submit_wait_any(std::move(empty_tasks)), std::invalid_argument);
+}
+
+TEST_F(UnifiedSubmitTest, SubmitWaitAnyWithOptions) {
+    std::vector<std::function<int()>> tasks;
+    tasks.push_back([] { return 10; });
+    tasks.push_back([] { return 20; });
+
+    auto result = pool_->submit_wait_any(std::move(tasks), submit_options::named("any_job"));
+
+    EXPECT_TRUE(result == 10 || result == 20);
+}
+
+// ============================================================================
+// Comparison with deprecated API
+// ============================================================================
+
+TEST_F(UnifiedSubmitTest, SubmitEquivalentToSubmitAsync) {
+    auto future_new = pool_->submit([] { return 42; });
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    auto future_old = pool_->submit_async([] { return 42; });
+#pragma GCC diagnostic pop
+
+    EXPECT_EQ(future_new.get(), 42);
+    EXPECT_EQ(future_old.get(), 42);
+}
+
+TEST_F(UnifiedSubmitTest, SubmitBatchEquivalentToSubmitBatchAsync) {
+    std::vector<std::function<int()>> tasks1;
+    std::vector<std::function<int()>> tasks2;
+    for (int i = 0; i < 3; ++i) {
+        tasks1.push_back([i] { return i; });
+        tasks2.push_back([i] { return i; });
+    }
+
+    auto futures_new = pool_->submit(std::move(tasks1));
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    auto futures_old = pool_->submit_batch_async(std::move(tasks2));
+#pragma GCC diagnostic pop
+
+    EXPECT_EQ(futures_new.size(), futures_old.size());
+    for (size_t i = 0; i < futures_new.size(); ++i) {
+        EXPECT_EQ(futures_new[i].get(), futures_old[i].get());
+    }
+}
+
+}  // namespace kcenon::thread::test


### PR DESCRIPTION
## Summary

This PR implements a unified submit() API to consolidate the multiple submit method variants in thread_pool. Part of the SRP refactoring effort (#488).

- Add `submit_options` struct for configurable job submission behavior
- Add unified `submit()` method for single and batch task submission
- Add `submit_wait_all()` and `submit_wait_any()` convenience methods
- Deprecate old methods (`submit_async`, `submit_batch_async`, `submit_all`, `submit_any`)
- Add comprehensive unit tests for the new API

## Migration Example

```cpp
// Before
auto future = pool->submit_async([]{ return 42; }, "job_name");
auto futures = pool->submit_batch_async(std::move(tasks));
auto results = pool->submit_all(std::move(tasks));
auto result = pool->submit_any(std::move(tasks));

// After
auto future = pool->submit([]{ return 42; }, {.name = "job_name"});
auto futures = pool->submit(std::move(tasks));
auto results = pool->submit_wait_all(std::move(tasks));
auto result = pool->submit_wait_any(std::move(tasks));
```

## Test Plan

- [x] New unit tests pass for unified submit API
- [x] Existing tests continue to pass (with deprecation warnings)
- [x] Compilation succeeds without errors

Closes #492