### PR TITLE
docs(readme): add Documentation and License badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 [![Code Coverage](https://github.com/kcenon/thread_system/actions/workflows/coverage.yml/badge.svg)](https://github.com/kcenon/thread_system/actions/workflows/coverage.yml)
 [![Static Analysis](https://github.com/kcenon/thread_system/actions/workflows/static-analysis.yml/badge.svg)](https://github.com/kcenon/thread_system/actions/workflows/static-analysis.yml)
 [![codecov](https://codecov.io/gh/kcenon/thread_system/branch/main/graph/badge.svg)](https://codecov.io/gh/kcenon/thread_system)
+[![Documentation](https://github.com/kcenon/thread_system/actions/workflows/build-Doxygen.yaml/badge.svg)](https://github.com/kcenon/thread_system/actions/workflows/build-Doxygen.yaml)
+[![License](https://img.shields.io/github/license/kcenon/thread_system)](https://github.com/kcenon/thread_system/blob/main/LICENSE)
 
 # Thread System
 


### PR DESCRIPTION
Part of kcenon/common_system#467

## Summary
- Add Documentation badge for Doxygen workflow
- Add License badge for BSD-3-Clause

## Test plan
- [ ] Badges render correctly on GitHub