### PR TITLE
docs: add YAML frontmatter to all docs/ markdown files

### DIFF
--- a/docs/API_REFERENCE.kr.md
+++ b/docs/API_REFERENCE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-API-001"
+doc_title: "thread_system API 레퍼런스"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "API"
+---
+
 # thread_system API 레퍼런스
 
 > **버전**: 3.1.0

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-API-002"
+doc_title: "thread_system API Reference"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "API"
+---
+
 # thread_system API Reference
 
 > **Version**: 0.3.1.0

--- a/docs/ARCHITECTURE.kr.md
+++ b/docs/ARCHITECTURE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-ARCH-001"
+doc_title: "thread_system 아키텍처"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "ARCH"
+---
+
 # thread_system 아키텍처
 
 ## 목차

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-ARCH-002"
+doc_title: "thread_system Architecture"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "ARCH"
+---
+
 # thread_system Architecture
 
 > **Language:** **English** | [한국어](ARCHITECTURE.kr.md)

--- a/docs/ARCHITECTURE_DIAGRAM.md
+++ b/docs/ARCHITECTURE_DIAGRAM.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-ARCH-003"
+doc_title: "Thread System - Architecture Diagrams & Visual Reference"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "ARCH"
+---
+
 # Thread System - Architecture Diagrams & Visual Reference
 
 ## 1. System Architecture Overview

--- a/docs/AUTOSCALER_GUIDE.md
+++ b/docs/AUTOSCALER_GUIDE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-GUID-001"
+doc_title: "Autoscaler and Scaling Policies Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "GUID"
+---
+
 # Autoscaler and Scaling Policies Guide
 
 > **Language:** **English**

--- a/docs/BENCHMARKS.kr.md
+++ b/docs/BENCHMARKS.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-PERF-001"
+doc_title: "Thread System 성능 벤치마크"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "PERF"
+---
+
 # Thread System 성능 벤치마크
 
 **버전**: 0.2.0

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-PERF-002"
+doc_title: "Thread System Performance Benchmarks"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "PERF"
+---
+
 # Thread System Performance Benchmarks
 
 **Version**: 0.2.0.0

--- a/docs/CHANGELOG.kr.md
+++ b/docs/CHANGELOG.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-PROJ-001"
+doc_title: "thread_system 변경 이력"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "PROJ"
+---
+
 # thread_system 변경 이력
 
 이 프로젝트의 모든 주목할 만한 변경 사항은 이 파일에 문서화됩니다.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-PROJ-002"
+doc_title: "thread_system Changelog"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "PROJ"
+---
+
 # thread_system Changelog
 
 All notable changes to this project will be documented in this file.

--- a/docs/DIAGNOSTICS_METRICS_GUIDE.md
+++ b/docs/DIAGNOSTICS_METRICS_GUIDE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-GUID-002"
+doc_title: "Diagnostics and Metrics Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "GUID"
+---
+
 # Diagnostics and Metrics Guide
 
 > **Language:** **English**

--- a/docs/FEATURES.kr.md
+++ b/docs/FEATURES.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-FEAT-001"
+doc_title: "Thread System 기능 상세"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "FEAT"
+---
+
 # Thread System 기능 상세
 
 **버전**: 0.3.0

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-FEAT-002"
+doc_title: "Thread System Features"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "FEAT"
+---
+
 # Thread System Features
 
 **Version**: 0.3.0.0

--- a/docs/NUMA_GUIDE.md
+++ b/docs/NUMA_GUIDE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-PERF-003"
+doc_title: "NUMA Topology and Work-Stealing Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "PERF"
+---
+
 # NUMA Topology and Work-Stealing Guide
 
 > **Language:** **English**

--- a/docs/POLICY_QUEUE_GUIDE.md
+++ b/docs/POLICY_QUEUE_GUIDE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-GUID-003"
+doc_title: "Policy Queue Combinations Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "GUID"
+---
+
 # Policy Queue Combinations Guide
 
 > **Language:** **English**

