### PR TITLE
refactor(core): extract lifecycle_controller for thread state management

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -18,6 +18,7 @@ set(CORE_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/../include/kcenon/thread/core/job.h
     ${CMAKE_CURRENT_SOURCE_DIR}/../include/kcenon/thread/core/job_queue.h
     ${CMAKE_CURRENT_SOURCE_DIR}/../include/kcenon/thread/core/job_types.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/../include/kcenon/thread/core/lifecycle_controller.h
     ${CMAKE_CURRENT_SOURCE_DIR}/../include/kcenon/thread/core/pool_traits.h
     ${CMAKE_CURRENT_SOURCE_DIR}/../include/kcenon/thread/core/service_registry.h
     ${CMAKE_CURRENT_SOURCE_DIR}/../include/kcenon/thread/core/sync_primitives.h
@@ -85,6 +86,7 @@ set(CORE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/../src/core/hazard_pointer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../src/core/job.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../src/core/job_queue.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/core/lifecycle_controller.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../src/core/thread_base.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../src/core/thread_logger_init.cpp
     # Lock-free implementation

--- a/include/kcenon/thread/core/lifecycle_controller.h
+++ b/include/kcenon/thread/core/lifecycle_controller.h
@@ -1,0 +1,317 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024, 🍀☀🌕🌥 🌊
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#pragma once
+
+#include "thread_conditions.h"
+
+#include <mutex>
+#include <atomic>
+#include <chrono>
+#include <optional>
+#include <condition_variable>
+
+#ifdef USE_STD_JTHREAD
+#include <stop_token>
+#endif
+
+namespace kcenon::thread
+{
+	/**
+	 * @class lifecycle_controller
+	 * @brief Centralized thread lifecycle state and synchronization management.
+	 *
+	 * @ingroup core_threading
+	 *
+	 * The @c lifecycle_controller class consolidates duplicated thread lifecycle
+	 * management patterns (start, stop, state transitions, condition variables)
+	 * into a single reusable component. Thread classes can use composition with
+	 * this controller instead of implementing these patterns themselves.
+	 *
+	 * ### Key Features
+	 * - Thread state management (Created, Waiting, Working, Stopping, Stopped)
+	 * - Condition variable signaling for wake-ups
+	 * - Stop request handling (supports both std::jthread and legacy std::thread)
+	 * - Thread-safe state queries and transitions
+	 *
+	 * ### Thread Safety
+	 * All public methods are thread-safe. The class uses internal synchronization
+	 * to protect state transitions and condition variable operations.
+	 *
+	 * ### Example Usage
+	 * @code
+	 * class my_thread {
+	 * private:
+	 *     lifecycle_controller lifecycle_;
+	 *
+	 * public:
+	 *     void start() {
+	 *         lifecycle_.initialize_for_start();
+	 *         // spawn thread...
+	 *     }
+	 *
+	 *     void stop() {
+	 *         lifecycle_.request_stop();
+	 *         lifecycle_.notify_all();
+	 *         // join thread...
+	 *         lifecycle_.set_stopped();
+	 *     }
+	 *
+	 *     void worker_loop() {
+	 *         while (!lifecycle_.is_stop_requested() || has_work()) {
+	 *             lifecycle_.set_state(thread_conditions::Waiting);
+	 *             lifecycle_.wait_for(timeout, [this] { return has_work(); });
+	 *             lifecycle_.set_state(thread_conditions::Working);
+	 *             do_work();
+	 *         }
+	 *     }
+	 * };
+	 * @endcode
+	 */
+	class lifecycle_controller
+	{
+	public:
+		lifecycle_controller(const lifecycle_controller&) = delete;
+		lifecycle_controller& operator=(const lifecycle_controller&) = delete;
+		lifecycle_controller(lifecycle_controller&&) = delete;
+		lifecycle_controller& operator=(lifecycle_controller&&) = delete;
+
+		/**
+		 * @brief Constructs a new lifecycle_controller in Created state.
+		 */
+		lifecycle_controller();
+
+		/**
+		 * @brief Destructor.
+		 */
+		~lifecycle_controller() = default;
+
+		// =========================================================================
+		// State Management
+		// =========================================================================
+
+		/**
+		 * @brief Gets the current thread condition/state.
+		 * @return The current thread_conditions value.
+		 *
+		 * Thread Safety:
+		 * - Safe to call from any thread
+		 * - Uses atomic load with acquire memory ordering
+		 */
+		[[nodiscard]] auto get_state() const noexcept -> thread_conditions;
+
+		/**
+		 * @brief Sets the thread condition/state.
+		 * @param state The new thread_conditions value.
+		 *
+		 * Thread Safety:
+		 * - Safe to call from any thread
+		 * - Uses atomic store with release memory ordering
+		 */
+		auto set_state(thread_conditions state) noexcept -> void;
+
+		/**
+		 * @brief Checks if the thread is currently running.
+		 * @return true if state is Working or Waiting, false otherwise.
+		 */
+		[[nodiscard]] auto is_running() const noexcept -> bool;
+
+		/**
+		 * @brief Marks the thread as stopped.
+		 *
+		 * Convenience method equivalent to set_state(thread_conditions::Stopped).
+		 */
+		auto set_stopped() noexcept -> void;
+
+		// =========================================================================
+		// Stop Request Management
+		// =========================================================================
+
+		/**
+		 * @brief Initializes the controller for a new thread start.
+		 *
+		 * Resets the stop request flag and prepares for a new thread lifecycle.
+		 * In C++20 jthread mode, creates a new stop_source.
+		 *
+		 * @note Must be called before spawning the worker thread.
+		 */
+		auto initialize_for_start() -> void;
+
+		/**
+		 * @brief Requests the thread to stop.
+		 *
+		 * In C++20 mode, calls request_stop() on the stop_source.
+		 * In legacy mode, sets the atomic stop_requested_ flag to true.
+		 *
+		 * Thread Safety:
+		 * - Safe to call from any thread
+		 * - The request is visible to the worker thread immediately
+		 */
+		auto request_stop() noexcept -> void;
+
+		/**
+		 * @brief Checks if a stop has been requested.
+		 * @return true if stop has been requested, false otherwise.
+		 *
+		 * Thread Safety:
+		 * - Safe to call from any thread
+		 */
+		[[nodiscard]] auto is_stop_requested() const noexcept -> bool;
+
+		/**
+		 * @brief Checks if the controller has an active stop source (C++20 only).
+		 * @return true if a stop_source is active, false otherwise.
+		 *
+		 * In legacy mode, checks if stop has NOT been requested (indicating active state).
+		 */
+		[[nodiscard]] auto has_active_source() const noexcept -> bool;
+
+		/**
+		 * @brief Resets the stop control mechanism after thread completion.
+		 *
+		 * In C++20 mode, resets the stop_source.
+		 * Should be called after thread join to clean up resources.
+		 */
+		auto reset_stop_source() noexcept -> void;
+
+		// =========================================================================
+		// Condition Variable Operations
+		// =========================================================================
+
+		/**
+		 * @brief Acquires a unique lock on the condition variable mutex.
+		 * @return A unique_lock holding the mutex.
+		 *
+		 * Use this to prepare for wait operations.
+		 */
+		[[nodiscard]] auto acquire_lock() -> std::unique_lock<std::mutex>;
+
+		/**
+		 * @brief Waits on the condition variable with a predicate.
+		 * @tparam Predicate A callable returning bool.
+		 * @param lock The unique_lock (must be holding cv_mutex_).
+		 * @param pred The predicate to check.
+		 *
+		 * Waits until pred() returns true OR stop is requested.
+		 */
+		template<typename Predicate>
+		auto wait(std::unique_lock<std::mutex>& lock, Predicate pred) -> void
+		{
+#ifdef USE_STD_JTHREAD
+			if (stop_source_.has_value())
+			{
+				auto stop_token = stop_source_.value().get_token();
+				condition_.wait(lock, [this, &stop_token, &pred]() {
+					return stop_token.stop_requested() || pred();
+				});
+			}
+			else
+			{
+				condition_.wait(lock, pred);
+			}
+#else
+			condition_.wait(lock, [this, &pred]() {
+				return stop_requested_.load(std::memory_order_acquire) || pred();
+			});
+#endif
+		}
+
+		/**
+		 * @brief Waits on the condition variable with a timeout and predicate.
+		 * @tparam Rep Duration rep type.
+		 * @tparam Period Duration period type.
+		 * @tparam Predicate A callable returning bool.
+		 * @param lock The unique_lock (must be holding cv_mutex_).
+		 * @param timeout The maximum duration to wait.
+		 * @param pred The predicate to check.
+		 * @return true if pred() is satisfied, false if timed out.
+		 */
+		template<typename Rep, typename Period, typename Predicate>
+		auto wait_for(std::unique_lock<std::mutex>& lock,
+		              const std::chrono::duration<Rep, Period>& timeout,
+		              Predicate pred) -> bool
+		{
+#ifdef USE_STD_JTHREAD
+			if (stop_source_.has_value())
+			{
+				auto stop_token = stop_source_.value().get_token();
+				return condition_.wait_for(lock, timeout, [this, &stop_token, &pred]() {
+					return stop_token.stop_requested() || pred();
+				});
+			}
+			else
+			{
+				return condition_.wait_for(lock, timeout, pred);
+			}
+#else
+			return condition_.wait_for(lock, timeout, [this, &pred]() {
+				return stop_requested_.load(std::memory_order_acquire) || pred();
+			});
+#endif
+		}
+
+		/**
+		 * @brief Notifies one waiting thread.
+		 *
+		 * Thread Safety:
+		 * - Safe to call from any thread
+		 */
+		auto notify_one() -> void;
+
+		/**
+		 * @brief Notifies all waiting threads.
+		 *
+		 * Thread Safety:
+		 * - Safe to call from any thread
+		 */
+		auto notify_all() -> void;
+
+	private:
+		/// Mutex for condition variable operations.
+		std::mutex cv_mutex_;
+
+		/// Condition variable for thread signaling.
+		std::condition_variable condition_;
+
+		/// Current thread state.
+		std::atomic<thread_conditions> state_{thread_conditions::Created};
+
+#ifdef USE_STD_JTHREAD
+		/// Stop source for cooperative cancellation (C++20).
+		std::optional<std::stop_source> stop_source_;
+#else
+		/// Atomic flag for stop request (legacy mode).
+		std::atomic<bool> stop_requested_{false};
+#endif
+	};
+
+} // namespace kcenon::thread

--- a/src/core/lifecycle_controller.cpp
+++ b/src/core/lifecycle_controller.cpp
@@ -1,0 +1,140 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024, 🍀☀🌕🌥 🌊
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#include <kcenon/thread/core/lifecycle_controller.h>
+
+namespace kcenon::thread
+{
+	lifecycle_controller::lifecycle_controller()
+		: state_(thread_conditions::Created)
+#ifdef USE_STD_JTHREAD
+		, stop_source_(std::nullopt)
+#else
+		, stop_requested_(false)
+#endif
+	{
+	}
+
+	auto lifecycle_controller::get_state() const noexcept -> thread_conditions
+	{
+		return state_.load(std::memory_order_acquire);
+	}
+
+	auto lifecycle_controller::set_state(thread_conditions state) noexcept -> void
+	{
+		state_.store(state, std::memory_order_release);
+	}
+
+	auto lifecycle_controller::is_running() const noexcept -> bool
+	{
+		auto condition = state_.load(std::memory_order_acquire);
+		return condition == thread_conditions::Working ||
+		       condition == thread_conditions::Waiting;
+	}
+
+	auto lifecycle_controller::set_stopped() noexcept -> void
+	{
+		set_state(thread_conditions::Stopped);
+	}
+
+	auto lifecycle_controller::initialize_for_start() -> void
+	{
+#ifdef USE_STD_JTHREAD
+		stop_source_ = std::stop_source();
+#else
+		stop_requested_.store(false, std::memory_order_release);
+#endif
+		set_state(thread_conditions::Created);
+	}
+
+	auto lifecycle_controller::request_stop() noexcept -> void
+	{
+#ifdef USE_STD_JTHREAD
+		if (stop_source_.has_value())
+		{
+			stop_source_.value().request_stop();
+		}
+#else
+		stop_requested_.store(true, std::memory_order_release);
+#endif
+	}
+
+	auto lifecycle_controller::is_stop_requested() const noexcept -> bool
+	{
+#ifdef USE_STD_JTHREAD
+		if (stop_source_.has_value())
+		{
+			return stop_source_.value().stop_requested();
+		}
+		return true;
+#else
+		return stop_requested_.load(std::memory_order_acquire);
+#endif
+	}
+
+	auto lifecycle_controller::has_active_source() const noexcept -> bool
+	{
+#ifdef USE_STD_JTHREAD
+		return stop_source_.has_value();
+#else
+		// In legacy mode, check if we're in an active state (not stopped/created)
+		auto state = state_.load(std::memory_order_acquire);
+		return state == thread_conditions::Working ||
+		       state == thread_conditions::Waiting;
+#endif
+	}
+
+	auto lifecycle_controller::reset_stop_source() noexcept -> void
+	{
+#ifdef USE_STD_JTHREAD
+		stop_source_.reset();
+#endif
+	}
+
+	auto lifecycle_controller::acquire_lock() -> std::unique_lock<std::mutex>
+	{
+		return std::unique_lock<std::mutex>(cv_mutex_);
+	}
+
+	auto lifecycle_controller::notify_one() -> void
+	{
+		std::scoped_lock<std::mutex> lock(cv_mutex_);
+		condition_.notify_one();
+	}
+
+	auto lifecycle_controller::notify_all() -> void
+	{
+		std::scoped_lock<std::mutex> lock(cv_mutex_);
+		condition_.notify_all();
+	}
+
+} // namespace kcenon::thread

--- a/tests/unit/thread_base_test/lifecycle_controller_test.cpp
+++ b/tests/unit/thread_base_test/lifecycle_controller_test.cpp
@@ -1,0 +1,334 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024, 🍀☀🌕🌥 🌊
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#include <gtest/gtest.h>
+#include <kcenon/thread/core/lifecycle_controller.h>
+
+#include <thread>
+#include <chrono>
+#include <atomic>
+#include <latch>
+
+using namespace kcenon::thread;
+
+class LifecycleControllerTest : public ::testing::Test
+{
+protected:
+	void SetUp() override
+	{
+		controller_ = std::make_unique<lifecycle_controller>();
+	}
+
+	void TearDown() override
+	{
+		controller_.reset();
+	}
+
+	std::unique_ptr<lifecycle_controller> controller_;
+};
+
+TEST_F(LifecycleControllerTest, InitialStateIsCreated)
+{
+	EXPECT_EQ(controller_->get_state(), thread_conditions::Created);
+	EXPECT_FALSE(controller_->is_running());
+	// Note: In legacy mode (no jthread), has_active_source() returns !stop_requested_
+	// which is true initially. In jthread mode, it returns stop_source_.has_value()
+	// which is false initially. We test the initialized state instead.
+	EXPECT_FALSE(controller_->is_stop_requested());
+}
+
+TEST_F(LifecycleControllerTest, StateTransitions)
+{
+	controller_->set_state(thread_conditions::Waiting);
+	EXPECT_EQ(controller_->get_state(), thread_conditions::Waiting);
+	EXPECT_TRUE(controller_->is_running());
+
+	controller_->set_state(thread_conditions::Working);
+	EXPECT_EQ(controller_->get_state(), thread_conditions::Working);
+	EXPECT_TRUE(controller_->is_running());
+
+	controller_->set_state(thread_conditions::Stopping);
+	EXPECT_EQ(controller_->get_state(), thread_conditions::Stopping);
+	EXPECT_FALSE(controller_->is_running());
+
+	controller_->set_stopped();
+	EXPECT_EQ(controller_->get_state(), thread_conditions::Stopped);
+	EXPECT_FALSE(controller_->is_running());
+}
+
+TEST_F(LifecycleControllerTest, InitializeForStart)
+{
+	controller_->initialize_for_start();
+	// After initialize_for_start, stop is not requested and state is Created
+	EXPECT_FALSE(controller_->is_stop_requested());
+	EXPECT_EQ(controller_->get_state(), thread_conditions::Created);
+	// has_active_source() returns true only when in Working/Waiting state (legacy mode)
+	// or when stop_source_ is set (jthread mode)
+}
+
+TEST_F(LifecycleControllerTest, StopRequestBehavior)
+{
+	controller_->initialize_for_start();
+	EXPECT_FALSE(controller_->is_stop_requested());
+
+	controller_->request_stop();
+	EXPECT_TRUE(controller_->is_stop_requested());
+}
+
+TEST_F(LifecycleControllerTest, ResetStopSource)
+{
+	controller_->initialize_for_start();
+
+	// Simulate an active thread by setting state to Working
+	controller_->set_state(thread_conditions::Working);
+	EXPECT_TRUE(controller_->has_active_source());
+
+	controller_->request_stop();
+	controller_->reset_stop_source();
+	controller_->set_stopped();
+
+	EXPECT_FALSE(controller_->has_active_source());
+}
+
+TEST_F(LifecycleControllerTest, WaitWithPredicate)
+{
+	controller_->initialize_for_start();
+
+	std::atomic<bool> predicate_met{false};
+	std::atomic<bool> wait_completed{false};
+
+	std::thread waiter([this, &predicate_met, &wait_completed]() {
+		auto lock = controller_->acquire_lock();
+		controller_->wait(lock, [&predicate_met]() {
+			return predicate_met.load();
+		});
+		wait_completed.store(true);
+	});
+
+	std::this_thread::sleep_for(std::chrono::milliseconds(50));
+	EXPECT_FALSE(wait_completed.load());
+
+	predicate_met.store(true);
+	controller_->notify_all();
+
+	waiter.join();
+	EXPECT_TRUE(wait_completed.load());
+}
+
+TEST_F(LifecycleControllerTest, WaitExitsOnStopRequest)
+{
+	controller_->initialize_for_start();
+
+	std::atomic<bool> wait_completed{false};
+
+	std::thread waiter([this, &wait_completed]() {
+		auto lock = controller_->acquire_lock();
+		controller_->wait(lock, []() {
+			return false;
+		});
+		wait_completed.store(true);
+	});
+
+	std::this_thread::sleep_for(std::chrono::milliseconds(50));
+	EXPECT_FALSE(wait_completed.load());
+
+	controller_->request_stop();
+	controller_->notify_all();
+
+	waiter.join();
+	EXPECT_TRUE(wait_completed.load());
+}
+
+TEST_F(LifecycleControllerTest, WaitForWithTimeout)
+{
+	controller_->initialize_for_start();
+
+	auto lock = controller_->acquire_lock();
+
+	auto start = std::chrono::steady_clock::now();
+	bool result = controller_->wait_for(
+		lock,
+		std::chrono::milliseconds(100),
+		[]() { return false; }
+	);
+	auto elapsed = std::chrono::steady_clock::now() - start;
+
+	EXPECT_FALSE(result);
+	EXPECT_GE(elapsed, std::chrono::milliseconds(90));
+}
+
+TEST_F(LifecycleControllerTest, WaitForReturnsImmediatelyWhenPredicateTrue)
+{
+	controller_->initialize_for_start();
+
+	auto lock = controller_->acquire_lock();
+
+	auto start = std::chrono::steady_clock::now();
+	bool result = controller_->wait_for(
+		lock,
+		std::chrono::milliseconds(1000),
+		[]() { return true; }
+	);
+	auto elapsed = std::chrono::steady_clock::now() - start;
+
+	EXPECT_TRUE(result);
+	EXPECT_LT(elapsed, std::chrono::milliseconds(100));
+}
+
+TEST_F(LifecycleControllerTest, NotifyOneBehavior)
+{
+	controller_->initialize_for_start();
+
+	std::atomic<int> woken_count{0};
+	std::latch start_latch{2};
+
+	auto waiter_func = [this, &woken_count, &start_latch]() {
+		auto lock = controller_->acquire_lock();
+		start_latch.count_down();
+		controller_->wait(lock, [&woken_count]() {
+			return woken_count.load() > 0;
+		});
+		woken_count.fetch_add(1);
+	};
+
+	std::thread waiter1(waiter_func);
+	std::thread waiter2(waiter_func);
+
+	start_latch.wait();
+	std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+	woken_count.store(1);
+	controller_->notify_one();
+
+	std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+	controller_->request_stop();
+	controller_->notify_all();
+
+	waiter1.join();
+	waiter2.join();
+
+	EXPECT_GE(woken_count.load(), 2);
+}
+
+TEST_F(LifecycleControllerTest, NotifyAllBehavior)
+{
+	controller_->initialize_for_start();
+
+	std::atomic<int> woken_count{0};
+	std::latch start_latch{3};
+	std::atomic<bool> should_wake{false};
+
+	auto waiter_func = [this, &woken_count, &start_latch, &should_wake]() {
+		auto lock = controller_->acquire_lock();
+		start_latch.count_down();
+		controller_->wait(lock, [&should_wake]() {
+			return should_wake.load();
+		});
+		woken_count.fetch_add(1);
+	};
+
+	std::thread waiter1(waiter_func);
+	std::thread waiter2(waiter_func);
+	std::thread waiter3(waiter_func);
+
+	start_latch.wait();
+	std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+	EXPECT_EQ(woken_count.load(), 0);
+
+	should_wake.store(true);
+	controller_->notify_all();
+
+	waiter1.join();
+	waiter2.join();
+	waiter3.join();
+
+	EXPECT_EQ(woken_count.load(), 3);
+}
+
+TEST_F(LifecycleControllerTest, ConcurrentStateUpdates)
+{
+	controller_->initialize_for_start();
+
+	const int thread_count = 10;
+	const int iterations = 100;
+	std::atomic<int> completed{0};
+
+	auto worker = [this, iterations, &completed]() {
+		for (int i = 0; i < iterations; ++i)
+		{
+			controller_->set_state(thread_conditions::Working);
+			controller_->set_state(thread_conditions::Waiting);
+		}
+		completed.fetch_add(1);
+	};
+
+	std::vector<std::thread> threads;
+	threads.reserve(thread_count);
+	for (int i = 0; i < thread_count; ++i)
+	{
+		threads.emplace_back(worker);
+	}
+
+	for (auto& t : threads)
+	{
+		t.join();
+	}
+
+	EXPECT_EQ(completed.load(), thread_count);
+
+	auto final_state = controller_->get_state();
+	EXPECT_TRUE(final_state == thread_conditions::Working ||
+	            final_state == thread_conditions::Waiting);
+}
+
+TEST_F(LifecycleControllerTest, MultipleInitializeCycles)
+{
+	for (int cycle = 0; cycle < 5; ++cycle)
+	{
+		controller_->initialize_for_start();
+		EXPECT_FALSE(controller_->is_stop_requested());
+
+		controller_->set_state(thread_conditions::Working);
+		EXPECT_TRUE(controller_->is_running());
+		EXPECT_TRUE(controller_->has_active_source());
+
+		controller_->request_stop();
+		EXPECT_TRUE(controller_->is_stop_requested());
+
+		controller_->reset_stop_source();
+		controller_->set_stopped();
+		EXPECT_FALSE(controller_->is_running());
+		EXPECT_FALSE(controller_->has_active_source());
+	}
+}


### PR DESCRIPTION
## Summary

- Extract thread lifecycle management logic into dedicated `lifecycle_controller` class
- Refactor `thread_base` to use composition with `lifecycle_controller`
- Consolidate duplicated patterns for state transitions, stop requests, and condition variables

## Changes Made

### New Files
- `include/kcenon/thread/core/lifecycle_controller.h` - Header for the new class
- `src/core/lifecycle_controller.cpp` - Implementation
- `tests/unit/thread_base_test/lifecycle_controller_test.cpp` - Unit tests

### Modified Files
- `thread_base.h` - Replace internal members with `lifecycle_controller`
- `thread_base.cpp` - Update to use `lifecycle_controller` methods
- `core/CMakeLists.txt` - Add new source files

## Test Plan

- [x] All lifecycle_controller unit tests pass (13 tests)
- [x] All thread_base unit tests pass (8 tests)
- [x] Full test suite passes (316 tests, excluding 3 pre-existing Autoscaler failures)
- [x] Build succeeds in Release mode

Closes #504