### PR TITLE
perf(lockfree): back queue nodes with lock-free freelist pool

### DIFF
--- a/include/kcenon/thread/lockfree/lockfree_job_queue.h
+++ b/include/kcenon/thread/lockfree/lockfree_job_queue.h
@@ -237,14 +237,95 @@ private:
         std::unique_ptr<job> data;          // Payload (nullptr for dummy node)
         std::atomic<node*> next{nullptr};   // Next node in queue
 
+        node() : data(nullptr), next(nullptr) {}
+
         explicit node(std::unique_ptr<job>&& job_data)
             : data(std::move(job_data))
             , next(nullptr) {}
     };
 
+    /**
+     * @brief Lock-free node freelist (Treiber stack) for node recycling
+     *
+     * Reduces heap allocations by reusing retired queue nodes. Nodes are
+     * returned to the pool via hazard pointer reclamation callbacks and
+     * acquired on enqueue instead of calling new.
+     *
+     * Shared via shared_ptr so retire callbacks remain valid after queue
+     * destruction (the hazard pointer domain is a process-wide singleton
+     * and may invoke deleters after the queue is destroyed).
+     */
+    class node_pool {
+    public:
+        node_pool() = default;
+
+        ~node_pool() {
+            // Drain freelist and delete all pooled nodes
+            node* head = free_list_.load(std::memory_order_relaxed);
+            while (head) {
+                node* next = head->next.load(std::memory_order_relaxed);
+                delete head;
+                head = next;
+            }
+        }
+
+        // Non-copyable, non-movable
+        node_pool(const node_pool&) = delete;
+        node_pool& operator=(const node_pool&) = delete;
+
+        /**
+         * @brief Acquire a node from the pool, or allocate a new one
+         * @param job_data Job to store in the node
+         * @return Pointer to a ready-to-use node
+         */
+        node* acquire(std::unique_ptr<job>&& job_data) {
+            node* head = free_list_.load(std::memory_order_acquire);
+            while (head) {
+                if (free_list_.compare_exchange_weak(
+                        head, head->next.load(std::memory_order_relaxed),
+                        std::memory_order_acq_rel,
+                        std::memory_order_acquire)) {
+                    // Reuse pooled node — reset fields
+                    head->data = std::move(job_data);
+                    head->next.store(nullptr, std::memory_order_relaxed);
+                    return head;
+                }
+                // head is updated by CAS on failure, retry
+            }
+            // Pool empty — allocate fresh node
+            return new node(std::move(job_data));
+        }
+
+        /**
+         * @brief Return a retired node to the pool for reuse
+         * @param n Node to recycle (must have been fully retired by HP scan)
+         */
+        void release(node* n) {
+            if (!n) return;
+            // Clear payload before pooling
+            n->data.reset();
+            node* old_head = free_list_.load(std::memory_order_relaxed);
+            do {
+                n->next.store(old_head, std::memory_order_relaxed);
+            } while (!free_list_.compare_exchange_weak(
+                old_head, n,
+                std::memory_order_release,
+                std::memory_order_relaxed));
+        }
+
+    private:
+        std::atomic<node*> free_list_{nullptr};
+    };
+
+    /// Retire a node through hazard pointers, recycling via pool on reclamation
+    void retire_node(node* n);
+
     // Queue state: head and tail pointers
     std::atomic<node*> head_;  // Dequeue end (with acquire/release)
     std::atomic<node*> tail_;  // Enqueue end (with acquire/release)
+
+    // Node pool for recycling retired nodes (shared_ptr for capture safety)
+    std::shared_ptr<node_pool> pool_;
 
     // Hazard pointer domain for safe memory reclamation
     // Uses safe_hazard_pointer with explicit memory ordering (safe on ARM/weak memory models)

