### PR TITLE
refactor(thread_pool): add thread_pool_builder for fluent configuration

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -28,6 +28,7 @@ set(CORE_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/../include/kcenon/thread/core/thread_pool.h
     ${CMAKE_CURRENT_SOURCE_DIR}/../include/kcenon/thread/core/numa_thread_pool.h
     ${CMAKE_CURRENT_SOURCE_DIR}/../include/kcenon/thread/core/thread_worker.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/../include/kcenon/thread/core/thread_pool_builder.h
     ${CMAKE_CURRENT_SOURCE_DIR}/../include/kcenon/thread/core/typed_thread_pool.h
     ${CMAKE_CURRENT_SOURCE_DIR}/../include/kcenon/thread/core/typed_thread_worker.h
     ${CMAKE_CURRENT_SOURCE_DIR}/../include/kcenon/thread/core/worker_policy.h
@@ -92,6 +93,7 @@ set(CORE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/../src/queue/queue_factory.cpp
     # Thread pool implementation
     ${CMAKE_CURRENT_SOURCE_DIR}/../src/impl/thread_pool/thread_pool.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/impl/thread_pool/thread_pool_builder.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../src/impl/thread_pool/numa_thread_pool.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../src/impl/thread_pool/thread_worker.cpp
     # Typed pool implementation

--- a/include/kcenon/thread/core/thread_pool_builder.h
+++ b/include/kcenon/thread/core/thread_pool_builder.h
@@ -1,0 +1,275 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#pragma once
+
+#include <kcenon/thread/core/thread_pool.h>
+#include <kcenon/thread/core/worker_policy.h>
+#include <kcenon/thread/interfaces/thread_context.h>
+#include <kcenon/thread/pool_policies/circuit_breaker_policy.h>
+#include <kcenon/thread/pool_policies/autoscaling_pool_policy.h>
+#include <kcenon/thread/pool_policies/work_stealing_pool_policy.h>
+#include <kcenon/thread/resilience/circuit_breaker_config.h>
+#include <kcenon/thread/scaling/autoscaling_policy.h>
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace kcenon::thread
+{
+	/**
+	 * @class thread_pool_builder
+	 * @brief Fluent builder for creating and configuring thread pools.
+	 *
+	 * @ingroup thread_pools
+	 *
+	 * The `thread_pool_builder` provides a fluent API for constructing thread pools
+	 * with various configuration options. This pattern improves readability and
+	 * makes configuration immutable until the pool is built.
+	 *
+	 * ### Design Principles
+	 * - **Fluent Interface**: All `with_*()` methods return `*this` for chaining
+	 * - **Immutable Configuration**: Settings are accumulated before building
+	 * - **Sensible Defaults**: Unconfigured options use reasonable defaults
+	 * - **Policy Composition**: Multiple policies can be combined
+	 *
+	 * ### Usage Example
+	 * @code
+	 * // Basic usage
+	 * auto pool = thread_pool_builder("my_pool")
+	 *     .with_workers(8)
+	 *     .build();
+	 *
+	 * // With policies
+	 * auto pool = thread_pool_builder("resilient_pool")
+	 *     .with_workers(4)
+	 *     .with_circuit_breaker(circuit_breaker_config{
+	 *         .failure_threshold = 5,
+	 *         .open_duration = std::chrono::seconds{30}
+	 *     })
+	 *     .with_autoscaling(autoscaling_policy{
+	 *         .min_workers = 2,
+	 *         .max_workers = 16,
+	 *         .scaling_mode = autoscaling_policy::mode::automatic
+	 *     })
+	 *     .with_work_stealing()
+	 *     .build();
+	 *
+	 * pool->start();
+	 * @endcode
+	 *
+	 * @see thread_pool
+	 * @see circuit_breaker_policy
+	 * @see autoscaling_pool_policy
+	 * @see work_stealing_pool_policy
+	 */
+	class thread_pool_builder
+	{
+	public:
+		/**
+		 * @brief Constructs a builder with the given pool name.
+		 * @param name Name/title for the thread pool.
+		 *
+		 * The name is used for identification, logging, and debugging.
+		 */
+		explicit thread_pool_builder(const std::string& name = "thread_pool");
+
+		/**
+		 * @brief Sets the number of worker threads.
+		 * @param count Number of workers to create.
+		 * @return Reference to this builder for chaining.
+		 *
+		 * If not specified, defaults to `std::thread::hardware_concurrency()`.
+		 */
+		thread_pool_builder& with_workers(std::size_t count);
+
+		/**
+		 * @brief Sets the thread context for logging and monitoring.
+		 * @param context Thread context with logger and monitoring services.
+		 * @return Reference to this builder for chaining.
+		 */
+		thread_pool_builder& with_context(const thread_context& context);
+
+		/**
+		 * @brief Sets a custom job queue.
+		 * @param queue Custom job queue implementation.
+		 * @return Reference to this builder for chaining.
+		 *
+		 * Use this to inject specialized queues like `backpressure_job_queue`.
+		 */
+		thread_pool_builder& with_queue(std::shared_ptr<job_queue> queue);
+
+		/**
+		 * @brief Sets a policy-based queue adapter.
+		 * @param adapter Queue adapter for policy_queue.
+		 * @return Reference to this builder for chaining.
+		 *
+		 * Use this for the new policy-based queue system.
+		 */
+		thread_pool_builder& with_queue_adapter(
+			std::unique_ptr<pool_queue_adapter_interface> adapter);
+
+		/**
+		 * @brief Adds circuit breaker protection.
+		 * @param config Circuit breaker configuration.
+		 * @return Reference to this builder for chaining.
+		 *
+		 * The circuit breaker monitors job failures and automatically opens
+		 * when a threshold is exceeded, preventing cascading failures.
+		 *
+		 * @see circuit_breaker_config
+		 * @see circuit_breaker_policy
+		 */
+		thread_pool_builder& with_circuit_breaker(
+			const circuit_breaker_config& config = {});
+
+		/**
+		 * @brief Adds circuit breaker with an existing circuit breaker instance.
+		 * @param cb Shared circuit breaker for multiple pools.
+		 * @return Reference to this builder for chaining.
+		 *
+		 * Use this to share a circuit breaker across multiple pools.
+		 */
+		thread_pool_builder& with_circuit_breaker(
+			std::shared_ptr<circuit_breaker> cb);
+
+		/**
+		 * @brief Enables autoscaling with the specified policy.
+		 * @param config Autoscaling policy configuration.
+		 * @return Reference to this builder for chaining.
+		 *
+		 * The autoscaler automatically adjusts worker count based on
+		 * load metrics (utilization, queue depth, latency).
+		 *
+		 * @see autoscaling_policy
+		 * @see autoscaling_pool_policy
+		 */
+		thread_pool_builder& with_autoscaling(
+			const autoscaling_policy& config = {});
+
+		/**
+		 * @brief Enables work-stealing with default configuration.
+		 * @return Reference to this builder for chaining.
+		 *
+		 * Work-stealing enables idle workers to steal jobs from busy workers,
+		 * improving load balancing and throughput.
+		 *
+		 * @see work_stealing_pool_policy
+		 */
+		thread_pool_builder& with_work_stealing();
+
+		/**
+		 * @brief Enables work-stealing with custom configuration.
+		 * @param config Worker policy with work-stealing settings.
+		 * @return Reference to this builder for chaining.
+		 *
+		 * @see worker_policy
+		 * @see work_stealing_pool_policy
+		 */
+		thread_pool_builder& with_work_stealing(const worker_policy& config);
+
+		/**
+		 * @brief Enables diagnostics for the pool.
+		 * @return Reference to this builder for chaining.
+		 *
+		 * Diagnostics provide thread dumps, job inspection, and
+		 * bottleneck detection capabilities.
+		 */
+		thread_pool_builder& with_diagnostics();
+
+		/**
+		 * @brief Enables enhanced metrics collection.
+		 * @return Reference to this builder for chaining.
+		 *
+		 * Enhanced metrics include latency histograms, percentiles,
+		 * and sliding window throughput tracking.
+		 */
+		thread_pool_builder& with_enhanced_metrics();
+
+		/**
+		 * @brief Adds a custom policy to the pool.
+		 * @param policy Custom pool policy.
+		 * @return Reference to this builder for chaining.
+		 *
+		 * Use this to add custom policies that implement pool_policy.
+		 *
+		 * @see pool_policy
+		 */
+		thread_pool_builder& with_policy(std::unique_ptr<pool_policy> policy);
+
+		/**
+		 * @brief Builds and returns the configured thread pool.
+		 * @return Shared pointer to the constructed thread pool.
+		 *
+		 * After calling build(), the builder is reset and can be reused
+		 * to build another pool with different settings.
+		 *
+		 * @note The pool is NOT started automatically. Call pool->start()
+		 *       to begin processing jobs.
+		 */
+		[[nodiscard]] std::shared_ptr<thread_pool> build();
+
+		/**
+		 * @brief Builds the pool and starts it immediately.
+		 * @return Shared pointer to the started thread pool.
+		 *
+		 * Convenience method equivalent to:
+		 * @code
+		 * auto pool = builder.build();
+		 * pool->start();
+		 * return pool;
+		 * @endcode
+		 */
+		[[nodiscard]] std::shared_ptr<thread_pool> build_and_start();
+
+	private:
+		std::string name_;
+		std::size_t worker_count_{0};
+		thread_context context_;
+		std::shared_ptr<job_queue> custom_queue_;
+		std::unique_ptr<pool_queue_adapter_interface> queue_adapter_;
+		std::vector<std::unique_ptr<pool_policy>> policies_;
+		bool enable_diagnostics_{false};
+		bool enable_enhanced_metrics_{false};
+
+		std::optional<circuit_breaker_config> circuit_breaker_config_;
+		std::shared_ptr<circuit_breaker> shared_circuit_breaker_;
+		std::optional<autoscaling_policy> autoscaling_config_;
+		std::optional<worker_policy> work_stealing_config_;
+
+		void reset();
+	};
+
+} // namespace kcenon::thread

--- a/src/impl/thread_pool/thread_pool_builder.cpp
+++ b/src/impl/thread_pool/thread_pool_builder.cpp
@@ -1,0 +1,230 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#include <kcenon/thread/core/thread_pool_builder.h>
+
+namespace kcenon::thread
+{
+	thread_pool_builder::thread_pool_builder(const std::string& name)
+		: name_(name)
+		, worker_count_(0)
+		, context_()
+		, enable_diagnostics_(false)
+		, enable_enhanced_metrics_(false)
+	{
+	}
+
+	thread_pool_builder& thread_pool_builder::with_workers(std::size_t count)
+	{
+		worker_count_ = count;
+		return *this;
+	}
+
+	thread_pool_builder& thread_pool_builder::with_context(const thread_context& context)
+	{
+		context_ = context;
+		return *this;
+	}
+
+	thread_pool_builder& thread_pool_builder::with_queue(std::shared_ptr<job_queue> queue)
+	{
+		custom_queue_ = std::move(queue);
+		return *this;
+	}
+
+	thread_pool_builder& thread_pool_builder::with_queue_adapter(
+		std::unique_ptr<pool_queue_adapter_interface> adapter)
+	{
+		queue_adapter_ = std::move(adapter);
+		return *this;
+	}
+
+	thread_pool_builder& thread_pool_builder::with_circuit_breaker(
+		const circuit_breaker_config& config)
+	{
+		circuit_breaker_config_ = config;
+		shared_circuit_breaker_.reset();
+		return *this;
+	}
+
+	thread_pool_builder& thread_pool_builder::with_circuit_breaker(
+		std::shared_ptr<circuit_breaker> cb)
+	{
+		shared_circuit_breaker_ = std::move(cb);
+		circuit_breaker_config_.reset();
+		return *this;
+	}
+
+	thread_pool_builder& thread_pool_builder::with_autoscaling(
+		const autoscaling_policy& config)
+	{
+		autoscaling_config_ = config;
+		return *this;
+	}
+
+	thread_pool_builder& thread_pool_builder::with_work_stealing()
+	{
+		worker_policy config;
+		config.enable_work_stealing = true;
+		work_stealing_config_ = config;
+		return *this;
+	}
+
+	thread_pool_builder& thread_pool_builder::with_work_stealing(const worker_policy& config)
+	{
+		work_stealing_config_ = config;
+		return *this;
+	}
+
+	thread_pool_builder& thread_pool_builder::with_diagnostics()
+	{
+		enable_diagnostics_ = true;
+		return *this;
+	}
+
+	thread_pool_builder& thread_pool_builder::with_enhanced_metrics()
+	{
+		enable_enhanced_metrics_ = true;
+		return *this;
+	}
+
+	thread_pool_builder& thread_pool_builder::with_policy(std::unique_ptr<pool_policy> policy)
+	{
+		policies_.push_back(std::move(policy));
+		return *this;
+	}
+
+	std::shared_ptr<thread_pool> thread_pool_builder::build()
+	{
+		std::shared_ptr<thread_pool> pool;
+
+		if (queue_adapter_)
+		{
+			pool = std::make_shared<thread_pool>(name_, std::move(queue_adapter_), context_);
+		}
+		else if (custom_queue_)
+		{
+			pool = std::make_shared<thread_pool>(name_, custom_queue_, context_);
+		}
+		else
+		{
+			pool = std::make_shared<thread_pool>(name_, context_);
+		}
+
+		std::size_t worker_count = worker_count_;
+		if (worker_count == 0)
+		{
+			worker_count = std::thread::hardware_concurrency();
+			if (worker_count == 0)
+			{
+				worker_count = 4;
+			}
+		}
+
+		for (std::size_t i = 0; i < worker_count; ++i)
+		{
+			auto worker = std::make_unique<thread_worker>(true, context_);
+			worker->set_job_queue(pool->get_job_queue());
+			pool->enqueue(std::move(worker));
+		}
+
+		if (circuit_breaker_config_.has_value())
+		{
+			auto cb_policy = std::make_unique<circuit_breaker_policy>(
+				circuit_breaker_config_.value());
+			pool->add_policy(std::move(cb_policy));
+		}
+		else if (shared_circuit_breaker_)
+		{
+			auto cb_policy = std::make_unique<circuit_breaker_policy>(
+				shared_circuit_breaker_);
+			pool->add_policy(std::move(cb_policy));
+		}
+
+		if (autoscaling_config_.has_value())
+		{
+			auto as_policy = std::make_unique<autoscaling_pool_policy>(
+				*pool, autoscaling_config_.value());
+			pool->add_policy(std::move(as_policy));
+		}
+
+		if (work_stealing_config_.has_value())
+		{
+			auto ws_policy = std::make_unique<work_stealing_pool_policy>(
+				work_stealing_config_.value());
+			pool->add_policy(std::move(ws_policy));
+		}
+
+		for (auto& policy : policies_)
+		{
+			pool->add_policy(std::move(policy));
+		}
+
+		if (enable_enhanced_metrics_)
+		{
+			pool->set_enhanced_metrics_enabled(true);
+		}
+
+		if (enable_diagnostics_)
+		{
+			(void)pool->diagnostics();
+		}
+
+		reset();
+
+		return pool;
+	}
+
+	std::shared_ptr<thread_pool> thread_pool_builder::build_and_start()
+	{
+		auto pool = build();
+		pool->start();
+		return pool;
+	}
+
+	void thread_pool_builder::reset()
+	{
+		name_ = "thread_pool";
+		worker_count_ = 0;
+		context_ = thread_context();
+		custom_queue_.reset();
+		queue_adapter_.reset();
+		policies_.clear();
+		enable_diagnostics_ = false;
+		enable_enhanced_metrics_ = false;
+		circuit_breaker_config_.reset();
+		shared_circuit_breaker_.reset();
+		autoscaling_config_.reset();
+		work_stealing_config_.reset();
+	}
+
+} // namespace kcenon::thread

--- a/tests/unit/thread_pool_test/thread_pool_builder_test.cpp
+++ b/tests/unit/thread_pool_test/thread_pool_builder_test.cpp
@@ -1,0 +1,288 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#include "gtest/gtest.h"
+
+#include <kcenon/thread/core/thread_pool_builder.h>
+#include <kcenon/thread/core/callback_job.h>
+#include <kcenon/thread/pool_policies/circuit_breaker_policy.h>
+#include <kcenon/thread/pool_policies/work_stealing_pool_policy.h>
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+using namespace kcenon::thread;
+
+class ThreadPoolBuilderTest : public ::testing::Test
+{
+protected:
+	void TearDown() override
+	{
+		std::this_thread::sleep_for(std::chrono::milliseconds(50));
+	}
+};
+
+TEST_F(ThreadPoolBuilderTest, BasicConstruction)
+{
+	auto pool = thread_pool_builder("test_pool")
+		.with_workers(2)
+		.build();
+
+	ASSERT_NE(pool, nullptr);
+	EXPECT_FALSE(pool->is_running());
+}
+
+TEST_F(ThreadPoolBuilderTest, BuildAndStart)
+{
+	auto pool = thread_pool_builder("test_pool")
+		.with_workers(2)
+		.build_and_start();
+
+	ASSERT_NE(pool, nullptr);
+	EXPECT_TRUE(pool->is_running());
+
+	pool->stop();
+}
+
+TEST_F(ThreadPoolBuilderTest, DefaultWorkerCount)
+{
+	auto pool = thread_pool_builder("test_pool")
+		.build();
+
+	ASSERT_NE(pool, nullptr);
+
+	auto start_result = pool->start();
+	EXPECT_FALSE(start_result.is_err());
+	EXPECT_TRUE(pool->is_running());
+
+	pool->stop();
+}
+
+TEST_F(ThreadPoolBuilderTest, WithCircuitBreaker)
+{
+	circuit_breaker_config config;
+	config.failure_threshold = 3;
+	config.open_duration = std::chrono::seconds{10};
+
+	auto pool = thread_pool_builder("cb_pool")
+		.with_workers(2)
+		.with_circuit_breaker(config)
+		.build();
+
+	ASSERT_NE(pool, nullptr);
+
+	auto* cb_policy = pool->find_policy<circuit_breaker_policy>("circuit_breaker_policy");
+	ASSERT_NE(cb_policy, nullptr);
+	EXPECT_TRUE(cb_policy->is_accepting_work());
+	EXPECT_EQ(cb_policy->get_state(), circuit_state::closed);
+
+	pool->stop();
+}
+
+TEST_F(ThreadPoolBuilderTest, WithWorkStealing)
+{
+	auto pool = thread_pool_builder("ws_pool")
+		.with_workers(4)
+		.with_work_stealing()
+		.build();
+
+	ASSERT_NE(pool, nullptr);
+
+	auto* ws_policy = pool->find_policy<work_stealing_pool_policy>("work_stealing_pool_policy");
+	ASSERT_NE(ws_policy, nullptr);
+	EXPECT_TRUE(ws_policy->is_enabled());
+
+	pool->stop();
+}
+
+TEST_F(ThreadPoolBuilderTest, WithWorkStealingCustomConfig)
+{
+	worker_policy config;
+	config.enable_work_stealing = true;
+	config.victim_selection = steal_policy::adaptive;
+	config.max_steal_attempts = 5;
+
+	auto pool = thread_pool_builder("ws_custom_pool")
+		.with_workers(4)
+		.with_work_stealing(config)
+		.build();
+
+	ASSERT_NE(pool, nullptr);
+
+	auto* ws_policy = pool->find_policy<work_stealing_pool_policy>("work_stealing_pool_policy");
+	ASSERT_NE(ws_policy, nullptr);
+	EXPECT_TRUE(ws_policy->is_enabled());
+	EXPECT_EQ(ws_policy->get_steal_policy(), steal_policy::adaptive);
+	EXPECT_EQ(ws_policy->get_max_steal_attempts(), 5u);
+
+	pool->stop();
+}
+
+TEST_F(ThreadPoolBuilderTest, WithEnhancedMetrics)
+{
+	auto pool = thread_pool_builder("metrics_pool")
+		.with_workers(2)
+		.with_enhanced_metrics()
+		.build();
+
+	ASSERT_NE(pool, nullptr);
+	EXPECT_TRUE(pool->is_enhanced_metrics_enabled());
+
+	pool->stop();
+}
+
+TEST_F(ThreadPoolBuilderTest, WithDiagnostics)
+{
+	auto pool = thread_pool_builder("diag_pool")
+		.with_workers(2)
+		.with_diagnostics()
+		.build();
+
+	ASSERT_NE(pool, nullptr);
+
+	auto& diag = pool->diagnostics();
+	(void)diag;
+
+	pool->stop();
+}
+
+TEST_F(ThreadPoolBuilderTest, MultiplePolicies)
+{
+	circuit_breaker_config cb_config;
+	cb_config.failure_threshold = 5;
+
+	auto pool = thread_pool_builder("multi_policy_pool")
+		.with_workers(4)
+		.with_circuit_breaker(cb_config)
+		.with_work_stealing()
+		.with_enhanced_metrics()
+		.with_diagnostics()
+		.build();
+
+	ASSERT_NE(pool, nullptr);
+
+	auto* cb_policy = pool->find_policy<circuit_breaker_policy>("circuit_breaker_policy");
+	ASSERT_NE(cb_policy, nullptr);
+
+	auto* ws_policy = pool->find_policy<work_stealing_pool_policy>("work_stealing_pool_policy");
+	ASSERT_NE(ws_policy, nullptr);
+
+	EXPECT_TRUE(pool->is_enhanced_metrics_enabled());
+
+	pool->stop();
+}
+
+TEST_F(ThreadPoolBuilderTest, JobExecution)
+{
+	std::atomic<int> counter{0};
+
+	auto pool = thread_pool_builder("exec_pool")
+		.with_workers(2)
+		.build_and_start();
+
+	ASSERT_NE(pool, nullptr);
+
+	for (int i = 0; i < 10; ++i)
+	{
+		auto job = std::make_unique<callback_job>(
+			[&counter]() -> std::optional<std::string> {
+				counter.fetch_add(1, std::memory_order_relaxed);
+				return std::nullopt;
+			});
+		auto result = pool->enqueue(std::move(job));
+		EXPECT_FALSE(result.is_err());
+	}
+
+	std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+	EXPECT_EQ(counter.load(), 10);
+
+	pool->stop();
+}
+
+TEST_F(ThreadPoolBuilderTest, BuilderReuse)
+{
+	thread_pool_builder builder("reuse_pool");
+
+	auto pool1 = builder
+		.with_workers(2)
+		.build();
+
+	ASSERT_NE(pool1, nullptr);
+
+	auto pool2 = builder
+		.with_workers(4)
+		.with_circuit_breaker()
+		.build();
+
+	ASSERT_NE(pool2, nullptr);
+
+	EXPECT_NE(pool1.get(), pool2.get());
+
+	pool1->stop();
+	pool2->stop();
+}
+
+TEST_F(ThreadPoolBuilderTest, FluentInterface)
+{
+	circuit_breaker_config cb_config;
+	worker_policy ws_config;
+	ws_config.enable_work_stealing = true;
+
+	auto pool = thread_pool_builder("fluent_pool")
+		.with_workers(8)
+		.with_circuit_breaker(cb_config)
+		.with_work_stealing(ws_config)
+		.with_enhanced_metrics()
+		.with_diagnostics()
+		.build_and_start();
+
+	ASSERT_NE(pool, nullptr);
+	EXPECT_TRUE(pool->is_running());
+
+	pool->stop();
+}
+
+TEST_F(ThreadPoolBuilderTest, SubmitWithBuilder)
+{
+	auto pool = thread_pool_builder("submit_pool")
+		.with_workers(2)
+		.build_and_start();
+
+	ASSERT_NE(pool, nullptr);
+
+	auto future = pool->submit([]() { return 42; });
+	EXPECT_EQ(future.get(), 42);
+
+	pool->stop();
+}


### PR DESCRIPTION
## Summary

Implement `thread_pool_builder` class for fluent configuration of thread pools as part of the SRP refactoring effort.

Part of #488
Closes #493

### Changes

- Add `thread_pool_builder.h` with fluent builder API
- Add `thread_pool_builder.cpp` implementation
- Add comprehensive unit tests (13 tests, all passing)
- Update `CMakeLists.txt` to include new files

### Features

The builder supports:
- `with_workers(count)` - Set worker thread count
- `with_circuit_breaker(config)` - Add circuit breaker protection
- `with_autoscaling(policy)` - Enable automatic scaling
- `with_work_stealing()` - Enable work-stealing for load balancing
- `with_enhanced_metrics()` - Enable enhanced metrics collection
- `with_diagnostics()` - Enable diagnostics
- `with_policy(policy)` - Add custom pool policies
- `build()` / `build_and_start()` - Create the thread pool

### Usage Example

```cpp
// Before (multiple method calls)
auto pool = std::make_shared<thread_pool>("my_pool");
pool->enable_circuit_breaker(config);
pool->enable_autoscaling(policy);
pool->start();

// After (fluent builder)
auto pool = thread_pool_builder("my_pool")
    .with_workers(8)
    .with_circuit_breaker(config)
    .with_autoscaling(policy)
    .with_work_stealing()
    .build_and_start();
```

## Test Plan

- [x] All 13 new unit tests pass
- [x] Library builds successfully
- [x] No regressions to existing functionality