### PR TITLE
chore: unify version to 0.1.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ cmake_minimum_required(VERSION 3.16)
 
 # Define the project
 project(ThreadSystem
-    VERSION 0.3.0.0
+    VERSION 0.1.0.0
     DESCRIPTION "High-performance C++20 multithreading framework"
     HOMEPAGE_URL "https://github.com/kcenon/thread_system"
     LANGUAGES CXX

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "kcenon-thread-system",
-  "version": "3.0.0",
+  "version": "0.1.0",
   "port-version": 0,
   "description": "High-performance C++20 multithreading framework with common_system integration",
   "homepage": "https://github.com/kcenon/thread_system",


### PR DESCRIPTION
## Summary
- Unify CMake project version to 0.1.0.0
- Unify vcpkg version to 0.1.0
- Part of ecosystem-wide version normalization for SOUP compliance

## Changes
- CMakeLists.txt: VERSION 0.3.0.0 → 0.1.0.0
- vcpkg.json: version 3.0.0 → 0.1.0

## Test plan
- [x] CI build passes on all platforms
- [x] No breaking changes (version number only)