### PR TITLE
docs(readme): add downstream dependency impact note for compiler requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Thread System is a comprehensive multithreading framework that provides intuitiv
 - **CMake 3.20+**
 - **[common_system](https://github.com/kcenon/common_system)**: Required dependency (must be cloned alongside thread_system)
 
+> **⚠️ Downstream Impact**: Systems that depend on thread_system (monitoring_system, database_system, network_system) inherit these compiler requirements. When building the full ecosystem, ensure your compiler meets GCC 13+/Clang 17+.
+
 ### Installation
 
 ```bash


### PR DESCRIPTION
## Summary

- Added a warning note after the Requirements section in README.md
- Note explains that systems depending on thread_system (monitoring_system, database_system, network_system) inherit the GCC 13+/Clang 17+ compiler requirements
- Provides actionable guidance for users building the full ecosystem

Closes #527

## Test Plan

- [x] Verify note appears correctly after Requirements section
- [x] Verify markdown formatting renders properly
- [x] Confirm downstream systems are correctly listed