--- a/docs/PRODUCTION_QUALITY.kr.md
+++ b/docs/PRODUCTION_QUALITY.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-QUAL-001"
+doc_title: "Thread System 프로덕션 품질"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "QUAL"
+---
+
 # Thread System 프로덕션 품질
 
 **언어:** [English](PRODUCTION_QUALITY.md) | **한국어**

--- a/docs/PRODUCTION_QUALITY.md
+++ b/docs/PRODUCTION_QUALITY.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-QUAL-002"
+doc_title: "Thread System Production Quality"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "QUAL"
+---
+
 # Thread System Production Quality
 
 **Version**: 0.2.0.0

--- a/docs/PROJECT_STRUCTURE.kr.md
+++ b/docs/PROJECT_STRUCTURE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-PROJ-003"
+doc_title: "Thread System 프로젝트 구조"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "PROJ"
+---
+
 # Thread System 프로젝트 구조
 
 **버전**: 0.3.0

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-PROJ-004"
+doc_title: "Thread System Project Structure"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "PROJ"
+---
+
 # Thread System Project Structure
 
 **Version**: 0.3.0.0

--- a/docs/QUEUE_BACKWARD_COMPATIBILITY.md
+++ b/docs/QUEUE_BACKWARD_COMPATIBILITY.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-PROJ-005"
+doc_title: "Queue Backward Compatibility"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "PROJ"
+---
+
 # Queue Backward Compatibility
 
 > **Language:** **English** | [한국어](QUEUE_BACKWARD_COMPATIBILITY.kr.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-GUID-004"
+doc_title: "thread_system"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "GUID"
+---
+
 # thread_system
 
 > **Version**: 0.2.0.0

--- a/docs/SOUP.md
+++ b/docs/SOUP.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-PROJ-006"
+doc_title: "SOUP List &mdash; thread_system"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "PROJ"
+---
+
 # SOUP List &mdash; thread_system
 
 > **Software of Unknown Provenance (SOUP) Register per IEC 62304:2006+AMD1:2015 &sect;8.1.2**

--- a/docs/adr/ADR-001-v3-api-surface.md
+++ b/docs/adr/ADR-001-v3-api-surface.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-ADR-001"
+doc_title: "ADR-001: v3.0 API Surface and Compatibility Policy"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "ADR"
+---
+
 # ADR-001: v3.0 API Surface and Compatibility Policy
 
 **Status:** Proposed

--- a/docs/adr/ADR-002-typed-pool-evaluation.md
+++ b/docs/adr/ADR-002-typed-pool-evaluation.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-ADR-002"
+doc_title: "ADR-002: typed_pool Template Hierarchy Evaluation"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "ADR"
+---
+
 # ADR-002: typed_pool Template Hierarchy Evaluation
 
 **Status:** Accepted

--- a/docs/advanced/API_REFERENCE.kr.md
+++ b/docs/advanced/API_REFERENCE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-API-003"
+doc_title: "Thread System API Reference"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "API"
+---
+
 # Thread System API Reference
 
 > **Language:** [English](API_REFERENCE.md) | **한국어**

--- a/docs/advanced/API_REFERENCE.md
+++ b/docs/advanced/API_REFERENCE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-API-004"
+doc_title: "Thread System API Reference"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "API"
+---
+
 # Thread System API Reference
 
 > **Language:** **English** | [한국어](API_REFERENCE.kr.md)

--- a/docs/advanced/ARCHITECTURE.kr.md
+++ b/docs/advanced/ARCHITECTURE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-ARCH-004"
+doc_title: "Threading Ecosystem 아키텍처"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "ARCH"
+---
+
 # Threading Ecosystem 아키텍처
 
 > **Language:** [English](ARCHITECTURE.md) | **한국어**

--- a/docs/advanced/ARCHITECTURE.md
+++ b/docs/advanced/ARCHITECTURE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-ARCH-005"
+doc_title: "Threading Ecosystem Architecture"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "ARCH"
+---
+
 # Threading Ecosystem Architecture
 
 > **Language:** **English** | [한국어](ARCHITECTURE.kr.md)

--- a/docs/advanced/CHANGELOG.kr.md
+++ b/docs/advanced/CHANGELOG.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-PROJ-007"
+doc_title: "변경 이력"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "PROJ"
+---
+
 # 변경 이력
 
 [English](CHANGELOG.md) | **한국어**

--- a/docs/advanced/CHANGELOG.md
+++ b/docs/advanced/CHANGELOG.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-PROJ-008"
+doc_title: "Changelog"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "PROJ"
+---
+
 # Changelog
 
 **English** | [한국어](CHANGELOG.kr.md)

--- a/docs/advanced/CI_CD_PERFORMANCE.md
+++ b/docs/advanced/CI_CD_PERFORMANCE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-PERF-004"
+doc_title: "CI/CD Performance Metrics Integration"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "PERF"
+---
+
 # CI/CD Performance Metrics Integration
 
 ## Overview

--- a/docs/advanced/CPP20_CONCEPTS.kr.md
+++ b/docs/advanced/CPP20_CONCEPTS.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-API-005"
+doc_title: "C++20 Concepts 통합"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "API"
+---
+
 # C++20 Concepts 통합
 
 > **Language:** [English](CPP20_CONCEPTS.md) | **한국어**

--- a/docs/advanced/CPP20_CONCEPTS.md
+++ b/docs/advanced/CPP20_CONCEPTS.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-API-006"
+doc_title: "C++20 Concepts Integration"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "API"
+---
+
 # C++20 Concepts Integration
 
 > **Language:** **English** | [한국어](CPP20_CONCEPTS.kr.md)

--- a/docs/advanced/ERROR_SYSTEM_MIGRATION_GUIDE.md
+++ b/docs/advanced/ERROR_SYSTEM_MIGRATION_GUIDE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-MIGR-001"
+doc_title: "Error System Migration Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "MIGR"
+---
+
 # Error System Migration Guide
 
 **Version:** 1.0.0

--- a/docs/advanced/FAQ.md
+++ b/docs/advanced/FAQ.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-GUID-005"
+doc_title: "Frequently Asked Questions (FAQ)"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "GUID"
+---
+
 # Frequently Asked Questions (FAQ)
 
 > **Language:** **English** | [한국어](faq.kr.md)

--- a/docs/advanced/HAZARD_POINTER_DESIGN.md
+++ b/docs/advanced/HAZARD_POINTER_DESIGN.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-ARCH-006"
+doc_title: "Hazard Pointer Design Document"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "ARCH"
+---
+
 # Hazard Pointer Design Document
 
 **Version**: 0.1.0.0

--- a/docs/advanced/INTEGRATION.md
+++ b/docs/advanced/INTEGRATION.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-INTR-001"
+doc_title: "Integration Guide - Thread System"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "INTR"
+---
+
 # Integration Guide - Thread System
 
 > **Language:** **English** | [한국어](INTEGRATION.kr.md)

--- a/docs/advanced/JOB_CANCELLATION.md
+++ b/docs/advanced/JOB_CANCELLATION.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-GUID-006"
+doc_title: "Job Cancellation System"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "GUID"
+---
+
 # Job Cancellation System
 
 ## Overview

--- a/docs/advanced/KNOWN_ISSUES.md
+++ b/docs/advanced/KNOWN_ISSUES.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-GUID-007"
+doc_title: "Known Issues"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "GUID"
+---
+
 # Known Issues
 
 **Version**: 0.3.0.0

--- a/docs/advanced/MIGRATION.kr.md
+++ b/docs/advanced/MIGRATION.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-MIGR-002"
+doc_title: "Thread System 마이그레이션 가이드"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "MIGR"
+---
+
 # Thread System 마이그레이션 가이드
 
 > **Language:** [English](MIGRATION.md) | **한국어**

--- a/docs/advanced/MIGRATION.md
+++ b/docs/advanced/MIGRATION.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-MIGR-003"
+doc_title: "Thread System Migration Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "MIGR"
+---
+
 # Thread System Migration Guide
 
 > **Language:** **English** | [한국어](MIGRATION.kr.md)

--- a/docs/advanced/PATTERNS.kr.md
+++ b/docs/advanced/PATTERNS.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-GUID-008"
+doc_title: "Thread System: 패턴, 모범 사례 및 문제 해결 가이드"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "GUID"
+---
+
 # Thread System: 패턴, 모범 사례 및 문제 해결 가이드
 
 > **Language:** [English](PATTERNS.md) | **한국어**

--- a/docs/advanced/PATTERNS.md
+++ b/docs/advanced/PATTERNS.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-GUID-009"
+doc_title: "Thread System: Patterns, Best Practices, and Troubleshooting Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "GUID"
+---
+
 # Thread System: Patterns, Best Practices, and Troubleshooting Guide
 
 > **Language:** **English** | [한국어](PATTERNS.kr.md)

--- a/docs/advanced/PERFORMANCE.kr.md
+++ b/docs/advanced/PERFORMANCE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-PERF-005"
+doc_title: "Thread System Performance Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "PERF"
+---
+
 # Thread System Performance Guide
 
 > **Language:** [English](PERFORMANCE.md) | **한국어**

--- a/docs/advanced/PERFORMANCE.md
+++ b/docs/advanced/PERFORMANCE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-PERF-006"
+doc_title: "Thread System Performance Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "PERF"
+---
+
 # Thread System Performance Guide
 
 > **Language:** **English** | [한국어](PERFORMANCE.kr.md)

--- a/docs/advanced/QUALITY.kr.md
+++ b/docs/advanced/QUALITY.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-QUAL-003"
+doc_title: "품질 및 QA 가이드"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "QUAL"
+---
+
 # 품질 및 QA 가이드
 
 > **Language:** [English](QUALITY.md) | **한국어**

--- a/docs/advanced/QUALITY.md
+++ b/docs/advanced/QUALITY.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-QUAL-004"
+doc_title: "Quality & QA Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "QUAL"
+---
+
 # Quality & QA Guide
 
 > **Language:** **English** | [한국어](QUALITY.kr.md)

--- a/docs/advanced/QUEUE_SELECTION_GUIDE.md
+++ b/docs/advanced/QUEUE_SELECTION_GUIDE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-GUID-010"
+doc_title: "Queue Selection Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "GUID"
+---
+
 # Queue Selection Guide
 
 > **Language:** **English** | [한국어](QUEUE_SELECTION_GUIDE.kr.md)

--- a/docs/advanced/README.kr.md
+++ b/docs/advanced/README.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-GUID-011"
+doc_title: "Thread System 문서"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "GUID"
+---
+
 # Thread System 문서
 
 Thread System 프레임워크에 대한 포괄적인 문서에 오신 것을 환영합니다. 이 가이드는 여러분의 역할과 필요에 따라 올바른 문서를 찾는 데 도움을 줍니다.

--- a/docs/advanced/README.md
+++ b/docs/advanced/README.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-GUID-012"
+doc_title: "Thread System Documentation"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "GUID"
+---
+
 # Thread System Documentation
 
 > **Language:** **English** | [한국어](README.kr.md)

--- a/docs/advanced/STRUCTURE.kr.md
+++ b/docs/advanced/STRUCTURE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-ARCH-007"
+doc_title: "Thread System - 새로운 구조"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "ARCH"
+---
+
 # Thread System - 새로운 구조
 
 [English](STRUCTURE.md) | **한국어**

--- a/docs/advanced/STRUCTURE.md
+++ b/docs/advanced/STRUCTURE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-ARCH-008"
+doc_title: "Thread System - New Structure"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "ARCH"
+---
+
 # Thread System - New Structure
 
 **English** | [한국어](STRUCTURE.kr.md)

--- a/docs/advanced/THREAD_SYSTEM_ARCHITECTURE.md
+++ b/docs/advanced/THREAD_SYSTEM_ARCHITECTURE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-ARCH-009"
+doc_title: "Architecture - Thread System"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "ARCH"
+---
+
 # Architecture - Thread System
 
 > **Language:** **English** | [한국어](ARCHITECTURE.kr.md)

--- a/docs/advanced/USER_GUIDE.kr.md
+++ b/docs/advanced/USER_GUIDE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-GUID-013"
+doc_title: "Thread System 사용자 가이드"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "GUID"
+---
+
 # Thread System 사용자 가이드
 
 > **Language:** [English](USER_GUIDE.md) | **한국어**

--- a/docs/advanced/USER_GUIDE.md
+++ b/docs/advanced/USER_GUIDE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-GUID-014"
+doc_title: "Thread System User Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "GUID"
+---
+
 # Thread System User Guide
 
 > **Language:** **English** | [한국어](USER_GUIDE.kr.md)

--- a/docs/advanced/USER_MIGRATION_GUIDE.md
+++ b/docs/advanced/USER_MIGRATION_GUIDE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-MIGR-004"
+doc_title: "Migration Guide - Thread System"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "MIGR"
+---
+
 # Migration Guide - Thread System
 
 > **Language:** **English** | [한국어](MIGRATION.kr.md)

--- a/docs/advanced/faq.kr.md
+++ b/docs/advanced/faq.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-GUID-015"
+doc_title: "자주 묻는 질문 (FAQ)"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "GUID"
+---
+
 # 자주 묻는 질문 (FAQ)
 
 > **Language:** [English](faq.md) | **한국어**

--- a/docs/contributing/CONTRIBUTING.kr.md
+++ b/docs/contributing/CONTRIBUTING.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-PROJ-009"
+doc_title: "Thread System에 기여하기"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "PROJ"
+---
+
 # Thread System에 기여하기
 
 > **Language:** [English](CONTRIBUTING.md) | **한국어**

--- a/docs/contributing/CONTRIBUTING.md
+++ b/docs/contributing/CONTRIBUTING.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-PROJ-010"
+doc_title: "Contributing to Thread System"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "PROJ"
+---
+
 # Contributing to Thread System
 
 > **Language:** **English** | [한국어](CONTRIBUTING.kr.md)

--- a/docs/design/QUEUE_MIGRATION_GUIDE.md
+++ b/docs/design/QUEUE_MIGRATION_GUIDE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-MIGR-005"
+doc_title: "Queue Migration Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "MIGR"
+---
+
 # Queue Migration Guide
 
 **Version**: 0.1.0.0

--- a/docs/design/QUEUE_POLICY_DESIGN.md
+++ b/docs/design/QUEUE_POLICY_DESIGN.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-ARCH-010"
+doc_title: "Queue Policy Interface Design"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "ARCH"
+---
+
 # Queue Policy Interface Design
 
 **Version**: 0.1.1.0

--- a/docs/guides/BUILD_GUIDE.kr.md
+++ b/docs/guides/BUILD_GUIDE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-GUID-016"
+doc_title: "Platform-Specific Build Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "GUID"
+---
+
 # Platform-Specific Build Guide
 
 > **Language:** [English](BUILD_GUIDE.md) | **한국어**

--- a/docs/guides/BUILD_GUIDE.md
+++ b/docs/guides/BUILD_GUIDE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-GUID-017"
+doc_title: "Platform-Specific Build Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "GUID"
+---
+
 # Platform-Specific Build Guide
 
 > **Language:** **English** | [한국어](BUILD_GUIDE.kr.md)

--- a/docs/guides/COVERAGE_GUIDE.md
+++ b/docs/guides/COVERAGE_GUIDE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-QUAL-005"
+doc_title: "Test Coverage Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "QUAL"
+---
+
 # Test Coverage Guide
 
 ## Current Status

--- a/docs/guides/DEPENDENCY_COMPATIBILITY_MATRIX.kr.md
+++ b/docs/guides/DEPENDENCY_COMPATIBILITY_MATRIX.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-PROJ-011"
+doc_title: "Dependency Version Compatibility Matrix"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "PROJ"
+---
+
 # Dependency Version Compatibility Matrix
 
 > **Language:** [English](DEPENDENCY_COMPATIBILITY_MATRIX.md) | **한국어**

--- a/docs/guides/DEPENDENCY_COMPATIBILITY_MATRIX.md
+++ b/docs/guides/DEPENDENCY_COMPATIBILITY_MATRIX.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-PROJ-012"
+doc_title: "Dependency Version Compatibility Matrix"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "PROJ"
+---
+
 # Dependency Version Compatibility Matrix
 
 > **Language:** **English** | [한국어](DEPENDENCY_COMPATIBILITY_MATRIX.kr.md)

--- a/docs/guides/DEPENDENCY_CONFLICT_RESOLUTION_GUIDE.kr.md
+++ b/docs/guides/DEPENDENCY_CONFLICT_RESOLUTION_GUIDE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-GUID-018"
+doc_title: "Dependency Conflict Resolution Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "GUID"
+---
+
 # Dependency Conflict Resolution Guide
 
 > **Language:** [English](DEPENDENCY_CONFLICT_RESOLUTION_GUIDE.md) | **한국어**

--- a/docs/guides/DEPENDENCY_CONFLICT_RESOLUTION_GUIDE.md
+++ b/docs/guides/DEPENDENCY_CONFLICT_RESOLUTION_GUIDE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-GUID-019"
+doc_title: "Dependency Conflict Resolution Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "GUID"
+---
+
 # Dependency Conflict Resolution Guide
 
 > **Language:** **English** | [한국어](DEPENDENCY_CONFLICT_RESOLUTION_GUIDE.kr.md)

--- a/docs/guides/FAQ.md
+++ b/docs/guides/FAQ.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-GUID-020"
+doc_title: "Thread System - Frequently Asked Questions"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "GUID"
+---
+
 # Thread System - Frequently Asked Questions
 
 > **Version:** 0.1.0

--- a/docs/guides/LICENSE_COMPATIBILITY.kr.md
+++ b/docs/guides/LICENSE_COMPATIBILITY.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-PROJ-013"
+doc_title: "License Compatibility Analysis"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "PROJ"
+---
+
 # License Compatibility Analysis
 
 > **Language:** [English](LICENSE_COMPATIBILITY.md) | **한국어**

--- a/docs/guides/LICENSE_COMPATIBILITY.md
+++ b/docs/guides/LICENSE_COMPATIBILITY.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-PROJ-014"
+doc_title: "License Compatibility Analysis"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "PROJ"
+---
+
 # License Compatibility Analysis
 
 > **Language:** **English** | [한국어](LICENSE_COMPATIBILITY.kr.md)

--- a/docs/guides/LOGGER_INTERFACE_MIGRATION_GUIDE.kr.md
+++ b/docs/guides/LOGGER_INTERFACE_MIGRATION_GUIDE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-MIGR-006"
+doc_title: "Logger Interface 마이그레이션 가이드"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "MIGR"
+---
+
 # Logger Interface 마이그레이션 가이드
 
 > **Language:** [English](LOGGER_INTERFACE_MIGRATION_GUIDE.md) | **한국어**

--- a/docs/guides/LOGGER_INTERFACE_MIGRATION_GUIDE.md
+++ b/docs/guides/LOGGER_INTERFACE_MIGRATION_GUIDE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-MIGR-007"
+doc_title: "Logger Interface Migration Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "MIGR"
+---
+
 # Logger Interface Migration Guide
 
 > **Language:** **English** | [한국어](LOGGER_INTERFACE_MIGRATION_GUIDE.kr.md)

--- a/docs/guides/LOG_LEVEL_MIGRATION_GUIDE.kr.md
+++ b/docs/guides/LOG_LEVEL_MIGRATION_GUIDE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-MIGR-008"
+doc_title: "로그 레벨 마이그레이션 가이드"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "MIGR"
+---
+
 # 로그 레벨 마이그레이션 가이드
 
 > **Language:** [English](LOG_LEVEL_MIGRATION_GUIDE.md) | **한국어**

--- a/docs/guides/LOG_LEVEL_MIGRATION_GUIDE.md
+++ b/docs/guides/LOG_LEVEL_MIGRATION_GUIDE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-MIGR-009"
+doc_title: "Log Level Migration Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "MIGR"
+---
+
 # Log Level Migration Guide
 
 > **Language:** **English** | [한국어](LOG_LEVEL_MIGRATION_GUIDE.kr.md)

--- a/docs/guides/QUICK_START.kr.md
+++ b/docs/guides/QUICK_START.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-GUID-021"
+doc_title: "빠른 시작 가이드"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "GUID"
+---
+
 # 빠른 시작 가이드
 
 > **Language:** [English](QUICK_START.md) | **한국어**

--- a/docs/guides/QUICK_START.md
+++ b/docs/guides/QUICK_START.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-GUID-022"
+doc_title: "Quick Start Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "GUID"
+---
+
 # Quick Start Guide
 
 > **Language:** **English** | [한국어](QUICK_START.kr.md)

--- a/docs/guides/THREAD_POOL_API_MIGRATION_GUIDE.md
+++ b/docs/guides/THREAD_POOL_API_MIGRATION_GUIDE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-MIGR-010"
+doc_title: "Thread Pool API Migration Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "MIGR"
+---
+
 # Thread Pool API Migration Guide
 
 This guide helps you migrate from deprecated `thread_pool` methods to their recommended replacements. All deprecated methods will be removed in v2.0.

--- a/docs/guides/TROUBLESHOOTING.kr.md
+++ b/docs/guides/TROUBLESHOOTING.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-GUID-023"
+doc_title: "문제 해결 가이드"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "GUID"
+---
+
 # 문제 해결 가이드
 
 > **Language:** [English](TROUBLESHOOTING.md) | **한국어**

--- a/docs/guides/TROUBLESHOOTING.md
+++ b/docs/guides/TROUBLESHOOTING.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-GUID-024"
+doc_title: "Troubleshooting Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "GUID"
+---
+
 # Troubleshooting Guide
 
 > **Language:** **English** | [한국어](TROUBLESHOOTING.kr.md)

--- a/docs/integration/README.md
+++ b/docs/integration/README.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-GUID-025"
+doc_title: "Thread System Integration Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "GUID"
+---
+
 # Thread System Integration Guide
 
 ## Overview

--- a/docs/metrics_audit.md
+++ b/docs/metrics_audit.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-GUID-026"
+doc_title: "Metrics System Audit"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "GUID"
+---
+
 # Metrics System Audit
 
 ## Overview

--- a/docs/performance/BASELINE.md
+++ b/docs/performance/BASELINE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "THR-PERF-007"
+doc_title: "Baseline Performance Metrics"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "thread_system"
+category: "PERF"
+---
+
 # Baseline Performance Metrics
 
 **Document Version**: 1.0


### PR DESCRIPTION
Part of kcenon/common_system#562

## Summary
- Add standardized YAML frontmatter metadata to 83 markdown files in `docs/`
- Each file gets a unique `doc_id` (`THR-{CATEGORY}-{NNN}`), title, version, date, status, project, and category
- Generated by `tools/add_frontmatter.py` from common_system

## Category Breakdown (83 files)
| Category | Count | Description |
|----------|-------|-------------|
| ADR | 2 | Decision Records |
| API | 6 | API Reference |
| ARCH | 10 | Architecture |
| FEAT | 2 | Features |
| GUID | 26 | User Guides |
| INTR | 1 | Integration |
| MIGR | 10 | Migration |
| PERF | 7 | Performance |
| PROJ | 14 | Project Info |
| QUAL | 5 | Quality |

## Test Plan
- [x] Script runs idempotently (re-running skips all files)
- [x] No duplicate doc_id values
- [x] Existing document content unchanged (frontmatter prepended only)