### PR TITLE
fix(tests): update tests to use new API after thread_pool refactoring

### DIFF
--- a/tests/unit/interfaces_test/queue_capabilities_test.cpp
+++ b/tests/unit/interfaces_test/queue_capabilities_test.cpp
@@ -40,6 +40,7 @@ BSD 3-Clause License
 #include <kcenon/thread/core/callback_job.h>
 
 using namespace kcenon::thread;
+using namespace kcenon::thread::detail;
 
 // Test queue_capabilities struct default values
 TEST(queue_capabilities_test, default_values)

--- a/tests/unit/thread_base_test/lockfree_job_queue_test.cpp
+++ b/tests/unit/thread_base_test/lockfree_job_queue_test.cpp
@@ -40,6 +40,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <vector>
 
 using namespace kcenon::thread;
+using namespace kcenon::thread::detail;
 
 class LockFreeJobQueueTest : public ::testing::Test {
 protected:

--- a/tests/unit/thread_base_test/queue_factory_test.cpp
+++ b/tests/unit/thread_base_test/queue_factory_test.cpp
@@ -70,10 +70,10 @@ TEST_F(QueueFactoryTest, CreateStandardQueue) {
     EXPECT_TRUE(caps.supports_stop);
 }
 
-TEST_F(QueueFactoryTest, CreateLockfreeQueue) {
-    // Note: create_lockfree_queue() now returns adaptive_job_queue with performance_first policy
-    // (lockfree_job_queue is now an internal implementation detail)
-    auto queue = queue_factory::create_lockfree_queue();
+TEST_F(QueueFactoryTest, CreatePerformanceFirstAdaptiveQueue) {
+    // Note: create_lockfree_queue() has been replaced with create_adaptive_queue(policy::performance_first)
+    // (lockfree_job_queue is now an internal implementation detail in detail:: namespace)
+    auto queue = queue_factory::create_adaptive_queue(adaptive_job_queue::policy::performance_first);
 
     ASSERT_NE(queue, nullptr);
     EXPECT_TRUE(queue->empty());
@@ -318,8 +318,8 @@ TEST_F(QueueFactoryTest, StandardQueueFunctional) {
     EXPECT_TRUE(queue->empty());
 }
 
-TEST_F(QueueFactoryTest, LockfreeQueueFunctional) {
-    auto queue = queue_factory::create_lockfree_queue();
+TEST_F(QueueFactoryTest, PerformanceFirstAdaptiveQueueFunctional) {
+    auto queue = queue_factory::create_adaptive_queue(adaptive_job_queue::policy::performance_first);
 
     std::atomic<int> counter{0};
     for (int i = 0; i < 10; ++i) {
@@ -388,9 +388,9 @@ TEST_F(QueueFactoryTest, AllQueuesImplementSchedulerInterface) {
         EXPECT_TRUE(scheduler->get_next_job().is_ok());
     }
 
-    // Lockfree queue
+    // Performance-first adaptive queue (formerly lockfree queue)
     {
-        auto queue = queue_factory::create_lockfree_queue();
+        auto queue = queue_factory::create_adaptive_queue(adaptive_job_queue::policy::performance_first);
         scheduler_interface* scheduler = queue.get();
         ASSERT_NE(scheduler, nullptr);
 
@@ -423,9 +423,8 @@ TEST_F(QueueFactoryTest, ExistingCodeStillWorks) {
     auto q1 = std::make_shared<job_queue>();
     EXPECT_TRUE(q1->empty());
 
-    // Direct lockfree_job_queue construction
-    auto q2 = std::make_unique<lockfree_job_queue>();
-    EXPECT_TRUE(q2->empty());
+    // Note: lockfree_job_queue is now in detail:: namespace and not for direct use
+    // Use adaptive_job_queue with performance_first policy instead
 
     // Direct adaptive_job_queue construction
     auto q3 = std::make_unique<adaptive_job_queue>();

--- a/tests/unit/thread_pool_test/thread_pool_test.cpp
+++ b/tests/unit/thread_pool_test/thread_pool_test.cpp
@@ -37,6 +37,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <kcenon/thread/core/callback_job.h>
 
 using namespace kcenon::thread;
+using namespace kcenon;
 
 // Static assertions for ARM64 compatibility (Issue #223)
 // These compile-time checks verify memory alignment requirements


### PR DESCRIPTION
## Summary
- Update test files to use new API introduced during thread_pool SRP refactoring (#488)
- Fix build errors caused by namespace changes and removed deprecated methods

## Changes
- Add `detail::` namespace for `lockfree_job_queue` (now internal implementation)
- Replace `create_lockfree_queue()` with `create_adaptive_queue(policy::performance_first)`
- Rewrite `work_stealing_integration_test` to use `work_stealing_pool_policy` instead of removed methods
- Add missing `kcenon` namespace in test files

## Test Plan
- [x] Build passes (`cmake --build build --config Release`)
- [x] 309 out of 311 tests pass
- [ ] 2 pre-existing flaky tests (AutoscalerTest timing issues, unrelated to these changes)

Part of #488