### PR TITLE
docs(doxygen): Add @code examples to public API headers

### DIFF
--- a/include/kcenon/thread/core/thread_pool.h
+++ b/include/kcenon/thread/core/thread_pool.h
@@ -33,6 +33,23 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /**
  * @file thread_pool.h
  * @brief Core thread pool implementation with work stealing and auto-scaling.
+ *
+ * @code
+ * #include <kcenon/thread/core/thread_pool.h>
+ *
+ * // Create a thread pool with 4 workers
+ * auto pool = std::make_shared<kcenon::thread::thread_pool>("my_pool", 4);
+ *
+ * // Submit a task
+ * pool->enqueue([] { std::cout << "Task executed\n"; });
+ *
+ * // Submit a task with a result
+ * auto future = pool->enqueue([] { return 42; });
+ * int result = future.get();
+ *
+ * // Graceful shutdown (waits for pending tasks)
+ * pool->stop();
+ * @endcode
  */
 
 #pragma once

--- a/include/kcenon/thread/core/typed_thread_pool.h
+++ b/include/kcenon/thread/core/typed_thread_pool.h
@@ -29,8 +29,25 @@
 
 #pragma once
 
-// Public forwarding header for typed_thread_pool
-// Provides stable include path for tests/examples
+/**
+ * @file typed_thread_pool.h
+ * @brief Public forwarding header for type-safe thread pool.
+ *
+ * Provides a stable include path for typed_thread_pool, which offers
+ * compile-time type safety for job submission and result retrieval.
+ *
+ * @code
+ * #include <kcenon/thread/core/typed_thread_pool.h>
+ *
+ * // Create a typed thread pool for string processing
+ * typed_thread_pool<std::string> pool("string_pool", 2);
+ *
+ * // Submit typed work
+ * pool.enqueue([](const std::string& input) {
+ *     return "processed: " + input;
+ * }, "hello");
+ * @endcode
+ */
 
 #include <kcenon/thread/impl/typed_pool/typed_thread_pool.h>
 


### PR DESCRIPTION
## What

### Summary
Add @code usage examples to core public API headers for improved Doxygen documentation.

### Change Type
- [x] Documentation

## Why

### Related Issues
- Part of kcenon/common_system#476

### Motivation
API documentation without inline examples forces users to read source code or tests. @code blocks in Doxygen comments serve as inline tutorials directly in the generated docs.

## How

### Test Plan
- [ ] Doxygen build succeeds without warnings
- [ ] Code examples render correctly in generated HTML docs