### PR TITLE
docs(doxyfile): Add ecosystem-standard ALIASES

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -186,6 +186,8 @@ MACRO_EXPANSION        = YES
 EXPAND_ONLY_PREDEF     = NO
 SEARCH_INCLUDES        = YES
 SKIP_FUNCTION_MACROS   = YES
+ALIASES                = "thread_safety=@par Thread Safety:^^" \
+                         "performance=@par Performance:^^"
 ALLEXTERNALS           = NO
 EXTERNAL_GROUPS        = YES
 EXTERNAL_PAGES         = YES


### PR DESCRIPTION
## What

### Summary
Add `@thread_safety` and `@performance` custom ALIASES to Doxyfile, aligning with the ecosystem standard established by monitoring_system.

### Change Type
- [x] Documentation

## Why

### Related Issues
- Part of kcenon/common_system#472

### Motivation
Custom ALIASES enable consistent cross-referencing of thread safety guarantees and performance characteristics in API documentation across all 8 ecosystem libraries.

## How

### Implementation Details
Added two ALIASES entries matching monitoring_system's existing configuration.

### Test Plan
- [ ] Doxygen build succeeds (`build-Doxygen.yaml` workflow)