### PR TITLE
fix(examples): update stale examples and benchmarks to current kcenon::thread API

### DIFF
--- a/examples/job_cancellation_example/job_cancellation_example.cpp
+++ b/examples/job_cancellation_example/job_cancellation_example.cpp
@@ -33,7 +33,7 @@ All rights reserved.
 #include <atomic>
 
 using namespace kcenon::thread;
-using utility_module::formatter;
+using kcenon::thread::utils::formatter;
 
 /**
  * @class cancellable_long_job

--- a/examples/logger_sample/logger_sample.cpp
+++ b/examples/logger_sample/logger_sample.cpp
@@ -35,9 +35,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <thread>
 
 #include "logger/core/logger.h"
-#include "utilities/core/formatter.h"
+#include <kcenon/thread/utils/formatter.h>
 
-using namespace utility_module;
+using kcenon::thread::utils::formatter;
 
 bool use_backup_ = false;
 uint32_t max_lines_ = 0;

--- a/examples/multi_process_monitoring_integration/multi_process_monitoring_integration.cpp
+++ b/examples/multi_process_monitoring_integration/multi_process_monitoring_integration.cpp
@@ -32,7 +32,7 @@ All rights reserved.
 #include <random>
 
 using namespace kcenon::thread;
-using namespace utility_module;
+using kcenon::thread::utils::formatter;
 
 // Implementation of IMonitor for multi-process monitoring
 class sample_monitoring : public kcenon::common::interfaces::IMonitor {

--- a/examples/thread_pool_sample/thread_pool_sample.cpp
+++ b/examples/thread_pool_sample/thread_pool_sample.cpp
@@ -35,10 +35,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <chrono>
 
 #include "logger/core/logger.h"
-#include "utilities/core/formatter.h"
-#include "thread_pool/core/thread_pool.h"
+#include <kcenon/thread/utils/formatter.h>
+#include <kcenon/thread/core/thread_pool.h>
 
-using namespace utility_module;
+using kcenon::thread::utils::formatter;
 using namespace kcenon::thread;
 
 bool use_backup_ = false;

--- a/examples/typed_thread_pool_sample/typed_thread_pool_sample.cpp
+++ b/examples/typed_thread_pool_sample/typed_thread_pool_sample.cpp
@@ -36,13 +36,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <thread>
 
 #include "logger/core/logger.h"
-#include "utilities/core/formatter.h"
-#include "typed_thread_pool/pool/typed_thread_pool.h"
+#include <kcenon/thread/utils/formatter.h>
+#include <kcenon/thread/impl/typed_pool/typed_thread_pool.h>
 
 #include <format>
 
-using namespace utility_module;
-using namespace kcenon::thread;
+using kcenon::thread::utils::formatter;
 using namespace kcenon::thread;
 
 bool use_backup_ = false;

--- a/examples/typed_thread_pool_sample_2/typed_thread_pool_sample_2.cpp
+++ b/examples/typed_thread_pool_sample_2/typed_thread_pool_sample_2.cpp
@@ -36,14 +36,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <thread>
 
 #include "logger/core/logger.h"
-#include "utilities/core/formatter.h"
+#include <kcenon/thread/utils/formatter.h>
 #include "test_type.h"
-#include "typed_thread_pool/pool/typed_thread_pool.h"
+#include <kcenon/thread/impl/typed_pool/typed_thread_pool.h>
 
 #include <format>
 
-using namespace utility_module;
-using namespace kcenon::thread;
+using kcenon::thread::utils::formatter;
 using namespace kcenon::thread;
 
 bool use_backup_ = false;

--- a/include/kcenon/thread/core/job.h
+++ b/include/kcenon/thread/core/job.h
@@ -221,37 +221,21 @@ namespace kcenon::thread
 		/**
 		 * @brief The core task execution method to be overridden by derived classes.
 		 *
-		 * @return A @c std::optional<std::string> indicating success or error:
-		 * - @c std::nullopt on success, meaning no error occurred.
-		 * - A non-empty string on failure, providing an error message or explanation.
+		 * @return A @c common::VoidResult indicating success or error:
+		 * - A success result (constructed with common::ok()) if no error occurred.
+		 * - An error result (constructed with common::error_info{code, message}) on failure.
 		 *
 		 * #### Default Behavior
-		 * The base class implementation simply returns @c std::nullopt (i.e., no error).
+		 * The base class implementation simply returns a success result.
 		 * Override this method in a derived class to perform meaningful work.
 		 *
 		 * #### Concurrency
 		 * - Typically invoked by worker threads in a @c job_queue.
 		 * - Ensure that any shared data or resources accessed here are protected with
 		 *   appropriate synchronization mechanisms (mutexes, locks, etc.) if needed.
+		 * - This method should check the cancellation token if one is set and return
+		 *   an error with code operation_canceled if the token is cancelled.
 		 */
