### PR TITLE
test: add standalone unit tests for retry_policy and service_registry

### DIFF
--- a/tests/unit/interfaces_test/service_registry_test.cpp
+++ b/tests/unit/interfaces_test/service_registry_test.cpp
@@ -1,0 +1,269 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+/**
+ * @file service_registry_test.cpp
+ * @brief Comprehensive unit tests for service_registry
+ * @since 4.0.0
+ */
+
+#include <gtest/gtest.h>
+
+#include <kcenon/thread/core/service_registry.h>
+
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+#include <atomic>
+
+using namespace kcenon::thread;
+
+// =============================================================================
+// Test service types
+// =============================================================================
+
+struct ILogger {
+    virtual ~ILogger() = default;
+    virtual std::string name() const = 0;
+};
+
+struct ConsoleLogger : ILogger {
+    std::string name() const override { return "console"; }
+};
+
+struct FileLogger : ILogger {
+    std::string name() const override { return "file"; }
+};
+
+struct IDatabase {
+    virtual ~IDatabase() = default;
+    virtual int version() const = 0;
+};
+
+struct MockDatabase : IDatabase {
+    int version() const override { return 42; }
+};
+
+// =============================================================================
+// Test fixture (clears registry between tests)
+// =============================================================================
+
+class ServiceRegistryTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        service_registry::clear_services();
+    }
+
+    void TearDown() override {
+        service_registry::clear_services();
+    }
+};
+
+// =============================================================================
+// Registration and retrieval
+// =============================================================================
+
+TEST_F(ServiceRegistryTest, RegisterAndRetrieve) {
+    auto logger = std::make_shared<ConsoleLogger>();
+    service_registry::register_service<ILogger>(logger);
+
+    auto retrieved = service_registry::get_service<ILogger>();
+    ASSERT_NE(retrieved, nullptr);
+    EXPECT_EQ(retrieved->name(), "console");
+}
+
+TEST_F(ServiceRegistryTest, RetrieveUnregisteredReturnsNull) {
+    auto result = service_registry::get_service<ILogger>();
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(ServiceRegistryTest, RegisterMultipleTypes) {
+    service_registry::register_service<ILogger>(std::make_shared<ConsoleLogger>());
+    service_registry::register_service<IDatabase>(std::make_shared<MockDatabase>());
+
+    auto logger = service_registry::get_service<ILogger>();
+    auto db = service_registry::get_service<IDatabase>();
+
+    ASSERT_NE(logger, nullptr);
+    ASSERT_NE(db, nullptr);
+    EXPECT_EQ(logger->name(), "console");
+    EXPECT_EQ(db->version(), 42);
+}
+
+TEST_F(ServiceRegistryTest, ReplaceService) {
+    service_registry::register_service<ILogger>(std::make_shared<ConsoleLogger>());
+    EXPECT_EQ(service_registry::get_service<ILogger>()->name(), "console");
+
+    service_registry::register_service<ILogger>(std::make_shared<FileLogger>());
+    EXPECT_EQ(service_registry::get_service<ILogger>()->name(), "file");
+}
+
+// =============================================================================
+// Service count
+// =============================================================================
+
+TEST_F(ServiceRegistryTest, InitialCountIsZero) {
+    EXPECT_EQ(service_registry::get_service_count(), 0u);
+}
+
+TEST_F(ServiceRegistryTest, CountIncreasesOnRegistration) {
+    service_registry::register_service<ILogger>(std::make_shared<ConsoleLogger>());
+    EXPECT_EQ(service_registry::get_service_count(), 1u);
+
+    service_registry::register_service<IDatabase>(std::make_shared<MockDatabase>());
+    EXPECT_EQ(service_registry::get_service_count(), 2u);
+}
+
+TEST_F(ServiceRegistryTest, ReplaceDoesNotIncreaseCount) {
+    service_registry::register_service<ILogger>(std::make_shared<ConsoleLogger>());
+    EXPECT_EQ(service_registry::get_service_count(), 1u);
+
+    service_registry::register_service<ILogger>(std::make_shared<FileLogger>());
+    EXPECT_EQ(service_registry::get_service_count(), 1u);
+}
+
+// =============================================================================
+// Clear services
+// =============================================================================
+
+TEST_F(ServiceRegistryTest, ClearRemovesAll) {
+    service_registry::register_service<ILogger>(std::make_shared<ConsoleLogger>());
+    service_registry::register_service<IDatabase>(std::make_shared<MockDatabase>());
+    EXPECT_EQ(service_registry::get_service_count(), 2u);
+
+    service_registry::clear_services();
+    EXPECT_EQ(service_registry::get_service_count(), 0u);
+    EXPECT_EQ(service_registry::get_service<ILogger>(), nullptr);
+    EXPECT_EQ(service_registry::get_service<IDatabase>(), nullptr);
+}
+
+TEST_F(ServiceRegistryTest, ClearThenReregister) {
+    service_registry::register_service<ILogger>(std::make_shared<ConsoleLogger>());
+    service_registry::clear_services();
+
+    service_registry::register_service<ILogger>(std::make_shared<FileLogger>());
+    auto logger = service_registry::get_service<ILogger>();
+    ASSERT_NE(logger, nullptr);
+    EXPECT_EQ(logger->name(), "file");
+}
+
+// =============================================================================
+// Type isolation
+// =============================================================================
+
+TEST_F(ServiceRegistryTest, DifferentTypesAreIsolated) {
+    service_registry::register_service<ILogger>(std::make_shared<ConsoleLogger>());
+
+    // IDatabase should not be found even though ILogger is registered
+    EXPECT_EQ(service_registry::get_service<IDatabase>(), nullptr);
+    EXPECT_EQ(service_registry::get_service_count(), 1u);
+}
+
+// =============================================================================
+// Thread safety
+// =============================================================================
+
+TEST_F(ServiceRegistryTest, ConcurrentRegistrationAndRetrieval) {
+    std::atomic<int> found_count{0};
+    std::atomic<int> errors{0};
+
+    std::vector<std::thread> threads;
+
+    // Writers
+    for (int i = 0; i < 4; ++i) {
+        threads.emplace_back([&]() {
+            for (int j = 0; j < 50; ++j) {
+                service_registry::register_service<ILogger>(
+                    std::make_shared<ConsoleLogger>());
+            }
+        });
+    }
+
+    // Readers
+    for (int i = 0; i < 4; ++i) {
+        threads.emplace_back([&]() {
+            for (int j = 0; j < 100; ++j) {
+                auto logger = service_registry::get_service<ILogger>();
+                if (logger) {
+                    found_count++;
+                    if (logger->name() != "console") {
+                        errors++;
+                    }
+                }
+            }
+        });
+    }
+
+    for (auto& th : threads) th.join();
+
+    EXPECT_EQ(errors.load(), 0);
+    EXPECT_GT(found_count.load(), 0);
+}
+
+TEST_F(ServiceRegistryTest, ConcurrentCountReads) {
+    service_registry::register_service<ILogger>(std::make_shared<ConsoleLogger>());
+    service_registry::register_service<IDatabase>(std::make_shared<MockDatabase>());
+
+    std::atomic<int> errors{0};
+    std::vector<std::thread> threads;
+
+    for (int i = 0; i < 8; ++i) {
+        threads.emplace_back([&]() {
+            for (int j = 0; j < 100; ++j) {
+                auto count = service_registry::get_service_count();
+                if (count != 2u) {
+                    errors++;
+                }
+            }
+        });
+    }
+
+    for (auto& th : threads) th.join();
+    EXPECT_EQ(errors.load(), 0);
+}
+
+// =============================================================================
+// Shared pointer semantics
+// =============================================================================
+
+TEST_F(ServiceRegistryTest, RetrievedServiceSharesOwnership) {
+    auto logger = std::make_shared<ConsoleLogger>();
+    EXPECT_EQ(logger.use_count(), 1);
+
+    service_registry::register_service<ILogger>(logger);
+    EXPECT_GE(logger.use_count(), 2);  // held by both local and registry
+
+    auto retrieved = service_registry::get_service<ILogger>();
+    EXPECT_GE(logger.use_count(), 3);
+    EXPECT_EQ(logger.get(), retrieved.get());
+}

--- a/tests/unit/thread_base_test/retry_policy_test.cpp
+++ b/tests/unit/thread_base_test/retry_policy_test.cpp
@@ -1,0 +1,316 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+/**
+ * @file retry_policy_test.cpp
+ * @brief Standalone unit tests for retry_policy class
+ * @since 4.0.0
+ */
+
+#include <gtest/gtest.h>
+
+#include <kcenon/thread/core/retry_policy.h>
+
+#include <chrono>
+#include <string>
+
+using namespace kcenon::thread;
+using namespace std::chrono_literals;
+
+// =============================================================================
+// Default construction tests
+// =============================================================================
+
+TEST(RetryPolicyTest, DefaultConstructorIsNoRetry) {
+    retry_policy policy;
+    EXPECT_EQ(policy.get_strategy(), retry_strategy::none);
+    EXPECT_EQ(policy.get_max_attempts(), 1u);
+    EXPECT_EQ(policy.get_initial_delay(), 0ms);
+    EXPECT_EQ(policy.get_current_attempt(), 0u);
+    EXPECT_FALSE(policy.is_retry_enabled());
+    EXPECT_FALSE(policy.uses_jitter());
+}
+
+// =============================================================================
+// Factory method tests: no_retry
+// =============================================================================
+
+TEST(RetryPolicyTest, NoRetryFactory) {
+    auto policy = retry_policy::no_retry();
+    EXPECT_EQ(policy.get_strategy(), retry_strategy::none);
+    EXPECT_FALSE(policy.is_retry_enabled());
+    EXPECT_EQ(policy.get_max_attempts(), 1u);
+}
+
+// =============================================================================
+// Factory method tests: fixed
+// =============================================================================
+
+TEST(RetryPolicyTest, FixedFactory) {
+    auto policy = retry_policy::fixed(3, 100ms);
+    EXPECT_EQ(policy.get_strategy(), retry_strategy::fixed);
+    EXPECT_TRUE(policy.is_retry_enabled());
+    EXPECT_EQ(policy.get_max_attempts(), 3u);
+    EXPECT_EQ(policy.get_initial_delay(), 100ms);
+    EXPECT_EQ(policy.get_max_delay(), 100ms);
+}
+
+TEST(RetryPolicyTest, FixedWithOneAttemptIsEffectivelyNoRetry) {
+    auto policy = retry_policy::fixed(1, 100ms);
+    EXPECT_EQ(policy.get_strategy(), retry_strategy::fixed);
+    // strategy is fixed but max_attempts is 1, so no actual retry
+    EXPECT_FALSE(policy.is_retry_enabled());
+}
+
+// =============================================================================
+// Factory method tests: linear
+// =============================================================================
+
+TEST(RetryPolicyTest, LinearFactory) {
+    auto policy = retry_policy::linear(5, 200ms);
+    EXPECT_EQ(policy.get_strategy(), retry_strategy::linear);
+    EXPECT_TRUE(policy.is_retry_enabled());
+    EXPECT_EQ(policy.get_max_attempts(), 5u);
+    EXPECT_EQ(policy.get_initial_delay(), 200ms);
+}
+
+TEST(RetryPolicyTest, LinearWithCustomMaxDelay) {
+    auto policy = retry_policy::linear(5, 100ms, 500ms);
+    EXPECT_EQ(policy.get_max_delay(), 500ms);
+}
+
+// =============================================================================
+// Factory method tests: exponential_backoff
+// =============================================================================
+
+TEST(RetryPolicyTest, ExponentialBackoffDefaults) {
+    auto policy = retry_policy::exponential_backoff(4);
+    EXPECT_EQ(policy.get_strategy(), retry_strategy::exponential_backoff);
+    EXPECT_TRUE(policy.is_retry_enabled());
+    EXPECT_EQ(policy.get_max_attempts(), 4u);
+    EXPECT_EQ(policy.get_initial_delay(), 100ms);
+    EXPECT_DOUBLE_EQ(policy.get_multiplier(), 2.0);
+    EXPECT_EQ(policy.get_max_delay(), 30000ms);
+    EXPECT_FALSE(policy.uses_jitter());
+}
+
+TEST(RetryPolicyTest, ExponentialBackoffCustomParams) {
+    auto policy = retry_policy::exponential_backoff(5, 50ms, 3.0, 10000ms, true);
+    EXPECT_EQ(policy.get_max_attempts(), 5u);
+    EXPECT_EQ(policy.get_initial_delay(), 50ms);
+    EXPECT_DOUBLE_EQ(policy.get_multiplier(), 3.0);
+    EXPECT_EQ(policy.get_max_delay(), 10000ms);
+    EXPECT_TRUE(policy.uses_jitter());
+}
+
+// =============================================================================
+// Attempt tracking tests
+// =============================================================================
+
+TEST(RetryPolicyTest, InitialAttemptIsZero) {
+    auto policy = retry_policy::fixed(3, 100ms);
+    EXPECT_EQ(policy.get_current_attempt(), 0u);
+}
+
+TEST(RetryPolicyTest, RecordAttemptIncrements) {
+    auto policy = retry_policy::fixed(3, 100ms);
+    policy.record_attempt();
+    EXPECT_EQ(policy.get_current_attempt(), 1u);
+    policy.record_attempt();
+    EXPECT_EQ(policy.get_current_attempt(), 2u);
+}
+
+TEST(RetryPolicyTest, HasAttemptsRemainingTracksCorrectly) {
+    auto policy = retry_policy::fixed(3, 100ms);
+    // max_attempts = 3, current = 0 -> remaining = true
+    EXPECT_TRUE(policy.has_attempts_remaining());
+
+    policy.record_attempt();  // attempt 1
+    EXPECT_TRUE(policy.has_attempts_remaining());
+
+    policy.record_attempt();  // attempt 2
+    EXPECT_FALSE(policy.has_attempts_remaining());  // current(2) >= max(3) - 1
+}
+
+TEST(RetryPolicyTest, ResetClearsAttemptCounter) {
+    auto policy = retry_policy::fixed(3, 100ms);
+    policy.record_attempt();
+    policy.record_attempt();
+    EXPECT_EQ(policy.get_current_attempt(), 2u);
+
+    policy.reset();
+    EXPECT_EQ(policy.get_current_attempt(), 0u);
+    EXPECT_TRUE(policy.has_attempts_remaining());
+}
+
+// =============================================================================
+// Delay calculation tests: fixed
+// =============================================================================
+
+TEST(RetryPolicyTest, FixedDelayIsConstant) {
+    auto policy = retry_policy::fixed(5, 200ms);
+
+    // Attempt 0: no delay (first attempt)
+    EXPECT_EQ(policy.get_delay_for_current_attempt(), 0ms);
+
+    policy.record_attempt();
+    EXPECT_EQ(policy.get_delay_for_current_attempt(), 200ms);
+
+    policy.record_attempt();
+    EXPECT_EQ(policy.get_delay_for_current_attempt(), 200ms);
+
+    policy.record_attempt();
+    EXPECT_EQ(policy.get_delay_for_current_attempt(), 200ms);
+}
+
+// =============================================================================
+// Delay calculation tests: linear
+// =============================================================================
+
+TEST(RetryPolicyTest, LinearDelayIncreasesLinearly) {
+    auto policy = retry_policy::linear(5, 100ms);
+
+    // Attempt 0: no delay
+    EXPECT_EQ(policy.get_delay_for_current_attempt(), 0ms);
+
+    policy.record_attempt();  // attempt 1
+    EXPECT_EQ(policy.get_delay_for_current_attempt(), 100ms);
+
+    policy.record_attempt();  // attempt 2
+    EXPECT_EQ(policy.get_delay_for_current_attempt(), 200ms);
+
+    policy.record_attempt();  // attempt 3
+    EXPECT_EQ(policy.get_delay_for_current_attempt(), 300ms);
+}
+
+TEST(RetryPolicyTest, LinearDelayRespectsCap) {
+    auto policy = retry_policy::linear(10, 100ms, 250ms);
+
+    policy.record_attempt();  // 1 -> 100ms
+    EXPECT_EQ(policy.get_delay_for_current_attempt(), 100ms);
+
+    policy.record_attempt();  // 2 -> 200ms
+    EXPECT_EQ(policy.get_delay_for_current_attempt(), 200ms);
+
+    policy.record_attempt();  // 3 -> 300ms capped to 250ms
+    EXPECT_EQ(policy.get_delay_for_current_attempt(), 250ms);
+
+    policy.record_attempt();  // 4 -> 400ms capped to 250ms
+    EXPECT_EQ(policy.get_delay_for_current_attempt(), 250ms);
+}
+
+// =============================================================================
+// Delay calculation tests: exponential
+// =============================================================================
+
+TEST(RetryPolicyTest, ExponentialDelayDoublesEachAttempt) {
+    auto policy = retry_policy::exponential_backoff(5, 100ms, 2.0, 30000ms, false);
+
+    EXPECT_EQ(policy.get_delay_for_current_attempt(), 0ms);  // attempt 0
+
+    policy.record_attempt();  // attempt 1: 100 * 2^0 = 100ms
+    EXPECT_EQ(policy.get_delay_for_current_attempt(), 100ms);
+
+    policy.record_attempt();  // attempt 2: 100 * 2^1 = 200ms
+    EXPECT_EQ(policy.get_delay_for_current_attempt(), 200ms);
+
+    policy.record_attempt();  // attempt 3: 100 * 2^2 = 400ms
+    EXPECT_EQ(policy.get_delay_for_current_attempt(), 400ms);
+}
+
+TEST(RetryPolicyTest, ExponentialDelayRespectsCap) {
+    auto policy = retry_policy::exponential_backoff(10, 100ms, 2.0, 500ms, false);
+
+    policy.record_attempt();  // 100ms
+    policy.record_attempt();  // 200ms
+    policy.record_attempt();  // 400ms
+    policy.record_attempt();  // 800ms -> capped to 500ms
+    EXPECT_EQ(policy.get_delay_for_current_attempt(), 500ms);
+}
+
+// =============================================================================
+// Delay for none strategy
+// =============================================================================
+
+TEST(RetryPolicyTest, NoneStrategyAlwaysReturnsZeroDelay) {
+    retry_policy policy;  // none
+    EXPECT_EQ(policy.get_delay_for_current_attempt(), 0ms);
+
+    policy.record_attempt();
+    EXPECT_EQ(policy.get_delay_for_current_attempt(), 0ms);
+}
+
+// =============================================================================
+// to_string tests
+// =============================================================================
+
+TEST(RetryPolicyTest, ToStringNone) {
+    auto policy = retry_policy::no_retry();
+    EXPECT_EQ(policy.to_string(), "retry_policy(none)");
+}
+
+TEST(RetryPolicyTest, ToStringFixed) {
+    auto policy = retry_policy::fixed(3, 100ms);
+    auto str = policy.to_string();
+    EXPECT_NE(str.find("fixed"), std::string::npos);
+    EXPECT_NE(str.find("attempts=3"), std::string::npos);
+    EXPECT_NE(str.find("100"), std::string::npos);
+}
+
+TEST(RetryPolicyTest, ToStringLinear) {
+    auto policy = retry_policy::linear(5, 200ms);
+    auto str = policy.to_string();
+    EXPECT_NE(str.find("linear"), std::string::npos);
+    EXPECT_NE(str.find("attempts=5"), std::string::npos);
+}
+
+TEST(RetryPolicyTest, ToStringExponential) {
+    auto policy = retry_policy::exponential_backoff(4);
+    auto str = policy.to_string();
+    EXPECT_NE(str.find("exponential"), std::string::npos);
+    EXPECT_NE(str.find("attempts=4"), std::string::npos);
+}
+
+// =============================================================================
+// Copy and assignment
+// =============================================================================
+
+TEST(RetryPolicyTest, CopyPreservesState) {
+    auto original = retry_policy::fixed(3, 100ms);
+    original.record_attempt();
+
+    retry_policy copy = original;
+    EXPECT_EQ(copy.get_strategy(), retry_strategy::fixed);
+    EXPECT_EQ(copy.get_max_attempts(), 3u);
+    EXPECT_EQ(copy.get_initial_delay(), 100ms);
+    EXPECT_EQ(copy.get_current_attempt(), 1u);
+}


### PR DESCRIPTION
## Summary
- Add 2 new test files covering `retry_policy` and `service_registry` standalone tests
- No CMakeLists.txt changes needed (uses `file(GLOB *.cpp)` pattern)
- Total: ~35 test cases across 2 files

## Changes
| File | Tests | Description |
|------|-------|-------------|
| `retry_policy_test.cpp` | ~20 | Factory methods, delay calculations (fixed/linear/exponential), attempt tracking, reset, to_string, copy semantics |
| `service_registry_test.cpp` | ~15 | CRUD, type isolation, replace, clear, thread safety (concurrent R/W), shared_ptr ownership |

## Test Plan
- [x] Both test files compile without errors
- [x] All tests pass on CI
- [x] No existing tests broken
- [x] retry_policy: all 4 strategies and delay formulas verified
- [x] service_registry: concurrent access with 8 threads verified

Closes #538