### PR TITLE
chore(cmake): Standardize export naming and remove dual namespace

### DIFF
--- a/cmake/ThreadSystemConfig.cmake.in
+++ b/cmake/ThreadSystemConfig.cmake.in
@@ -1,70 +1,43 @@
 @PACKAGE_INIT@
 
-# ThreadSystem CMake configuration file (v3.0.0+)
-# This file helps other projects find and use ThreadSystem
-#
-# ThreadSystem v3.0.0 uses C++20 std::format exclusively (no fmt dependency)
-# ThreadSystem v3.0.0 requires common_system for interfaces
+# ThreadSystem legacy CMake configuration file
+# This wrapper delegates to the standardized thread_system config
+# for backward compatibility with find_package(ThreadSystem) consumers.
 
+# Find the standardized package which does all the real work
 include(CMakeFindDependencyMacro)
+find_dependency(thread_system CONFIG REQUIRED
+    HINTS "${CMAKE_CURRENT_LIST_DIR}/../thread_system")
 
-# Find required dependencies
-find_dependency(Threads)
+# Legacy aliases for backward compatibility
+set(ThreadSystem_FOUND TRUE)
+set(ThreadSystem_VERSION ${thread_system_VERSION})
 
-# common_system for standard interfaces (result, executor, etc.)
-find_dependency(common_system CONFIG REQUIRED)
+# Map thread_system:: targets to ThreadSystem:: aliases
+# In unified mode, alias from the real imported target
+if(TARGET thread_system::ThreadSystem)
+    set(ThreadSystem_LIBRARIES thread_system::ThreadSystem)
 
-# simdutf for SIMD-accelerated Unicode conversion
-find_dependency(simdutf CONFIG REQUIRED)
-
-# Include the targets file
-include("${CMAKE_CURRENT_LIST_DIR}/ThreadSystemTargets.cmake")
-
-# Determine available target structure
-# New unified build exports ThreadSystem::ThreadSystem as a single library
-# Legacy build exports individual component libraries
-if(TARGET ThreadSystem::ThreadSystem)
-    # Unified library mode - create component aliases for compatibility
-    set(_THREAD_SYSTEM_UNIFIED_MODE TRUE)
-    set(_THREAD_SYSTEM_MAIN_TARGET ThreadSystem::ThreadSystem)
-
-    # Create component aliases pointing to the unified library
-    if(NOT TARGET ThreadSystem::utilities)
-        add_library(ThreadSystem::utilities ALIAS ThreadSystem::ThreadSystem)
-    endif()
-    if(NOT TARGET ThreadSystem::thread_base)
-        add_library(ThreadSystem::thread_base ALIAS ThreadSystem::ThreadSystem)
-    endif()
-    if(NOT TARGET ThreadSystem::interfaces)
-        add_library(ThreadSystem::interfaces ALIAS ThreadSystem::ThreadSystem)
-    endif()
-    if(NOT TARGET ThreadSystem::thread_pool)
-        add_library(ThreadSystem::thread_pool ALIAS ThreadSystem::ThreadSystem)
-    endif()
-    if(NOT TARGET ThreadSystem::typed_thread_pool)
-        add_library(ThreadSystem::typed_thread_pool ALIAS ThreadSystem::ThreadSystem)
-    endif()
-    if(NOT TARGET ThreadSystem::logger)
-        add_library(ThreadSystem::logger ALIAS ThreadSystem::ThreadSystem)
-    endif()
-
-    # Set convenience variable to main target
-    set(ThreadSystem_LIBRARIES ThreadSystem::ThreadSystem)
-else()
-    # Legacy component mode - individual libraries
-    set(_THREAD_SYSTEM_UNIFIED_MODE FALSE)
-    set(ThreadSystem_LIBRARIES "")
-
-    # Collect available component targets
-    foreach(_component utilities thread_base interfaces thread_pool typed_thread_pool logger)
-        if(TARGET ThreadSystem::${_component})
-            list(APPEND ThreadSystem_LIBRARIES ThreadSystem::${_component})
+    foreach(_component utilities thread_base interfaces thread_pool typed_thread_pool lockfree logger)
+        if(NOT TARGET ThreadSystem::${_component})
+            add_library(ThreadSystem::${_component} ALIAS thread_system::ThreadSystem)
         endif()
     endforeach()
 
-    if(NOT ThreadSystem_LIBRARIES)
-        message(FATAL_ERROR "No ThreadSystem targets found. Installation may be corrupted.")
+    if(NOT TARGET ThreadSystem::ThreadSystem)
+        add_library(ThreadSystem::ThreadSystem ALIAS thread_system::ThreadSystem)
     endif()
+else()
+    # Legacy component mode
+    set(ThreadSystem_LIBRARIES "")
+    foreach(_component utilities thread_base interfaces thread_pool typed_thread_pool lockfree logger)
+        if(TARGET thread_system::${_component})
+            list(APPEND ThreadSystem_LIBRARIES thread_system::${_component})
+            if(NOT TARGET ThreadSystem::${_component})
+                add_library(ThreadSystem::${_component} ALIAS thread_system::${_component})
+            endif()
+        endif()
+    endforeach()
 endif()
 
 check_required_components(ThreadSystem)

