### PR TITLE
chore(deps): update spdlog version override from 1.13.0 to 1.15.3

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -13,7 +13,7 @@
   ],
   "overrides": [
     { "name": "simdutf", "version": "5.2.5" },
-    { "name": "spdlog", "version": "1.13.0" },
+    { "name": "spdlog", "version": "1.15.3" },
     { "name": "gtest", "version": "1.17.0" },
     { "name": "benchmark", "version": "1.9.5" }
   ],


### PR DESCRIPTION
## What

### Summary
Updates the spdlog version override in `vcpkg.json` from 1.13.0 to 1.15.3, aligning with logger_system and database_system.

### Change Type
- [x] Chore (maintenance)

### Affected Components
- `vcpkg.json` — spdlog version override

## Why

### Related Issues
- Closes #619

### Motivation
The spdlog version override was pinned to 1.13.0 while logger_system and database_system pin to 1.15.3. This discrepancy can cause vcpkg resolution conflicts when multiple kcenon systems are consumed in the same manifest. spdlog 1.15.3 contains bug fixes with no breaking API changes.

### Version Matrix (after fix)

| System | spdlog Override |
|--------|----------------|
| **thread_system** | **1.15.3** (was 1.13.0) |
| logger_system | 1.15.3 |
| database_system | 1.15.3 |

## Where

| File | Description |
|------|-------------|
| `vcpkg.json:16` | spdlog version in `overrides` array |

## How

### Implementation Details
Single-line version string update in `vcpkg.json`.

### Testing Done
- [x] Verified diff matches expected changes
- [ ] CI build and test validation

### Breaking Changes
None — spdlog 1.15.3 is API-compatible with 1.13.0.