### PR TITLE
chore(deps): synchronize vcpkg baseline with ecosystem standard

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,9 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg-configuration.schema.json",
   "default-registry": {
-    "kind": "git",
-    "repository": "https://github.com/microsoft/vcpkg.git",
-    "baseline": "50c0cb48a0cf2f6fc5c7b2c0d2bafbe26d0a7ca2"
+    "kind": "builtin",
+    "baseline": "c4af3593e1f1aa9e14a560a09e45ea2cb0dfd74d"
   },
   "registries": []
 }


### PR DESCRIPTION
## What

### Summary
Aligns thread_system's vcpkg-configuration.json baseline to the ecosystem standard (`c4af3593`) used by all other kcenon projects. Also changes registry kind from `git` to `builtin` for consistency.

### Change Type
- [x] Chore

## Why

### Related Issues
Closes #555

### Motivation
thread_system was the only project using a different vcpkg baseline (`50c0cb48`) and `git` registry kind. This divergence could cause inconsistent transitive dependency resolution when ecosystem libraries are linked together.

## Where

### Files Changed
| File | Type of Change |
|------|----------------|
| `vcpkg-configuration.json` | Baseline and registry kind updated |

## How

### Implementation Details
1. Changed `"kind": "git"` + `"repository"` to `"kind": "builtin"` (matches common_system, container_system, etc.)
2. Updated baseline from `50c0cb48a0cf2f6fc5c7b2c0d2bafbe26d0a7ca2` to `c4af3593e1f1aa9e14a560a09e45ea2cb0dfd74d`

### Testing Done
- [x] CI builds pass (Linux, macOS, Windows)
- [x] All unit tests pass
- [x] No version resolution conflicts

### Test Plan
1. Verify vcpkg install resolves all dependencies correctly
2. Verify all existing version overrides in vcpkg.json still apply
3. Full CI matrix validation

### Breaking Changes
None — baseline change only affects dependency resolution versions