### PR TITLE
ci(doxygen): replace workflow with reusable template

### DIFF
--- a/.github/workflows/build-Doxygen.yaml
+++ b/.github/workflows/build-Doxygen.yaml
@@ -2,54 +2,12 @@ name: Generate-Documentation
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
   pull_request:
-    branches:
-      - main
+    branches: [main]
   workflow_dispatch:
 
 jobs:
-  generate_docs:
-    permissions:
-      contents: write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-          ssh-strict: true
-          ssh-user: git
-          persist-credentials: true
-          clean: true
-          sparse-checkout-cone-mode: true
-          fetch-depth: 1
-          fetch-tags: false
-          show-progress: true
-          lfs: false
-          set-safe-directory: true
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install Doxygen
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y doxygen graphviz
-
-      - name: Cache Doxygen output
-        uses: actions/cache@v3
-        with:
-          path: ./documents/html
-          key: ${{ runner.os }}-doxygen-${{ hashFiles('**/*.h', '**/*.cpp', 'Doxyfile') }}
-          restore-keys: |
-            ${{ runner.os }}-doxygen-
-
-      - name: Generate Documentation
-        run: doxygen Doxyfile
-
-      - name: Deploy Documentation
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./documents/html
-          commit_message: "Update documentation via GitHub Actions"
-          enable_jekyll: false
+  docs:
+    uses: kcenon/common_system/.github/workflows/doxygen.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Replace inline Doxygen workflow with a call to the shared reusable workflow in `kcenon/common_system`
- Removes Doxygen output cache (fast generation, avoids stale docs)
- Removes redundant checkout options (`ssh-strict`, `sparse-checkout-cone-mode`, etc.)
- Standardizes on `actions/checkout@v5`, `peaceiris/actions-gh-pages@v4`
- Adds `force_orphan: true` to prevent gh-pages history accumulation
- Adds deploy guard (generate on PR, deploy only on main push)

## Context
Part of cross-repo Doxygen workflow unification. Depends on kcenon/common_system#362.

## Test plan
- [x] CI generates docs successfully on PR (no deploy)
- [x] After merge (and common_system#362 merge), gh-pages updates correctly
- [x] `https://kcenon.github.io/thread_system/` serves documentation