### PR TITLE
chore: add build directory cleanup script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,17 @@ cmake --preset default
 cmake --build build
 ```
 
+### Cleaning Build Directories
+
+To remove all build directories at once:
+
+```bash
+./scripts/clean.sh
+```
+
+> **Tip**: Prefer `cmake --preset <name>` over manual `mkdir build_*` directories.
+> Named presets produce consistent, reproducible builds and avoid build directory proliferation.
+
 ### Running Tests
 
 ```bash

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Clean all build directories
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+echo "Cleaning build directories in $(basename "$PROJECT_DIR")..."
+find "$PROJECT_DIR" -maxdepth 1 -type d -name "build*" -exec rm -rf {} +
+echo "Done. Use CMakePresets.json for reproducible build configurations."


### PR DESCRIPTION
## Summary
- Add `scripts/clean.sh` to remove all `build*` directories at the project root
- Document cleanup workflow and CMakePresets.json usage in CONTRIBUTING.md

## Related Issues
Part of kcenon/common_system#487

## Test plan
- [ ] Run `./scripts/clean.sh` and verify build directories are removed
- [ ] Verify `cmake --preset <name>` still works after cleanup