### PR TITLE
fix(build): update pkg-config template for unified ThreadSystem library

### DIFF
--- a/cmake/thread_system.pc.in
+++ b/cmake/thread_system.pc.in
@@ -15,7 +15,7 @@ URL: @PROJECT_HOMEPAGE_URL@
 # Note: common_system is a header-only dependency, no Requires entry needed
 
 # Libraries provided by thread_system as specified in T2.2
-Libs: -L${libdir} -lthread_pool -lthread_base -lutilities -llockfree -ltyped_thread_pool -linterfaces
+Libs: -L${libdir} -lThreadSystem
 # Additional system libraries required
 Libs.private: -pthread @SIMDUTF_LIBRARIES@
 

--- a/vcpkg-ports/kcenon-thread-system/usage
+++ b/vcpkg-ports/kcenon-thread-system/usage
@@ -1,0 +1,4 @@
+The package kcenon-thread-system provides CMake targets:
+
+    find_package(thread_system CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE thread_system::ThreadSystem)


### PR DESCRIPTION
## Summary
- Update `cmake/thread_system.pc.in` Libs to reference unified `ThreadSystem` library
- Add missing `usage` file to local port directory

## Related
- Closes #633

## Test plan
- [ ] Verify pkg-config Libs references ThreadSystem
- [ ] Verify usage file is present