-		/**
-	 * @brief The core task execution method to be overridden by derived classes.
-	 *
-	 * @return A @c common::VoidResult indicating success or error:
-	 * - A success result (constructed with common::ok()) if no error occurred.
-	 * - An error result (constructed with common::error_info{code, message}) on failure.
-	 *
-	 * #### Default Behavior
-	 * The base class implementation simply returns a success result.
-	 * Override this method in a derived class to perform meaningful work.
-	 *
-	 * #### Concurrency
-	 * - Typically invoked by worker threads in a @c job_queue.
-	 * - Ensure that any shared data or resources accessed here are protected with
-	 *   appropriate synchronization mechanisms (mutexes, locks, etc.) if needed.
-	 * - This method should check the cancellation token if one is set and return
-	 *   an error with code operation_canceled if the token is cancelled.
-	 */
 	[[nodiscard]] virtual auto do_work(void) -> common::VoidResult;
 	
 	/**

--- a/tests/benchmarks/data_race_benchmark.cpp
+++ b/tests/benchmarks/data_race_benchmark.cpp
@@ -40,11 +40,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * 3. job_queue consistency improvements
  */
 
-#include "../sources/thread_base/core/thread_base.h"
-#include "../sources/thread_base/jobs/job_queue.h"
-#include "../sources/thread_base/sync/cancellation_token.h"
-#include "../sources/thread_pool/core/thread_pool.h"
-#include "../sources/utilities/core/formatter.h"
+#include <kcenon/thread/core/thread_base.h>
+#include <kcenon/thread/core/job_queue.h>
+#include <kcenon/thread/core/cancellation_token.h>
+#include <kcenon/thread/core/thread_pool.h>
+#include <kcenon/thread/utils/formatter.h>
 
 #include <benchmark/benchmark.h>
 #include <kcenon/common/patterns/result.h>
@@ -55,7 +55,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <chrono>
 #include <random>
 
-using namespace kcenon::thread;
 using namespace kcenon::thread;
 
 // Test worker that frequently accesses wake_interval

--- a/tests/benchmarks/thread_pool_benchmarks/benchmark_common.h
+++ b/tests/benchmarks/thread_pool_benchmarks/benchmark_common.h
@@ -31,11 +31,11 @@
 
 #include <memory>
 #include <string>
-#include "../../sources/thread_base/jobs/callback_job.h"
-#include "../../sources/thread_pool/core/thread_pool.h"
-#include "../../sources/thread_pool/workers/thread_worker.h"
-#include "../../sources/typed_thread_pool/pool/typed_thread_pool.h"
-#include "../../sources/typed_thread_pool/scheduling/typed_thread_worker.h"
+#include <kcenon/thread/core/callback_job.h>
+#include <kcenon/thread/core/thread_pool.h>
+#include <kcenon/thread/core/thread_worker.h>
+#include <kcenon/thread/impl/typed_pool/typed_thread_pool.h>
+#include <kcenon/thread/impl/typed_pool/typed_thread_worker.h>
 
 // Include common_system Result types for v3.0 API
 #include <kcenon/common/patterns/result.h>