--- a/src/lockfree/lockfree_job_queue.cpp
+++ b/src/lockfree/lockfree_job_queue.cpp
@@ -35,10 +35,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace kcenon::thread::detail {
 
 // Constructor: Initialize with a dummy node
-lockfree_job_queue::lockfree_job_queue() {
+lockfree_job_queue::lockfree_job_queue()
+    : pool_(std::make_shared<node_pool>()) {
     // Create dummy node (Michael-Scott algorithm requires one dummy node)
     // This simplifies the algorithm by ensuring head and tail are never null
-    node* dummy = new node(nullptr);
+    node* dummy = new node();
 
     head_.store(dummy, std::memory_order_relaxed);
     tail_.store(dummy, std::memory_order_relaxed);
@@ -62,10 +63,10 @@ lockfree_job_queue::~lockfree_job_queue() {
     // Safe cleanup: acquire semantics ensure we see all writes
     node* dummy = head_.load(std::memory_order_acquire);
 
-    // Use safe hazard pointer for reclamation of dummy node
+    // Retire dummy node through pool-aware reclamation
     // This ensures the node is only deleted when no other thread
     // holds a hazard pointer to it (uses explicit memory ordering)
-    safe_retire_hazard(dummy);
+    retire_node(dummy);
 }
 
 // Enqueue operation (Michael-Scott algorithm)
@@ -74,8 +75,8 @@ auto lockfree_job_queue::enqueue(std::unique_ptr<job>&& job_ptr) -> common::Void
         return common::error_info{static_cast<int>(error_code::invalid_argument), "Cannot enqueue null job", "thread_system"};
     }
 
-    // Allocate new node with the job
-    node* new_node = new node(std::move(job_ptr));
+    // Acquire node from pool (reuses retired nodes, falls back to new)
+    node* new_node = pool_->acquire(std::move(job_ptr));
 
     // Acquire hazard pointer guard for tail protection (uses safe memory ordering)
     safe_hazard_guard hp_tail;
@@ -127,8 +128,8 @@ auto lockfree_job_queue::enqueue(std::unique_ptr<job>&& job_ptr) -> common::Void
         }
     }
 
-    // If we exhausted retries, clean up and return error
-    delete new_node;
+    // If we exhausted retries, return node to pool and report error
+    pool_->release(new_node);
     return common::error_info{static_cast<int>(error_code::queue_busy), "Queue is busy, retry later", "thread_system"};
 }
 
@@ -211,7 +212,8 @@ auto lockfree_job_queue::dequeue() -> common::Result<std::unique_ptr<job>> {
                     std::unique_ptr<job> job_data = std::move(next->data);
 
                     // Retire the old head node for later reclamation (safe memory ordering)
-                    safe_retire_hazard(head);
+                    // Reclaimed nodes are returned to the pool instead of deleted
+                    retire_node(head);
 
                     // Update size (relaxed - just for monitoring)
                     approximate_size_.fetch_sub(1, std::memory_order_relaxed);
@@ -264,6 +266,22 @@ auto lockfree_job_queue::empty() const -> bool {
 auto lockfree_job_queue::size() const -> std::size_t {
     // Return cached size (may not be exact due to concurrent modifications)
     return approximate_size_.load(std::memory_order_relaxed);
+}
+
+// Retire a node through hazard pointers, recycling via pool on reclamation
+void lockfree_job_queue::retire_node(node* n) {
+    if (!n) return;
+
+    // Capture pool by shared_ptr so the closure remains valid even if the
+    // queue is destroyed before the hazard pointer domain reclaims this node
+    std::shared_ptr<node_pool> pool = pool_;
+
+    safe_hazard_pointer_domain::instance().retire(
+        n,
+        [pool](void* ptr) {
+            pool->release(static_cast<node*>(ptr));
+        }
+    );
 }
 
 }  // namespace kcenon::thread::detail


### PR DESCRIPTION
## Summary

- Add a lock-free Treiber stack node pool (`node_pool`) to `lockfree_job_queue` that recycles retired Michael-Scott queue nodes instead of deleting them
- On enqueue, nodes are acquired from the pool (falling back to `new` when the pool is empty); on hazard pointer reclamation, nodes are returned to the pool instead of deleted
- The pool is held via `shared_ptr` so retire closures remain valid even if the queue is destroyed before the HP domain reclaims pending nodes

Closes #599

## Test plan

- [x] All 27 existing `LockFreeJobQueueTest` tests pass (basic, concurrent, MPMC, stress, thread churn, weak memory model, destructor safety)
- [x] Build succeeds with no new warnings in changed files
- [ ] CI runs (TSAN/ASAN) pass on Linux