### PR TITLE
fix(build): link kcenon::common_system target for vcpkg find_package support

### DIFF
--- a/cmake/ThreadSystemConfig.cmake.in
+++ b/cmake/ThreadSystemConfig.cmake.in
@@ -11,6 +11,9 @@ include(CMakeFindDependencyMacro)
 # Find required dependencies
 find_dependency(Threads)
 
+# common_system for standard interfaces (result, executor, etc.)
+find_dependency(common_system CONFIG REQUIRED)
+
 # simdutf for SIMD-accelerated Unicode conversion
 find_dependency(simdutf CONFIG REQUIRED)
 

--- a/cmake/ThreadSystemTargets.cmake
+++ b/cmake/ThreadSystemTargets.cmake
@@ -69,6 +69,14 @@ function(create_thread_system_targets)
       # Note: fmt library is no longer used - using C++20 std::format exclusively
       # The HAS_FMT_LIBRARY definition and fmt linking have been removed
 
+      # Link common_system when found via find_package(common_system CONFIG)
+      # This is required for vcpkg/find_package consumers to get transitive
+      # include directories and dependencies from the kcenon::common_system target
+      if(TARGET kcenon::common_system)
+        target_link_libraries(ThreadSystem PUBLIC kcenon::common_system)
+        message(STATUS "ThreadSystem: linked kcenon::common_system target")
+      endif()
+
       if(DEFINED THREAD_SYSTEM_SIMDUTF_FOUND AND THREAD_SYSTEM_SIMDUTF_FOUND)
         target_link_libraries(ThreadSystem PUBLIC ${THREAD_SYSTEM_SIMDUTF_TARGET})
         message(STATUS "ThreadSystem: simdutf support enabled")

--- a/cmake/thread_system-config.cmake.in
+++ b/cmake/thread_system-config.cmake.in
@@ -9,6 +9,9 @@ include(CMakeFindDependencyMacro)
 # Find required dependencies as specified in T2.1
 find_dependency(Threads REQUIRED)
 
+# common_system for standard interfaces (result, executor, etc.)
+find_dependency(common_system CONFIG REQUIRED)
+
 # Handle optional dependencies based on configuration
 # Check if std::format is used or if we need fmt library
 if(DEFINED USE_STD_FORMAT)


### PR DESCRIPTION
Closes #569

## Summary

- Link `kcenon::common_system` imported target to `ThreadSystem` in `create_thread_system_targets()` when found via `find_package(common_system CONFIG)` (vcpkg path)
- Add `find_dependency(common_system CONFIG REQUIRED)` to both consumer-side config templates (`ThreadSystemConfig.cmake.in` and `thread_system-config.cmake.in`) for transitive dependency resolution

## Problem

When thread_system is consumed via `find_package(ThreadSystem CONFIG)` (the vcpkg path), `find_common_system_dependency()` locates common_system but does not link the `kcenon::common_system` target to the ThreadSystem library. This causes downstream builds to fail with:

```
fatal error: 'kcenon/common/patterns/result.h' file not found
```

The `add_subdirectory()` path works because it adds include directories globally via `include_directories()`, but the `find_package()` path relies on proper target linkage to propagate include directories.

## Changes

| File | Change |
|------|--------|
| `cmake/ThreadSystemTargets.cmake` | Link `kcenon::common_system` to `ThreadSystem` when target exists |
| `cmake/ThreadSystemConfig.cmake.in` | Add `find_dependency(common_system CONFIG REQUIRED)` |
| `cmake/thread_system-config.cmake.in` | Add `find_dependency(common_system CONFIG REQUIRED)` |

## Test Plan

- [x] Local CMake configure succeeds
- [x] Full Release build succeeds (MSVC)
- [x] Smoke tests pass
- [x] CI passes on all platforms (Linux/Windows/macOS)
- [x] vcpkg overlay port build succeeds (`vcpkg install kcenon-thread-system`)
- [x] Downstream `find_package(ThreadSystem CONFIG)` resolves common_system transitively