@@ -45,7 +45,7 @@ using VoidResult = kcenon::common::VoidResult;
 
 // Helper macro to create callback jobs with proper return type
 #define MAKE_JOB(lambda_body) \
-    std::make_unique<thread_module::callback_job>([&]() -> VoidResult { \
+    std::make_unique<kcenon::thread::callback_job>([&]() -> VoidResult { \
         lambda_body \
         return kcenon::common::ok(); \
     })
@@ -68,17 +68,17 @@ inline auto setup_thread_pool(size_t worker_count) -> std::shared_ptr<kcenon::th
 
 // Helper function for typed thread pool
 template<typename PriorityType>
-inline auto setup_typed_thread_pool(size_t worker_count) -> std::shared_ptr<typed_kcenon::thread::typed_thread_pool_t<PriorityType>> {
-    auto pool = std::make_shared<typed_kcenon::thread::typed_thread_pool_t<PriorityType>>();
-    
+inline auto setup_typed_thread_pool(size_t worker_count) -> std::shared_ptr<kcenon::thread::typed_thread_pool_t<PriorityType>> {
+    auto pool = std::make_shared<kcenon::thread::typed_thread_pool_t<PriorityType>>();
+
     // Add workers
     for (size_t i = 0; i < worker_count; ++i) {
-        auto worker = std::make_unique<typed_kcenon::thread::typed_thread_worker_t<PriorityType>>();
+        auto worker = std::make_unique<kcenon::thread::typed_thread_worker_t<PriorityType>>();
         pool->enqueue(std::move(worker));
     }
-    
+
     // Start the pool
     pool->start();
-    
+
     return pool;
 }

--- a/tests/benchmarks/thread_pool_benchmarks/comparison_benchmark.cpp
+++ b/tests/benchmarks/thread_pool_benchmarks/comparison_benchmark.cpp
@@ -60,11 +60,11 @@
 #include <omp.h>
 #endif
 
-#include "../../sources/thread_pool/core/thread_pool.h"
-#include "../../sources/thread_pool/workers/thread_worker.h"
-#include "../../sources/typed_thread_pool/pool/typed_thread_pool.h"
-#include "../../sources/typed_thread_pool/jobs/callback_typed_job.h"
-#include "../../sources/utilities/core/formatter.h"
+#include <kcenon/thread/core/thread_pool.h>
+#include <kcenon/thread/core/thread_worker.h>
+#include <kcenon/thread/impl/typed_pool/typed_thread_pool.h>
+#include <kcenon/thread/impl/typed_pool/callback_typed_job.h>
+#include <kcenon/thread/utils/formatter.h>
 
 // Helper function to create thread pool
 auto create_default(const uint16_t& worker_counts)
@@ -96,20 +96,20 @@ auto create_default(const uint16_t& worker_counts)
 // Helper function to create typed thread pool
 template<typename Type>
 auto create_priority_default(const uint16_t& worker_counts, const std::vector<Type>& types)
-    -> std::tuple<std::shared_ptr<typed_kcenon::thread::typed_thread_pool_t<Type>>, std::optional<std::string>>
+    -> std::tuple<std::shared_ptr<kcenon::thread::typed_thread_pool_t<Type>>, std::optional<std::string>>
 {
-    std::shared_ptr<typed_kcenon::thread::typed_thread_pool_t<Type>> pool;
+    std::shared_ptr<kcenon::thread::typed_thread_pool_t<Type>> pool;
     try {
-        pool = std::make_shared<typed_kcenon::thread::typed_thread_pool_t<Type>>();
+        pool = std::make_shared<kcenon::thread::typed_thread_pool_t<Type>>();
     } catch (const std::bad_alloc& e) {
         return { nullptr, std::string(e.what()) };
     }
-    
+
     std::optional<std::string> error_message = std::nullopt;
-    std::vector<std::unique_ptr<typed_kcenon::thread::typed_thread_worker_t<Type>>> workers;
+    std::vector<std::unique_ptr<kcenon::thread::typed_thread_worker_t<Type>>> workers;
     workers.reserve(worker_counts);
     for (uint16_t i = 0; i < worker_counts; ++i) {
-        workers.push_back(std::make_unique<typed_kcenon::thread::typed_thread_worker_t<Type>>(types));
+        workers.push_back(std::make_unique<kcenon::thread::typed_thread_worker_t<Type>>(types));
     }
     
     auto result = pool->enqueue_batch(std::move(workers));
@@ -121,7 +121,6 @@ auto create_priority_default(const uint16_t& worker_counts, const std::vector<Ty
 }
 
 using namespace std::chrono;
-using namespace kcenon::thread;
 using namespace kcenon::thread;
 
 // Simple thread pool implementation for comparison
@@ -683,7 +682,7 @@ static void BM_MixedWorkload_TypedThreadSystem(benchmark::State& state) {
         
         for (size_t i = 0; i < num_tasks / 2; ++i) {
             // CPU-heavy tasks get higher priority
-            pool->enqueue(std::make_unique<typed_kcenon::thread::callback_typed_job_t<TaskType>>(
+            pool->enqueue(std::make_unique<kcenon::thread::callback_typed_job_t<TaskType>>(
                 [cpu_work_units]() -> kcenon::common::VoidResult {
                     volatile double result = 0;
                     for (int j = 0; j < cpu_work_units * 2; ++j) {
@@ -693,7 +692,7 @@ static void BM_MixedWorkload_TypedThreadSystem(benchmark::State& state) {
                 }, TaskType::CPU));
             
             // I/O-heavy tasks get lower priority
-            pool->enqueue(std::make_unique<typed_kcenon::thread::callback_typed_job_t<TaskType>>(
+            pool->enqueue(std::make_unique<kcenon::thread::callback_typed_job_t<TaskType>>(
                 [io_delay_ms]() -> kcenon::common::VoidResult {
                     std::this_thread::sleep_for(std::chrono::milliseconds(io_delay_ms * 2));
                     return kcenon::common::ok();

--- a/tests/benchmarks/thread_pool_benchmarks/contention_benchmark.cpp
+++ b/tests/benchmarks/thread_pool_benchmarks/contention_benchmark.cpp
@@ -24,14 +24,13 @@ All rights reserved.
 #include <memory>
 #include <unordered_map>
 
-#include "../../sources/thread_pool/core/thread_pool.h"
-#include "../../sources/thread_pool/workers/thread_worker.h"
-#include "../../sources/thread_base/jobs/callback_job.h"
-#include "../../sources/utilities/core/formatter.h"
+#include <kcenon/thread/core/thread_pool.h>
+#include <kcenon/thread/core/thread_worker.h>
+#include <kcenon/thread/core/callback_job.h>
+#include <kcenon/thread/utils/formatter.h>
 
 using namespace kcenon::thread;
-using namespace kcenon::thread;
-using namespace utility_module;
+using kcenon::thread::utils::formatter;
 
 // Cache-aligned data structure for memory contention tests
 struct alignas(64) cache_line_data {

--- a/tests/benchmarks/thread_pool_benchmarks/gbench_thread_pool.cpp
+++ b/tests/benchmarks/thread_pool_benchmarks/gbench_thread_pool.cpp
@@ -37,14 +37,13 @@
 #include <benchmark/benchmark.h>
 #include <kcenon/common/patterns/result.h>
 #include <kcenon/thread/core/error_handling.h>
-#include "../../sources/thread_pool/core/thread_pool.h"
-#include "../../sources/thread_pool/workers/thread_worker.h"
-#include "../../sources/thread_base/jobs/callback_job.h"
+#include <kcenon/thread/core/thread_pool.h>
+#include <kcenon/thread/core/thread_worker.h>
+#include <kcenon/thread/core/callback_job.h>
 #include <atomic>
 #include <memory>
 #include <vector>
 
-using namespace kcenon::thread;
 using namespace kcenon::thread;
 
 // Helper function to create thread pool with workers

--- a/tests/benchmarks/thread_pool_benchmarks/memory_benchmark.cpp
+++ b/tests/benchmarks/thread_pool_benchmarks/memory_benchmark.cpp
@@ -53,10 +53,10 @@
 #endif
 #endif
 
-#include "../../sources/thread_pool/core/thread_pool.h"
-#include "../../sources/thread_pool/workers/thread_worker.h"
-#include "../../sources/typed_thread_pool/pool/typed_thread_pool.h"
-#include "../../sources/utilities/core/formatter.h"
+#include <kcenon/thread/core/thread_pool.h>
+#include <kcenon/thread/core/thread_worker.h>
+#include <kcenon/thread/impl/typed_pool/typed_thread_pool.h>
+#include <kcenon/thread/utils/formatter.h>
 
 // Helper function to create thread pool
 auto create_default(const uint16_t& worker_counts)
@@ -93,7 +93,6 @@ auto create_priority_default(const uint16_t& worker_counts) {
     return std::make_tuple(pool, error);
 }
 
-using namespace kcenon::thread;
 using namespace kcenon::thread;
 
 class MemoryMonitor {

--- a/tests/benchmarks/thread_pool_benchmarks/real_world_benchmark.cpp
+++ b/tests/benchmarks/thread_pool_benchmarks/real_world_benchmark.cpp
@@ -57,12 +57,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <map>
 #include <thread>
 
-#include "../../sources/thread_pool/core/thread_pool.h"
-#include "../../sources/thread_pool/workers/thread_worker.h"
-#include "../../sources/typed_thread_pool/pool/typed_thread_pool.h"
-#include "../../sources/typed_thread_pool/scheduling/typed_thread_worker.h"
-#include "../../sources/typed_thread_pool/jobs/callback_typed_job.h"
-#include "../../sources/utilities/core/formatter.h"
+#include <kcenon/thread/core/thread_pool.h>
+#include <kcenon/thread/core/thread_worker.h>
+#include <kcenon/thread/impl/typed_pool/typed_thread_pool.h>
+#include <kcenon/thread/impl/typed_pool/typed_thread_worker.h>
+#include <kcenon/thread/impl/typed_pool/callback_typed_job.h>
+#include <kcenon/thread/utils/formatter.h>
 // Helper function to create thread pool
 auto create_default(const uint16_t& worker_counts)
     -> std::tuple<std::shared_ptr<kcenon::thread::thread_pool>, std::optional<std::string>>
@@ -93,19 +93,19 @@ auto create_default(const uint16_t& worker_counts)
 // Helper function to create typed thread pool
 template<typename Type>
 auto create_priority_default(const uint16_t& worker_counts)
-    -> std::tuple<std::shared_ptr<typed_kcenon::thread::typed_thread_pool_t<Type>>, std::optional<std::string>>
+    -> std::tuple<std::shared_ptr<kcenon::thread::typed_thread_pool_t<Type>>, std::optional<std::string>>
 {
-    std::shared_ptr<typed_kcenon::thread::typed_thread_pool_t<Type>> pool;
+    std::shared_ptr<kcenon::thread::typed_thread_pool_t<Type>> pool;
     try {
-        pool = std::make_shared<typed_kcenon::thread::typed_thread_pool_t<Type>>();
+        pool = std::make_shared<kcenon::thread::typed_thread_pool_t<Type>>();
     } catch (const std::bad_alloc& e) {
         return { nullptr, std::string(e.what()) };
     }
-    
-    std::vector<std::unique_ptr<typed_kcenon::thread::typed_thread_worker_t<Type>>> workers;
+
+    std::vector<std::unique_ptr<kcenon::thread::typed_thread_worker_t<Type>>> workers;
     workers.reserve(worker_counts);
     for (uint16_t i = 0; i < worker_counts; ++i) {
-        workers.push_back(std::make_unique<typed_kcenon::thread::typed_thread_worker_t<Type>>(
+        workers.push_back(std::make_unique<kcenon::thread::typed_thread_worker_t<Type>>(
             std::vector<Type>{}, true));
     }
     
@@ -118,7 +118,6 @@ auto create_priority_default(const uint16_t& worker_counts)
     return { pool, std::nullopt };
 }
 
-using namespace kcenon::thread;
 using namespace kcenon::thread;
 
 // Simulate different types of workloads

--- a/tests/benchmarks/thread_pool_benchmarks/scalability_benchmark.cpp
+++ b/tests/benchmarks/thread_pool_benchmarks/scalability_benchmark.cpp
@@ -24,14 +24,13 @@ All rights reserved.
 #include <numeric>
 #include <map>
 
-#include "../../sources/thread_pool/core/thread_pool.h"
-#include "../../sources/thread_pool/workers/thread_worker.h"
-#include "../../sources/thread_base/jobs/callback_job.h"
-#include "../../sources/utilities/core/formatter.h"
+#include <kcenon/thread/core/thread_pool.h>
+#include <kcenon/thread/core/thread_worker.h>
+#include <kcenon/thread/core/callback_job.h>
+#include <kcenon/thread/utils/formatter.h>
 
 using namespace kcenon::thread;
-using namespace kcenon::thread;
-using namespace utility_module;
+using kcenon::thread::utils::formatter;
 
 /**
  * @brief Benchmark CPU-bound workload scalability

--- a/tests/benchmarks/thread_pool_benchmarks/stress_test_benchmark.cpp
+++ b/tests/benchmarks/thread_pool_benchmarks/stress_test_benchmark.cpp
@@ -54,12 +54,12 @@
 #include <algorithm>
 #include <numeric>
 
-#include "../../sources/thread_pool/core/thread_pool.h"
-#include "../../sources/thread_pool/workers/thread_worker.h"
-#include "../../sources/typed_thread_pool/pool/typed_thread_pool.h"
-#include "../../sources/typed_thread_pool/scheduling/typed_thread_worker.h"
-#include "../../sources/typed_thread_pool/jobs/callback_typed_job.h"
-#include "../../sources/utilities/core/formatter.h"
+#include <kcenon/thread/core/thread_pool.h>
+#include <kcenon/thread/core/thread_worker.h>
+#include <kcenon/thread/impl/typed_pool/typed_thread_pool.h>
+#include <kcenon/thread/impl/typed_pool/typed_thread_worker.h>
+#include <kcenon/thread/impl/typed_pool/callback_typed_job.h>
+#include <kcenon/thread/utils/formatter.h>
 // Helper function to create thread pool
 auto create_default(const uint16_t& worker_counts)
     -> std::tuple<std::shared_ptr<kcenon::thread::thread_pool>, std::optional<std::string>>
@@ -90,19 +90,19 @@ auto create_default(const uint16_t& worker_counts)
 // Helper function to create typed thread pool
 template<typename Type>
 auto create_priority_default(const uint16_t& worker_counts)
-    -> std::tuple<std::shared_ptr<typed_kcenon::thread::typed_thread_pool_t<Type>>, std::optional<std::string>>
+    -> std::tuple<std::shared_ptr<kcenon::thread::typed_thread_pool_t<Type>>, std::optional<std::string>>
 {
-    std::shared_ptr<typed_kcenon::thread::typed_thread_pool_t<Type>> pool;
+    std::shared_ptr<kcenon::thread::typed_thread_pool_t<Type>> pool;
     try {
-        pool = std::make_shared<typed_kcenon::thread::typed_thread_pool_t<Type>>();
+        pool = std::make_shared<kcenon::thread::typed_thread_pool_t<Type>>();
     } catch (const std::bad_alloc& e) {
         return { nullptr, std::string(e.what()) };
     }
-    
-    std::vector<std::unique_ptr<typed_kcenon::thread::typed_thread_worker_t<Type>>> workers;
+
+    std::vector<std::unique_ptr<kcenon::thread::typed_thread_worker_t<Type>>> workers;
     workers.reserve(worker_counts);
     for (uint16_t i = 0; i < worker_counts; ++i) {
-        workers.push_back(std::make_unique<typed_kcenon::thread::typed_thread_worker_t<Type>>(
+        workers.push_back(std::make_unique<kcenon::thread::typed_thread_worker_t<Type>>(
             std::vector<Type>{}, true));
     }
     
@@ -116,8 +116,7 @@ auto create_priority_default(const uint16_t& worker_counts)
 }
 
 using namespace kcenon::thread;
-using namespace kcenon::thread;
-using namespace utility_module;
+using kcenon::thread::utils::formatter;
 
 // Forward declare Type enum before using it
 enum class Type { 

--- a/tests/benchmarks/thread_pool_benchmarks/thread_pool_benchmark.cpp
+++ b/tests/benchmarks/thread_pool_benchmarks/thread_pool_benchmark.cpp
@@ -55,13 +55,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <atomic>
 #include <cmath>
 
-#include "../../sources/thread_pool/core/thread_pool.h"
-#include "../../sources/typed_thread_pool/pool/typed_thread_pool.h"
-#include "../../sources/thread_pool/workers/thread_worker.h"
-#include "../../sources/thread_base/jobs/callback_job.h"
+#include <kcenon/thread/core/thread_pool.h>
+#include <kcenon/thread/impl/typed_pool/typed_thread_pool.h>
+#include <kcenon/thread/core/thread_worker.h>
+#include <kcenon/thread/core/callback_job.h>
 
-using namespace kcenon::thread;
-using namespace kcenon::thread;
 using namespace kcenon::thread;
 
 /**

--- a/tests/benchmarks/thread_pool_benchmarks/throughput_detailed_benchmark.cpp
+++ b/tests/benchmarks/thread_pool_benchmarks/throughput_detailed_benchmark.cpp
@@ -58,12 +58,12 @@
 #include <fstream>
 #include <future>
 
-#include "../../sources/thread_pool/core/thread_pool.h"
-#include "../../sources/thread_pool/workers/thread_worker.h"
-#include "../../sources/typed_thread_pool/pool/typed_thread_pool.h"
-#include "../../sources/typed_thread_pool/scheduling/typed_thread_worker.h"
-#include "../../sources/typed_thread_pool/jobs/callback_typed_job.h"
-#include "../../sources/utilities/core/formatter.h"
+#include <kcenon/thread/core/thread_pool.h>
+#include <kcenon/thread/core/thread_worker.h>
+#include <kcenon/thread/impl/typed_pool/typed_thread_pool.h>
+#include <kcenon/thread/impl/typed_pool/typed_thread_worker.h>
+#include <kcenon/thread/impl/typed_pool/callback_typed_job.h>
+#include <kcenon/thread/utils/formatter.h>
 // Helper function to create thread pool
 auto create_default(const uint16_t& worker_counts)
     -> std::tuple<std::shared_ptr<kcenon::thread::thread_pool>, std::optional<std::string>>
@@ -93,19 +93,19 @@ auto create_default(const uint16_t& worker_counts)
 // Helper function to create typed thread pool
 template<typename Type>
 auto create_priority_default(const uint16_t& worker_counts)
-    -> std::tuple<std::shared_ptr<typed_kcenon::thread::typed_thread_pool_t<Type>>, std::optional<std::string>>
+    -> std::tuple<std::shared_ptr<kcenon::thread::typed_thread_pool_t<Type>>, std::optional<std::string>>
 {
-    std::shared_ptr<typed_kcenon::thread::typed_thread_pool_t<Type>> pool;
+    std::shared_ptr<kcenon::thread::typed_thread_pool_t<Type>> pool;
     try {
-        pool = std::make_shared<typed_kcenon::thread::typed_thread_pool_t<Type>>();
+        pool = std::make_shared<kcenon::thread::typed_thread_pool_t<Type>>();
     } catch (const std::bad_alloc& e) {
         return { nullptr, std::string(e.what()) };
     }
-    
-    std::vector<std::unique_ptr<typed_kcenon::thread::typed_thread_worker_t<Type>>> workers;
+
+    std::vector<std::unique_ptr<kcenon::thread::typed_thread_worker_t<Type>>> workers;
     workers.reserve(worker_counts);
     for (uint16_t i = 0; i < worker_counts; ++i) {
-        workers.push_back(std::make_unique<typed_kcenon::thread::typed_thread_worker_t<Type>>(std::vector<Type>{}, true));
+        workers.push_back(std::make_unique<kcenon::thread::typed_thread_worker_t<Type>>(std::vector<Type>{}, true));
     }
     
     auto enqueue_result = pool->enqueue_batch(std::move(workers));
@@ -118,7 +118,6 @@ auto create_priority_default(const uint16_t& worker_counts)
 }
 
 using namespace std::chrono;
-using namespace kcenon::thread;
 using namespace kcenon::thread;
 
 // Job complexity levels
@@ -581,7 +580,7 @@ static void BM_PriorityImpact(benchmark::State& state) {
         // Submit jobs with different priorities
         for (size_t i = 0; i < jobs_per_priority; ++i) {
             for (auto priority : {Critical, High, Normal, Low, Background}) {
-                pool->enqueue(std::make_unique<typed_kcenon::thread::callback_typed_job_t<Priority>>([&completed, priority]() -> kcenon::common::VoidResult {
+                pool->enqueue(std::make_unique<kcenon::thread::callback_typed_job_t<Priority>>([&completed, priority]() -> kcenon::common::VoidResult {
                     execute_job_with_complexity(JobComplexity::Light);
                     completed[priority].fetch_add(1);
                     return kcenon::common::ok();

--- a/tests/benchmarks/typed_thread_pool_benchmarks/typed_scheduling_benchmark.cpp
+++ b/tests/benchmarks/typed_thread_pool_benchmarks/typed_scheduling_benchmark.cpp
@@ -24,8 +24,8 @@ All rights reserved.
 #include <algorithm>
 #include <iomanip>
 
-#include "../../sources/typed_thread_pool/pool/typed_thread_pool.h"
-#include "../../sources/utilities/core/formatter.h"
+#include <kcenon/thread/impl/typed_pool/typed_thread_pool.h>
+#include <kcenon/thread/utils/formatter.h>
 
 using namespace kcenon::thread;
 

--- a/tests/benchmarks/typed_thread_pool_benchmarks/typed_scheduling_benchmark_google.cpp
+++ b/tests/benchmarks/typed_thread_pool_benchmarks/typed_scheduling_benchmark_google.cpp
@@ -27,8 +27,8 @@ All rights reserved.
 #include <chrono>
 #include <future>
 
-#include "../../sources/typed_thread_pool/pool/typed_thread_pool.h"
-#include "../../sources/utilities/core/formatter.h"
+#include <kcenon/thread/impl/typed_pool/typed_thread_pool.h>
+#include <kcenon/thread/utils/formatter.h>
 
 using namespace kcenon::thread;
 using namespace std::chrono;


### PR DESCRIPTION
## Summary
- Replace all old relative include paths (`../../sources/`) with canonical `<kcenon/thread/...>` angle-bracket includes across 20 files
- Replace `utility_module` and `thread_module` namespace references with `kcenon::thread` and `kcenon::thread::utils`
- Remove duplicate `using namespace` declarations in 5 files
- Fix `typed_kcenon::thread::` typo prefix in benchmark_common.h and related benchmark files
- Remove stale `std::optional<std::string>` doc block from `job.h`, keeping only the current `common::VoidResult` documentation

## Test plan
- [x] CI builds pass on all platforms (macOS clang, ubuntu gcc, Debug/Release)
- [x] Enabled examples (job_cancellation_example, multi_process_monitoring_integration) compile
- [x] Benchmark files compile (thread_pool_benchmarks, typed_thread_pool_benchmarks)
- [x] No references to `utility_module`, `thread_module`, or old `../../sources/` paths remain (**Note**: 2 residual instances found post-merge — `examples/crash_protection/CMakeLists.txt` lines 24-26 still reference `../../sources/`, and `thread_pool.h` line 177 has a `typed_kcenon::thread::` Doxygen @see typo. These are outside the PR's 20-file scope but should be tracked separately.)

Closes #551