### PR TITLE
chore(release): bump version to 0.3.0 for semantic release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ cmake_minimum_required(VERSION 3.16)
 
 # Define the project
 project(ThreadSystem
-    VERSION 0.1.0.0
+    VERSION 0.3.0.0
     DESCRIPTION "High-performance C++20 multithreading framework"
     HOMEPAGE_URL "https://github.com/kcenon/thread_system"
     LANGUAGES CXX

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "kcenon-thread-system",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "port-version": 0,
   "description": "High-performance C++20 multithreading framework with common_system integration",
   "homepage": "https://github.com/kcenon/thread_system",


### PR DESCRIPTION
## What

Bump project version from 0.1.0 to 0.3.0 in `CMakeLists.txt` and `vcpkg.json` to enable semantic version tag creation for vcpkg registry submission.

### Change Type
- [x] Chore (version bump / release preparation)

## Why

### Related Issues
- Closes #570

### Motivation
The vcpkg overlay port in downstream repositories (monitoring_system, logger_system) declares a `0.3.0` dependency on `kcenon-thread-system`. The current codebase version (`0.1.0`) must be updated to match before creating the `v0.3.0` annotated git tag and GitHub Release.

Additionally, the current `portfile.cmake` uses a raw commit SHA as `REF` and a placeholder `SHA512 0`, which blocks actual port installation and fails vcpkg PR review checklist c000005 (requires versioned archives, not branch HEADs or arbitrary commits).

## Who

### Required Approvals
- [ ] Repository maintainer

## When

### Urgency
- [x] Normal - Follow standard review process

### Dependencies
- Depends on: #569 (CMake linking fix) — already merged as #571

## Where

### Files Changed

| File | Change |
|------|--------|
| `CMakeLists.txt` | `VERSION 0.1.0.0` → `VERSION 0.3.0.0` |
| `vcpkg.json` | `"version": "0.1.0"` → `"version": "0.3.0"` |

## How

### Implementation Details
Minimal, surgical change — only the two version fields are updated. No behavioral changes.

### Post-merge Steps
After this PR is merged to main, the following steps will be performed:
1. Create annotated tag: `git tag -a v0.3.0 -m "Release v0.3.0"`
2. Push tag: `git push origin v0.3.0`
3. Create GitHub Release with `gh release create v0.3.0 --generate-notes`
4. Obtain actual SHA512 hash from the release archive
5. Update `monitoring_system/vcpkg-ports/kcenon-thread-system/portfile.cmake` REF and SHA512

### Testing Done
- [x] Version fields verified in both files
- CI will validate no build regressions

### Breaking Changes
None — version string change only.