### PR TITLE
chore(ci): adopt setup-vcpkg composite action for ecosystem CI standardization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,12 +127,14 @@ jobs:
 
     - name: Install vcpkg dependencies (Unix)
       if: runner.os != 'Windows' && steps.vcpkg-installed.outputs.cache-hit != 'true'
-      run: vcpkg install --x-manifest-root=. --x-install-root=${{ github.workspace }}/vcpkg_installed --triplet ${{ matrix.triplet }}
+      run: |
+        ${{ env.VCPKG_ROOT }}/vcpkg install --x-manifest-root=. --x-install-root=${{ github.workspace }}/vcpkg_installed --triplet ${{ matrix.triplet }}
 
     - name: Install vcpkg dependencies (Windows)
       if: runner.os == 'Windows' && steps.vcpkg-installed.outputs.cache-hit != 'true'
       shell: pwsh
-      run: vcpkg install --x-manifest-root=. --x-install-root=${{ github.workspace }}/vcpkg_installed --triplet ${{ matrix.triplet }}
+      run: |
+        ${{ env.VCPKG_ROOT }}\vcpkg install --x-manifest-root=. --x-install-root=${{ github.workspace }}\vcpkg_installed --triplet ${{ matrix.triplet }}
 
     - name: Configure and Build (vcpkg - Unix)
       if: runner.os != 'Windows'


### PR DESCRIPTION
## Summary
- Add `kcenon/common_system/.github/actions/setup-vcpkg@main` composite action to the build job
- Use vcpkg as the primary build method with FetchContent as a fallback (via `continue-on-error`)
- Add `vcpkg_installed` cache with compiler+triplet-scoped keys for faster CI runs
- Sanitizer job remains unchanged (FetchContent only)

Part of kcenon/common_system#517

## What Changed
| Area | Change |
|------|--------|
| Matrix | Added `triplet` values (x64-linux, arm64-osx, x64-windows) |
| Setup | Added setup-vcpkg composite action after common_system checkout |
| Cache | Added vcpkg_installed cache step with `actions/cache@v5` |
| Install | Added conditional vcpkg install steps for Unix and Windows |
| Build | Restructured into vcpkg primary + FetchContent fallback pattern |
| CMake | Added `-DCMAKE_TOOLCHAIN_FILE` to vcpkg build steps |

## Test plan
- [ ] CI passes on all 4 matrix configurations (gcc, clang, macos, msvc)
- [ ] vcpkg build succeeds as primary method
- [ ] FetchContent fallback triggers correctly if vcpkg fails
- [ ] Sanitizer jobs unaffected and pass
- [ ] vcpkg_installed cache is populated on first run and restored on subsequent runs