### PR TITLE
docs: Add CHANGELOG.md and CONTRIBUTING.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.3.1] - 2026-03-14
+
+### Fixed
+- CMake: lower MINIMUM_SUPPORTED_VERSION and add missing vcpkg dependency (#577)
+- CI: pin osv-scanner-action to v2.3.3 and grant contents:write for docs (#573)
+
+### Documentation
+- Replace GIT_TAG main with v0.3.0 in FetchContent examples (#578)
+- Improve Doxyfile configuration and fix comment gaps (#575)
+
+## [0.3.0] - 2026-03-11
+
+### Added
+- Queue consolidation: 10 implementations reduced to 2 public types (adaptive_job_queue, job_queue)
+- Dependabot and OSV-Scanner weekly vulnerability monitoring (#561)
+- IEC 62304 SOUP register (#556)
+- SBOM generation and CVE scanning workflows
+
+### Changed
+- Replaced libiconv (LGPL-2.1) with simdutf (MIT/Apache-2.0) for license compliance (#560)
+- Synchronized vcpkg baseline with ecosystem standard (#555)
+- Graduated sanitizer jobs from Phase 0 to Phase 1 (#554)
+
+### Fixed
+- Updated stale examples and benchmarks to current kcenon::thread API (#553)
+- Build: link kcenon::common_system target for vcpkg find_package path (#571)
+
+### Documentation
+- SOUP list for IEC 62304 compliance (#549)
+- Ecosystem-aware CVE scanning with license check (#552)
+
+### Infrastructure
+- Reusable Doxygen workflow from common_system (#544)
+- Cross-platform CI with GCC, Clang, MSVC
+- ThreadSanitizer, AddressSanitizer, UBSan integration

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,160 @@
+# Contributing to Thread System
+
+Thank you for considering contributing to Thread System\! This document provides guidelines and instructions for contributors.
+
+## Table of Contents
+
+- [Getting Started](#getting-started)
+- [Development Workflow](#development-workflow)
+- [Code Standards](#code-standards)
+- [Testing](#testing)
+- [Pull Requests](#pull-requests)
+
+## Getting Started
+
+### Prerequisites
+
+- C++20 compatible compiler (GCC 13+, Clang 16+, MSVC 2022+)
+- CMake 3.20 or higher
+- Git
+- vcpkg (recommended)
+
+### Building from Source
+
+```bash
+git clone https://github.com/kcenon/thread_system.git
+cd thread_system
+cmake --preset default
+cmake --build build
+```
+
+### Running Tests
+
+```bash
+cd build
+ctest --output-on-failure
+```
+
+## Development Workflow
+
+1. Fork the repository
+2. Create a feature branch (`git checkout -b feature/your-feature`)
+3. Make your changes
+4. Run tests and ensure they pass
+5. Commit your changes (see commit message guidelines below)
+6. Push to your fork (`git push origin feature/your-feature`)
+7. Open a Pull Request
+
+### Commit Message Guidelines
+
+Follow the [Conventional Commits](https://www.conventionalcommits.org/) format:
+
+```
+<type>(<scope>): <description>
+
+[optional body]
+
+[optional footer]
+```
+
+**Types:**
+- `feat`: New feature
+- `fix`: Bug fix
+- `docs`: Documentation changes
+- `refactor`: Code refactoring
+- `test`: Adding or modifying tests
+- `perf`: Performance improvement
+- `chore`: Maintenance tasks
+
+## Code Standards
+
+### C++ Style
+
+- Use C++20 features when beneficial
+- Follow existing code style (clang-format configuration provided)
+- Prefer RAII for resource management
+- Use `auto` for obvious types
+- Avoid raw pointers; use smart pointers
+- Prefer standard library over custom implementations
+
+### Naming Conventions
+
+- **Classes/Structs**: `snake_case`
+- **Functions/Methods**: `snake_case`
+- **Variables**: `snake_case`
+- **Constants**: `UPPER_SNAKE_CASE`
+- **Template Parameters**: `PascalCase`
+- **Namespaces**: `kcenon::thread`
+
+### Documentation
+
+Use Doxygen-style comments:
+
+```cpp
+/**
+ * @brief Brief description
+ * @param param Parameter description
+ * @return Return value description
+ * @thread_safety Thread-safe / Not thread-safe
+ */
+auto function(int param) -> int;
+```
+
+## Testing
+
+### Test Requirements
+
+All code contributions must include tests:
+
+- **Unit tests**: Test individual components
+- **Integration tests**: Test component interactions
+- **Platform tests**: Test platform-specific code paths
+
+### Writing Tests
+
+Use Google Test framework:
+
+```cpp
+#include <gtest/gtest.h>
+
+TEST(ComponentTest, BasicFunctionality) {
+    // Test implementation
+}
+```
+
+### Test Coverage
+
+Aim for:
+- New code: > 80% coverage
+- Critical paths: 100% coverage
+- Error handling: Test failure scenarios
+
+## Pull Requests
+
+### PR Checklist
+
+Before submitting a PR, ensure:
+
+- [ ] Code compiles without warnings
+- [ ] All tests pass
+- [ ] New tests added for new functionality
+- [ ] Documentation updated
+- [ ] Code follows project style
+- [ ] Commit messages follow conventional format
+- [ ] No merge conflicts with main branch
+
+### Review Process
+
+1. Automated checks run (build, tests, linting)
+2. Maintainer reviews code
+3. Address review comments
+4. Approved PR is merged (squash merge preferred)
+
+## Getting Help
+
+- Check [existing issues](https://github.com/kcenon/thread_system/issues)
+- Open a [discussion](https://github.com/kcenon/thread_system/discussions) for questions
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the BSD 3-Clause License.


### PR DESCRIPTION
## What

### Summary
Add CHANGELOG.md (Keep a Changelog format) and CONTRIBUTING.md (standardized contributor guide) to the repository.

### Change Type
- [x] Documentation

## Why

### Related Issues
- Part of kcenon/common_system#475

### Motivation
- **CHANGELOG.md**: vcpkg users need to track breaking changes between versions. Previously only network_system had one (1/8 repos).
- **CONTRIBUTING.md**: GitHub displays a link to this file on issue/PR creation pages, improving contributor onboarding. Previously only monitoring_system had one (1/8 repos).

## How

### Implementation Details
- CHANGELOG.md generated from git tags with key commit summaries
- CONTRIBUTING.md follows ecosystem-standard template with build instructions, code standards, and PR guidelines

### Test Plan
- [ ] CHANGELOG.md version dates match git tags
- [ ] CONTRIBUTING.md build instructions are accurate