--- a/cmake/ThreadSystemInstall.cmake
+++ b/cmake/ThreadSystemInstall.cmake
@@ -87,7 +87,7 @@ function(install_thread_system_libraries)
 
     if(INSTALL_TARGETS)
       install(TARGETS ${INSTALL_TARGETS}
-              EXPORT ThreadSystemTargets
+              EXPORT thread_system-targets
               ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
               LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
               RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
@@ -97,7 +97,7 @@ function(install_thread_system_libraries)
     # New structure - install ThreadSystem library
     if(TARGET ThreadSystem)
       install(TARGETS ThreadSystem
-              EXPORT ThreadSystemTargets
+              EXPORT thread_system-targets
               ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
               LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
               RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
@@ -110,17 +110,11 @@ endfunction()
 # Install CMake config files
 ##################################################
 function(install_cmake_config_files)
-  # Install targets with standardized namespace
-  install(EXPORT ThreadSystemTargets
+  # Install targets with single standardized namespace
+  install(EXPORT thread_system-targets
           FILE thread_system-targets.cmake
           NAMESPACE thread_system::
           DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/thread_system)
-
-  # Legacy compatibility
-  install(EXPORT ThreadSystemTargets
-          FILE ThreadSystemTargets.cmake
-          NAMESPACE ThreadSystem::
-          DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ThreadSystem)
 
   # Generate standardized config files
   configure_package_config_file(
@@ -129,13 +123,13 @@ function(install_cmake_config_files)
     INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/thread_system
   )
 
-  configure_package_config_file(
-    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/thread_system-config-version.cmake.in
+  write_basic_package_version_file(
     ${CMAKE_CURRENT_BINARY_DIR}/thread_system-config-version.cmake
-    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/thread_system
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion
   )
 
-  # Legacy config files
+  # Legacy config wrapper (redirects to standardized config)
   configure_package_config_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/cmake/ThreadSystemConfig.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/ThreadSystemConfig.cmake
@@ -148,13 +142,14 @@ function(install_cmake_config_files)
     COMPATIBILITY SameMajorVersion
   )
 
-  # Install config files
+  # Install standardized config files
   install(FILES
     ${CMAKE_CURRENT_BINARY_DIR}/thread_system-config.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/thread_system-config-version.cmake
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/thread_system
   )
 
+  # Install legacy config wrapper for find_package(ThreadSystem) consumers
   install(FILES
     ${CMAKE_CURRENT_BINARY_DIR}/ThreadSystemConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/ThreadSystemConfigVersion.cmake

--- a/cmake/thread_system-config.cmake.in
+++ b/cmake/thread_system-config.cmake.in
@@ -117,6 +117,10 @@ else()
     endforeach()
 endif()
 
+# Legacy aliases for backward compatibility
+set(ThreadSystem_FOUND TRUE)
+set(ThreadSystem_VERSION ${PROJECT_VERSION})
+
 # Component handling for find_package with COMPONENTS
 set(thread_system_FOUND TRUE)
 


### PR DESCRIPTION
## Summary
- Consolidate dual CMake export namespace (`ThreadSystem::` / `thread_system::`) into single `thread_system::` namespace
- Rename CMake export from `ThreadSystemTargets` to `thread_system-targets` to match ecosystem convention
- Convert `ThreadSystemConfig.cmake.in` into a thin redirect wrapper that delegates to the standardized `thread_system-config`
- Add backward compatibility aliases (`ThreadSystem_FOUND`, `ThreadSystem_VERSION`, `ThreadSystem::` targets) for existing consumers

## What changed

### `cmake/ThreadSystemInstall.cmake`
- Changed `EXPORT ThreadSystemTargets` to `EXPORT thread_system-targets` in both `install(TARGETS ...)` calls (legacy and unified)
- Removed second `install(EXPORT ...)` call that generated `ThreadSystemTargets.cmake` with `ThreadSystem::` namespace
- Replaced `configure_package_config_file` for version file with `write_basic_package_version_file` (the `.in` template did not exist)
- Kept legacy config wrapper installation for `find_package(ThreadSystem)` consumers

### `cmake/ThreadSystemConfig.cmake.in`
- Converted from standalone config to thin wrapper that calls `find_dependency(thread_system)` 
- Creates `ThreadSystem::` aliases from `thread_system::` imported targets for backward compat

### `cmake/thread_system-config.cmake.in`
- Added `ThreadSystem_FOUND` and `ThreadSystem_VERSION` legacy variables

## Related issues
- Closes #587
- Part of kcenon/common_system#456

## Test plan
- [ ] CI builds pass on all platforms (Ubuntu, macOS, Windows)
- [ ] `find_package(thread_system)` works with `thread_system::` namespace targets
- [ ] `find_package(ThreadSystem)` still works via legacy wrapper and provides `ThreadSystem::` aliases