### PR TITLE
fix(cmake): lower MINIMUM_SUPPORTED_VERSION and add missing vcpkg dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ cmake_minimum_required(VERSION 3.16)
 
 # Define the project
 project(ThreadSystem
-    VERSION 0.3.0.0
+    VERSION 0.3.0
     DESCRIPTION "High-performance C++20 multithreading framework"
     HOMEPAGE_URL "https://github.com/kcenon/thread_system"
     LANGUAGES CXX

--- a/cmake/thread_system-config-version.cmake.in
+++ b/cmake/thread_system-config-version.cmake.in
@@ -31,8 +31,8 @@ else()
     set(PACKAGE_VERSION_EXACT FALSE)
 endif()
 
-# Minimum required version check (1.0.0 as specified in T2.1)
-set(MINIMUM_SUPPORTED_VERSION "1.0.0")
+# Minimum required version check
+set(MINIMUM_SUPPORTED_VERSION "0.1.0")
 if("${PACKAGE_VERSION}" VERSION_LESS "${MINIMUM_SUPPORTED_VERSION}")
     set(PACKAGE_VERSION_COMPATIBLE FALSE)
     message(WARNING "thread_system version ${PACKAGE_VERSION} is below minimum supported version ${MINIMUM_SUPPORTED_VERSION}")

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -8,7 +8,8 @@
   "license": "BSD-3-Clause",
   "supports": "!(uwp | xbox)",
   "dependencies": [
-    "simdutf"
+    "simdutf",
+    "kcenon-common-system"
   ],
   "overrides": [
     { "name": "simdutf", "version": "5.2.5" },


### PR DESCRIPTION
## Summary

- Lower `MINIMUM_SUPPORTED_VERSION` from `"1.0.0"` to `"0.1.0"` in `thread_system-config-version.cmake.in` — the library is at 0.3.0, so the 1.0.0 floor caused `find_package(thread_system 0.3.0)` to reject the package
- Add `kcenon-common-system` to source `vcpkg.json` dependencies — `ThreadSystemDependencies.cmake` issues `FATAL_ERROR` without it
- Normalize `project(VERSION)` from `0.3.0.0` to `0.3.0` for semver consistency

## Test plan

- [ ] `find_package(thread_system 0.3.0)` succeeds without the vcpkg-registry `vcpkg_replace_string` workaround
- [ ] `vcpkg install` from source tree resolves `kcenon-common-system` correctly
- [ ] CI passes on all platforms

Closes #576