### PR TITLE
docs: replace GIT_TAG main with v0.3.0 in FetchContent examples

### DIFF
--- a/README.kr.md
+++ b/README.kr.md
@@ -1113,7 +1113,7 @@ include(FetchContent)
 FetchContent_Declare(
     thread_system
     GIT_REPOSITORY https://github.com/kcenon/thread_system.git
-    GIT_TAG main
+    GIT_TAG v0.3.0  # Pin to a specific release tag; do NOT use main
 )
 FetchContent_MakeAvailable(thread_system)
 ```

--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ include(FetchContent)
 FetchContent_Declare(
     thread_system
     GIT_REPOSITORY https://github.com/kcenon/thread_system.git
-    GIT_TAG main
+    GIT_TAG v0.3.0  # Pin to a specific release tag; do NOT use main
 )
 FetchContent_MakeAvailable(thread_system)
 

--- a/docs/advanced/USER_MIGRATION_GUIDE.md
+++ b/docs/advanced/USER_MIGRATION_GUIDE.md
@@ -803,7 +803,7 @@ include(FetchContent)
 FetchContent_Declare(
     thread_system
     GIT_REPOSITORY https://github.com/kcenon/thread_system.git
-    GIT_TAG main
+    GIT_TAG v0.3.0  # Pin to a specific release tag; do NOT use main
 )
 FetchContent_MakeAvailable(thread_system)
 ```

--- a/docs/guides/QUICK_START.kr.md
+++ b/docs/guides/QUICK_START.kr.md
@@ -114,7 +114,7 @@ include(FetchContent)
 FetchContent_Declare(
     thread_system
     GIT_REPOSITORY https://github.com/kcenon/thread_system.git
-    GIT_TAG main
+    GIT_TAG v0.3.0  # Pin to a specific release tag; do NOT use main
 )
 FetchContent_MakeAvailable(thread_system)
 

--- a/docs/guides/QUICK_START.md
+++ b/docs/guides/QUICK_START.md
@@ -114,7 +114,7 @@ include(FetchContent)
 FetchContent_Declare(
     thread_system
     GIT_REPOSITORY https://github.com/kcenon/thread_system.git
-    GIT_TAG main
+    GIT_TAG v0.3.0  # Pin to a specific release tag; do NOT use main
 )
 FetchContent_MakeAvailable(thread_system)
 


### PR DESCRIPTION
Part of kcenon/common_system#448

## Summary

- Replace all `GIT_TAG main` references with `GIT_TAG v0.3.0` in documentation FetchContent examples
- Aligns with ecosystem versioning policy defined in common_system DEPENDENCY_MATRIX.md
- Prevents users from copy-pasting non-reproducible build configurations

## Files Changed

- `README.md`
- `README.kr.md`
- `docs/guides/QUICK_START.md`
- `docs/guides/QUICK_START.kr.md`
- `docs/advanced/USER_MIGRATION_GUIDE.md`

## Test Plan

- [ ] Verify no remaining `GIT_TAG main` references in documentation
- [ ] Confirm FetchContent examples use correct tagged version (v0.3.0)