### PR TITLE
docs: add autoscaler and scaling policies guide

### DIFF
--- a/docs/AUTOSCALER_GUIDE.md
+++ b/docs/AUTOSCALER_GUIDE.md
@@ -418,7 +418,7 @@ Multiple policies can coexist on the same thread pool:
 
 ```cpp
 // Autoscaling + circuit breaker
-pool->add_policy(std::make_unique<autoscaling_pool_policy>(pool, scaling_config));
+pool->add_policy(std::make_unique<autoscaling_pool_policy>(*pool, scaling_config));
 pool->add_policy(std::make_unique<circuit_breaker_policy>(cb_config));
 
 // Both policies are invoked for every job lifecycle event


### PR DESCRIPTION
## Summary

- Create comprehensive `docs/AUTOSCALER_GUIDE.md` documentation for the autoscaling subsystem
- Cover all 7 sections specified in issue #530: architecture, scaling policies, autoscaler API, pool integration, metrics/observability, configuration examples, and best practices
- Document asymmetric scaling triggers (scale-up OR logic, scale-down AND logic)
- Include state machine diagram for the monitor loop
- Provide configuration examples for basic, burst, manual, and shared-autoscaler patterns
- Add anti-patterns and troubleshooting sections

Closes #530

## Test Plan

- [x] Verify code examples compile against current API (`autoscaler.h`, `autoscaling_policy.h`, `autoscaling_pool_policy.h`)
- [x] Cross-reference scaling thresholds and defaults with `autoscaling_policy.h` source
- [x] Review anti-patterns section against `is_valid()` implementation
- [x] Check all internal documentation links resolve