### PR TITLE
perf: cap affinity matrix growth and add diagnostics sampling

### DIFF
--- a/include/kcenon/thread/core/thread_worker.h
+++ b/include/kcenon/thread/core/thread_worker.h
@@ -135,6 +135,16 @@ namespace kcenon::thread
 		void set_diagnostics(diagnostics::thread_pool_diagnostics* diag);
 
 		/**
+		 * @brief Set the diagnostics sampling rate.
+		 * @param rate Record diagnostics events every Nth job (1 = every job).
+		 *
+		 * When rate > 1, only every Nth job records diagnostic events,
+		 * reducing clock-read overhead while still providing representative data.
+		 * The is_tracing_enabled() check remains the top-level gate.
+		 */
+		void set_diagnostics_sample_rate(std::uint32_t rate);
+
+		/**
 		 * @brief Set the worker policy for this worker.
 		 * @param policy The worker policy configuration.
 		 */
@@ -344,6 +354,21 @@ namespace kcenon::thread
 		 * in on_stop_requested().
 		 */
 		cancellation_token worker_cancellation_token_;
+
+		/**
+		 * @brief Diagnostics sampling rate (record every Nth job).
+		 *
+		 * Default is 1 (every job) for backward compatibility.
+		 */
+		std::uint32_t diagnostics_sample_rate_{1};
+
+		/**
+		 * @brief Counter for diagnostics sampling.
+		 *
+		 * Incremented on each job execution. Diagnostics events are recorded
+		 * when (diagnostics_counter_ % diagnostics_sample_rate_ == 0).
+		 */
+		std::uint64_t diagnostics_counter_{0};
 
 		/**
 		 * @brief Pointer to the currently executing job.

--- a/include/kcenon/thread/diagnostics/thread_pool_diagnostics.h
+++ b/include/kcenon/thread/diagnostics/thread_pool_diagnostics.h
@@ -104,6 +104,15 @@ namespace diagnostics
 		 * @brief Configurable thresholds for health status determination.
 		 */
 		health_thresholds health_thresholds_config{};
+
+		/**
+		 * @brief Diagnostics event sampling rate (record every Nth job).
+		 *
+		 * When greater than 1, workers only record diagnostic events
+		 * for every Nth job, reducing clock-read overhead.
+		 * Default: 1 (every job, for backward compatibility).
+		 */
+		std::uint32_t event_sample_rate{1};
 	};
 
 	/**

--- a/include/kcenon/thread/stealing/work_affinity_tracker.h
+++ b/include/kcenon/thread/stealing/work_affinity_tracker.h
@@ -91,11 +91,23 @@ class work_affinity_tracker
 {
 public:
 	/**
+	 * @brief Maximum number of workers tracked for affinity.
+	 *
+	 * When the pool has more workers than this limit, only the first
+	 * MAX_TRACKED_WORKERS are tracked in the cooperation matrix to
+	 * prevent O(n^2) memory growth. Workers beyond this cap can still
+	 * participate in work stealing but won't have affinity data.
+	 */
+	static constexpr std::size_t MAX_TRACKED_WORKERS = 32;
+
+	/**
 	 * @brief Construct a work affinity tracker
 	 * @param worker_count Number of workers to track
 	 * @param history_size Size of history to consider for affinity calculations
 	 *
-	 * @note The history_size affects memory usage: O(worker_count^2 * history_size)
+	 * @note If worker_count exceeds MAX_TRACKED_WORKERS, only the first
+	 *       MAX_TRACKED_WORKERS workers are tracked in the cooperation matrix.
+	 * @note The history_size affects memory usage: O(min(worker_count, MAX_TRACKED_WORKERS)^2)
 	 */
 	explicit work_affinity_tracker(std::size_t worker_count,
 	                               std::size_t history_size = 16);
@@ -205,6 +217,7 @@ private:
 		-> std::pair<std::size_t, std::size_t>;
 
 	std::size_t worker_count_{0};
+	std::size_t tracked_count_{0};
 	std::size_t history_size_{16};
 	std::size_t matrix_size_{0};
 

