### PR TITLE
fix(vcpkg): add missing port-version to overlay manifest

### DIFF
--- a/vcpkg-ports/kcenon-thread-system/vcpkg.json
+++ b/vcpkg-ports/kcenon-thread-system/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kcenon-thread-system",
   "version-semver": "0.3.1",
+  "port-version": 0,
   "description": "High-performance C++20 multithreading framework with lock-free queues and adaptive optimization",
   "homepage": "https://github.com/kcenon/thread_system",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
## What
Add explicit `port-version: 0` to overlay port manifest for consistency with all other ecosystem repos.

## Why
All 7 other ecosystem repos explicitly declare `port-version` in their overlay `vcpkg.json`. The thread_system overlay was the only one missing it. While vcpkg defaults to 0, explicit declaration ensures consistency and prevents confusion during future port-version bumps.

## How
- Added `"port-version": 0` to `vcpkg-ports/kcenon-thread-system/vcpkg.json`

Closes #635