### PR TITLE
chore(deps): upgrade gtest and benchmark overrides to match ecosystem

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -14,8 +14,8 @@
   "overrides": [
     { "name": "simdutf", "version": "5.2.5" },
     { "name": "spdlog", "version": "1.13.0" },
-    { "name": "gtest", "version": "1.14.0" },
-    { "name": "benchmark", "version": "1.8.3" }
+    { "name": "gtest", "version": "1.17.0" },
+    { "name": "benchmark", "version": "1.9.5" }
   ],
   "features": {
     "testing": {


### PR DESCRIPTION
## What

Update test dependency version overrides in `vcpkg.json` to match the kcenon ecosystem standard:

| Dependency | Before | After |
|-----------|--------|-------|
| gtest | 1.14.0 | **1.17.0** |
| benchmark | 1.8.3 | **1.9.5** |

## Why

thread_system is the only Tier 1 system still pinned to older gtest/benchmark versions. Since higher-tier systems (monitoring_system, network_system, pacs_system) depend on thread_system, mismatched overrides can cause **diamond dependency conflicts** when vcpkg resolves different versions of the same library across the dependency graph.

Closes #617

## Where

- `vcpkg.json` — `overrides` array, entries for `gtest` and `benchmark`

## How

### Implementation
Bumped the two version strings in the overrides array. No code changes required — gtest 1.17.0 and benchmark 1.9.5 are backward-compatible with the existing test suite.

### Test plan
- [ ] CI build passes on all platforms (Linux, macOS, Windows)
- [ ] All existing unit tests pass against gtest 1.17.0
- [ ] All existing benchmarks compile and run against benchmark 1.9.5