--- a/src/impl/thread_pool/thread_pool.cpp
+++ b/src/impl/thread_pool/thread_pool.cpp
@@ -464,6 +464,7 @@ auto thread_pool::enqueue(std::unique_ptr<thread_worker>&& worker) -> common::Vo
     worker->set_context(context_);
     worker->set_metrics(metrics_service_->get_basic_metrics());
     worker->set_diagnostics(&diagnostics());
+    worker->set_diagnostics_sample_rate(diagnostics().get_config().event_sample_rate);
 
     // Acquire lock before checking start_pool_ and adding worker
     // This prevents race condition with stop():
@@ -513,14 +514,16 @@ auto thread_pool::enqueue_batch(std::vector<std::unique_ptr<thread_worker>>&& wo
     // Track the starting index for rollback in case of error
     std::size_t start_index = workers_.size();
 
-    // Get diagnostics pointer once outside the loop for efficiency
+    // Get diagnostics pointer and config once outside the loop for efficiency
     auto* diag = &diagnostics();
+    const auto sample_rate = diag->get_config().event_sample_rate;
 
     for (auto& worker : workers) {
         worker->set_job_queue(job_queue_);
         worker->set_context(context_);
         worker->set_metrics(metrics_service_->get_basic_metrics());
         worker->set_diagnostics(diag);
+        worker->set_diagnostics_sample_rate(sample_rate);
 
         // Add worker to vector first
         workers_.emplace_back(std::move(worker));
@@ -748,8 +751,9 @@ auto thread_pool::check_worker_health(bool restart_failed) -> std::size_t {
 
     // Restart workers if requested and pool is running
     if (restart_failed && failed_count > 0 && is_running()) {
-        // Get diagnostics pointer for new workers
+        // Get diagnostics pointer and config for new workers
         auto* diag = &diagnostics();
+        const auto sample_rate = diag->get_config().event_sample_rate;
 
         // Create new workers to replace failed ones
         for (std::size_t i = 0; i < failed_count; ++i) {
@@ -760,6 +764,7 @@ auto thread_pool::check_worker_health(bool restart_failed) -> std::size_t {
             worker->set_job_queue(job_queue_);
             worker->set_metrics(metrics_service_->get_basic_metrics());
             worker->set_diagnostics(diag);
+            worker->set_diagnostics_sample_rate(sample_rate);
 
             // Start the new worker
             auto start_result = worker->start();

--- a/src/impl/thread_pool/thread_worker.cpp
+++ b/src/impl/thread_pool/thread_worker.cpp
@@ -203,6 +203,11 @@ void thread_worker::set_diagnostics(diagnostics::thread_pool_diagnostics* diag)
 	diagnostics_ = diag;
 }
 
+void thread_worker::set_diagnostics_sample_rate(std::uint32_t rate)
+{
+	diagnostics_sample_rate_ = (rate > 0) ? rate : 1;
+}
+
 void thread_worker::set_policy(const worker_policy& policy)
 {
 	policy_ = policy;
@@ -544,8 +549,15 @@ std::unique_ptr<job> thread_worker::try_steal_work()
 		const auto job_name_for_event = current_job->get_name();
 		const auto enqueue_time = current_job->get_enqueue_time();
 
-		// Record dequeued event if tracing is enabled
-		if (diagnostics_ && diagnostics_->is_tracing_enabled())
+		// Determine whether this job should record diagnostics events.
+		// The sampling counter reduces clock-read overhead by skipping
+		// events for most jobs when sample_rate > 1.
+		const bool should_trace = diagnostics_
+			&& diagnostics_->is_tracing_enabled()
+			&& (++diagnostics_counter_ % diagnostics_sample_rate_ == 0);
+
+		// Record dequeued event if tracing is enabled and sampled
+		if (should_trace)
 		{
 			diagnostics::job_execution_event dequeued_event;
 			dequeued_event.job_id = job_id;
@@ -597,8 +609,8 @@ std::unique_ptr<job> thread_worker::try_steal_work()
 		// Use release ordering to ensure job state is visible to cancellation thread
 		current_job_.store(current_job.get(), std::memory_order_release);
 
-		// Record started event if tracing is enabled
-		if (diagnostics_ && diagnostics_->is_tracing_enabled())
+		// Record started event if tracing is enabled and sampled
+		if (should_trace)
 		{
 			diagnostics::job_execution_event started_event;
 			started_event.job_id = job_id;
@@ -666,8 +678,8 @@ std::unique_ptr<job> thread_worker::try_steal_work()
 			// Increment failed job counter
 			jobs_failed_.fetch_add(1, std::memory_order_relaxed);
 
-			// Record failed event if tracing is enabled
-			if (diagnostics_ && diagnostics_->is_tracing_enabled())
+			// Record failed event if tracing is enabled and sampled
+			if (should_trace)
 			{
 				diagnostics::job_execution_event failed_event;
 				failed_event.job_id = job_id;
@@ -696,8 +708,8 @@ std::unique_ptr<job> thread_worker::try_steal_work()
 		// Increment completed job counter
 		jobs_completed_.fetch_add(1, std::memory_order_relaxed);
 
-		// Record completed event if tracing is enabled
-		if (diagnostics_ && diagnostics_->is_tracing_enabled())
+		// Record completed event if tracing is enabled and sampled
+		if (should_trace)
 		{
 			diagnostics::job_execution_event completed_event;
 			completed_event.job_id = job_id;

--- a/src/stealing/work_affinity_tracker.cpp
+++ b/src/stealing/work_affinity_tracker.cpp
@@ -40,15 +40,17 @@ namespace kcenon::thread
 work_affinity_tracker::work_affinity_tracker(std::size_t worker_count,
                                              std::size_t history_size)
 	: worker_count_(worker_count)
+	, tracked_count_(std::min(worker_count, MAX_TRACKED_WORKERS))
 	, history_size_(history_size)
 	, matrix_size_(0)
 	, total_cooperations_(0)
 {
-	if (worker_count_ > 1)
+	if (tracked_count_ > 1)
 	{
 		// Size of upper triangular matrix without diagonal
-		// For n workers: n*(n-1)/2 pairs
-		matrix_size_ = (worker_count_ * (worker_count_ - 1)) / 2;
+		// For n tracked workers: n*(n-1)/2 pairs
+		// Capped at MAX_TRACKED_WORKERS to prevent O(n^2) growth
+		matrix_size_ = (tracked_count_ * (tracked_count_ - 1)) / 2;
 		cooperation_matrix_ =
 			std::make_unique<std::atomic<std::uint64_t>[]>(matrix_size_);
 
@@ -62,12 +64,14 @@ work_affinity_tracker::work_affinity_tracker(std::size_t worker_count,
 
 work_affinity_tracker::work_affinity_tracker(work_affinity_tracker&& other) noexcept
 	: worker_count_(other.worker_count_)
+	, tracked_count_(other.tracked_count_)
 	, history_size_(other.history_size_)
 	, matrix_size_(other.matrix_size_)
 	, cooperation_matrix_(std::move(other.cooperation_matrix_))
 	, total_cooperations_(other.total_cooperations_.load(std::memory_order_relaxed))
 {
 	other.worker_count_ = 0;
+	other.tracked_count_ = 0;
 	other.history_size_ = 0;
 	other.matrix_size_ = 0;
 	other.total_cooperations_.store(0, std::memory_order_relaxed);
@@ -79,6 +83,7 @@ auto work_affinity_tracker::operator=(work_affinity_tracker&& other) noexcept
 	if (this != &other)
 	{
 		worker_count_ = other.worker_count_;
+		tracked_count_ = other.tracked_count_;
 		history_size_ = other.history_size_;
 		matrix_size_ = other.matrix_size_;
 		cooperation_matrix_ = std::move(other.cooperation_matrix_);
@@ -87,6 +92,7 @@ auto work_affinity_tracker::operator=(work_affinity_tracker&& other) noexcept
 			std::memory_order_relaxed);
 
 		other.worker_count_ = 0;
+		other.tracked_count_ = 0;
 		other.history_size_ = 0;
 		other.matrix_size_ = 0;
 		other.total_cooperations_.store(0, std::memory_order_relaxed);
@@ -97,7 +103,7 @@ auto work_affinity_tracker::operator=(work_affinity_tracker&& other) noexcept
 void work_affinity_tracker::record_cooperation(std::size_t thief_id,
                                                std::size_t victim_id)
 {
-	if (thief_id >= worker_count_ || victim_id >= worker_count_ ||
+	if (thief_id >= tracked_count_ || victim_id >= tracked_count_ ||
 	    thief_id == victim_id || !cooperation_matrix_)
 	{
 		return;
@@ -114,7 +120,7 @@ void work_affinity_tracker::record_cooperation(std::size_t thief_id,
 auto work_affinity_tracker::get_affinity(std::size_t worker_a,
                                          std::size_t worker_b) const -> double
 {
-	if (worker_a >= worker_count_ || worker_b >= worker_count_ ||
+	if (worker_a >= tracked_count_ || worker_b >= tracked_count_ ||
 	    worker_a == worker_b || !cooperation_matrix_)
 	{
 		return 0.0;
@@ -140,16 +146,16 @@ auto work_affinity_tracker::get_preferred_victims(std::size_t worker_id,
                                                   std::size_t max_count) const
 	-> std::vector<std::size_t>
 {
-	if (worker_id >= worker_count_ || max_count == 0)
+	if (worker_id >= tracked_count_ || max_count == 0)
 	{
 		return {};
 	}
 
-	// Build list of (affinity, worker_id) pairs for all other workers
+	// Build list of (affinity, worker_id) pairs for tracked workers only
 	std::vector<std::pair<double, std::size_t>> affinities;
-	affinities.reserve(worker_count_ - 1);
+	affinities.reserve(tracked_count_ - 1);
 
-	for (std::size_t i = 0; i < worker_count_; ++i)
+	for (std::size_t i = 0; i < tracked_count_; ++i)
 	{
 		if (i != worker_id)
 		{
@@ -211,8 +217,8 @@ auto work_affinity_tracker::get_matrix_index(std::size_t worker_a,
 
 	// Upper triangular matrix index formula:
 	// For pair (i, j) where i < j:
-	// index = i * worker_count - i*(i+1)/2 + j - i - 1
-	return (i * worker_count_) - ((i * (i + 1)) / 2) + j - i - 1;
+	// index = i * tracked_count - i*(i+1)/2 + j - i - 1
+	return (i * tracked_count_) - ((i * (i + 1)) / 2) + j - i - 1;
 }
 
 auto work_affinity_tracker::normalize_pair(std::size_t a, std::size_t b)

--- a/tests/unit/stealing_test/work_affinity_tracker_test.cpp
+++ b/tests/unit/stealing_test/work_affinity_tracker_test.cpp
@@ -380,11 +380,22 @@ TEST(work_affinity_tracker_test, large_worker_count)
 {
 	work_affinity_tracker tracker(100, 16);
 
+	// Workers within the tracked cap should work normally
+	tracker.record_cooperation(0, 15);
+	tracker.record_cooperation(10, 20);
+
+	EXPECT_GT(tracker.get_affinity(0, 15), 0.0);
+	EXPECT_GT(tracker.get_affinity(10, 20), 0.0);
+
+	// Workers beyond MAX_TRACKED_WORKERS are silently ignored
 	tracker.record_cooperation(0, 99);
 	tracker.record_cooperation(50, 75);
 
-	EXPECT_GT(tracker.get_affinity(0, 99), 0.0);
-	EXPECT_GT(tracker.get_affinity(50, 75), 0.0);
+	EXPECT_EQ(tracker.get_affinity(0, 99), 0.0);
+	EXPECT_EQ(tracker.get_affinity(50, 75), 0.0);
+
+	// Verify the cap value is accessible
+	EXPECT_EQ(work_affinity_tracker::MAX_TRACKED_WORKERS, 32);
 }
 
 TEST(work_affinity_tracker_test, two_workers)


### PR DESCRIPTION
## Summary

- Cap `work_affinity_tracker` cooperation matrix at `MAX_TRACKED_WORKERS` (32) to prevent O(n^2) memory growth with large worker counts. Workers beyond the cap participate in stealing but have no affinity data.
- Add configurable diagnostics event sampling rate (`diagnostics_config::event_sample_rate`) to reduce clock-read overhead. When rate > 1, only every Nth job records tracing events, while `is_tracing_enabled()` remains the top-level gate.

## Test plan

- [x] All 26 affinity tracker tests pass (including updated `large_worker_count` test)
- [x] All 120 diagnostics unit tests pass
- [x] All 166 thread pool unit tests pass
- [x] All 131 core unit tests pass
- [x] Full build succeeds with no new errors