### PR TITLE
fix(ci): pin osv-scanner-action to v2.3.3 and grant contents:write for docs

### DIFF
--- a/.github/workflows/build-Doxygen.yaml
+++ b/.github/workflows/build-Doxygen.yaml
@@ -7,6 +7,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   docs:
     uses: kcenon/common_system/.github/workflows/doxygen.yml@main

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Run OSV-Scanner on vcpkg manifest
-        uses: google/osv-scanner-action/osv-scanner-action@v2
+        uses: google/osv-scanner-action/osv-scanner-action@v2.3.3
         with:
           scan-args: |-
             --lockfile=vcpkg.json
@@ -50,7 +50,7 @@ jobs:
 
       - name: Run OSV-Scanner filesystem scan (fallback)
         if: hashFiles('osv-results.sarif') == ''
-        uses: google/osv-scanner-action/osv-scanner-action@v2
+        uses: google/osv-scanner-action/osv-scanner-action@v2.3.3
         with:
           scan-args: |-
             --recursive


### PR DESCRIPTION
## What

Fix two pre-existing CI failures that have been occurring consistently since 2026-03-06.

### Change Type
- [x] Bugfix (CI/workflow fixes)

## Why

### Related Issues
- Related to #570 (discovered during release preparation)

### Problem 1: OSV Vulnerability Scan failure
`google/osv-scanner-action@v2` does not exist as a major-version tag in the upstream repository. Only specific patch versions exist (latest: `v2.3.3`). GitHub Actions failed to resolve the action reference with:
```
Unable to resolve action `google/osv-scanner-action@v2`, unable to find version `v2`
```

### Problem 2: Generate-Documentation startup_failure
The calling workflow (`build-Doxygen.yaml`) invokes the reusable workflow `kcenon/common_system/.github/workflows/doxygen.yml@main`, which deploys to GitHub Pages and requires `contents: write` permission. The calling workflow had no explicit `permissions` block, causing a pre-flight permission validation failure (startup_failure) before the job could run.

Both failures were pre-existing before PR #572 and unrelated to the v0.3.0 version bump.

## Who

### Required Approvals
- [ ] Repository maintainer

## When

### Urgency
- [x] Normal - Follow standard review process

## Where

### Files Changed

| File | Change |
|------|--------|
| `.github/workflows/osv-scanner.yml` | Pin `@v2` → `@v2.3.3` (both scan steps) |
| `.github/workflows/build-Doxygen.yaml` | Add `permissions: contents: write` |

## How

### Implementation Details

**OSV Scanner fix**: Pinned both `google/osv-scanner-action/osv-scanner-action` steps from the non-existent `@v2` to the specific stable release `@v2.3.3`.

**Doxygen permissions fix**: Added `permissions: contents: write` at the workflow level. This grants the called reusable workflow the permission it needs to write to the `gh-pages` branch. Without this, GitHub's pre-flight permission check fails and the job never starts.

### Testing Done
- [x] Verified `v2.3.3` exists in `google/osv-scanner-action` tags
- [x] Verified `v4` exists for `peaceiris/actions-gh-pages` (used in callee)
- [x] CI results pending

### Breaking Changes
None.