### PR TITLE
docs: add SSOT documentation registry

### DIFF
--- a/docs/API_REFERENCE.kr.md
+++ b/docs/API_REFERENCE.kr.md
@@ -10,6 +10,8 @@ category: "API"
 
 # thread_system API 레퍼런스
 
+> **SSOT**: This document is the single source of truth for **thread_system API 레퍼런스**.
+
 > **버전**: 3.1.0
 > **최종 업데이트**: 2025-01-09
 > **언어**: [English](API_REFERENCE.md) | [한국어]

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -10,6 +10,8 @@ category: "API"
 
 # thread_system API Reference
 
+> **SSOT**: This document is the single source of truth for **thread_system API Reference**.
+
 > **Version**: 0.3.1.0
 > **Last Updated**: 2025-01-09
 > **Language**: [English]

--- a/docs/ARCHITECTURE.kr.md
+++ b/docs/ARCHITECTURE.kr.md
@@ -10,6 +10,8 @@ category: "ARCH"
 
 # thread_system 아키텍처
 
+> **SSOT**: This document is the single source of truth for **thread_system 아키텍처**.
+
 ## 목차
 
 1. [개요](#개요)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -10,6 +10,8 @@ category: "ARCH"
 
 # thread_system Architecture
 
+> **SSOT**: This document is the single source of truth for **thread_system Architecture**.
+
 > **Language:** **English** | [한국어](ARCHITECTURE.kr.md)
 
 ## Table of Contents

--- a/docs/ARCHITECTURE_DIAGRAM.md
+++ b/docs/ARCHITECTURE_DIAGRAM.md
@@ -10,6 +10,8 @@ category: "ARCH"
 
 # Thread System - Architecture Diagrams & Visual Reference
 
+> **SSOT**: This document is the single source of truth for **Thread System - Architecture Diagrams & Visual Reference**.
+
 ## 1. System Architecture Overview
 
 ```

--- a/docs/AUTOSCALER_GUIDE.md
+++ b/docs/AUTOSCALER_GUIDE.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Autoscaler and Scaling Policies Guide
 
+> **SSOT**: This document is the single source of truth for **Autoscaler and Scaling Policies Guide**.
+
 > **Language:** **English**
 
 A comprehensive guide to thread_system's autoscaling subsystem, which dynamically adjusts thread pool size based on workload metrics.

--- a/docs/BENCHMARKS.kr.md
+++ b/docs/BENCHMARKS.kr.md
@@ -10,6 +10,8 @@ category: "PERF"
 
 # Thread System 성능 벤치마크
 
+> **SSOT**: This document is the single source of truth for **Thread System 성능 벤치마크**.
+
 **버전**: 0.2.0
 **최종 업데이트**: 2025-11-15
 **언어**: [English](BENCHMARKS.md) | [한국어]

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -10,6 +10,8 @@ category: "PERF"
 
 # Thread System Performance Benchmarks
 
+> **SSOT**: This document is the single source of truth for **Thread System Performance Benchmarks**.
+
 **Version**: 0.2.0.0
 **Last Updated**: 2025-11-15
 **Language**: [English] | [한국어](BENCHMARKS.kr.md)

--- a/docs/CHANGELOG.kr.md
+++ b/docs/CHANGELOG.kr.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # thread_system 변경 이력
 
+> **SSOT**: This document is the single source of truth for **thread_system 변경 이력**.
+
 이 프로젝트의 모든 주목할 만한 변경 사항은 이 파일에 문서화됩니다.
 
 이 형식은 [Keep a Changelog](https://keepachangelog.com/ko/1.0.0/)를 기반으로 하며,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # thread_system Changelog
 
+> **SSOT**: This document is the single source of truth for **thread_system Changelog**.
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/docs/DIAGNOSTICS_METRICS_GUIDE.md
+++ b/docs/DIAGNOSTICS_METRICS_GUIDE.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Diagnostics and Metrics Guide
 
+> **SSOT**: This document is the single source of truth for **Diagnostics and Metrics Guide**.
+
 > **Language:** **English**
 
 A comprehensive guide to thread_system's diagnostics and metrics subsystems, covering health checks, bottleneck detection, event tracing, latency histograms, throughput counters, and pluggable export backends.

--- a/docs/FEATURES.kr.md
+++ b/docs/FEATURES.kr.md
@@ -10,6 +10,8 @@ category: "FEAT"
 
 # Thread System 기능 상세
 
+> **SSOT**: This document is the single source of truth for **Thread System 기능 상세**.
+
 **버전**: 0.3.0
 **최종 업데이트**: 2026-02-08
 **언어**: [English](FEATURES.md) | [한국어]

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -10,6 +10,8 @@ category: "FEAT"
 
 # Thread System Features
 
+> **SSOT**: This document is the single source of truth for **Thread System Features**.
+
 **Version**: 0.3.0.0
 **Last Updated**: 2026-02-08
 **Language**: [English] | [한국어](FEATURES.kr.md)

--- a/docs/NUMA_GUIDE.md
+++ b/docs/NUMA_GUIDE.md
@@ -10,6 +10,8 @@ category: "PERF"
 
 # NUMA Topology and Work-Stealing Guide
 
+> **SSOT**: This document is the single source of truth for **NUMA Topology and Work-Stealing Guide**.
+
 > **Language:** **English**
 
 A comprehensive guide to thread_system's NUMA-aware thread pool and work-stealing subsystem, covering topology detection, NUMA-local scheduling, and cross-node work stealing.

--- a/docs/POLICY_QUEUE_GUIDE.md
+++ b/docs/POLICY_QUEUE_GUIDE.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Policy Queue Combinations Guide
 
+> **SSOT**: This document is the single source of truth for **Policy Queue Combinations Guide**.
+
 > **Language:** **English**
 
 ## Table of Contents

--- a/docs/PRODUCTION_QUALITY.kr.md
+++ b/docs/PRODUCTION_QUALITY.kr.md
@@ -10,6 +10,8 @@ category: "QUAL"
 
 # Thread System 프로덕션 품질
 
+> **SSOT**: This document is the single source of truth for **Thread System 프로덕션 품질**.
+
 **언어:** [English](PRODUCTION_QUALITY.md) | **한국어**
 
 **버전**: 0.2.0

--- a/docs/PRODUCTION_QUALITY.md
+++ b/docs/PRODUCTION_QUALITY.md
@@ -10,6 +10,8 @@ category: "QUAL"
 
 # Thread System Production Quality
 
+> **SSOT**: This document is the single source of truth for **Thread System Production Quality**.
+
 **Version**: 0.2.0.0
 **Last Updated**: 2025-11-15
 **Language**: [English] | [한국어](PRODUCTION_QUALITY.kr.md)

--- a/docs/PROJECT_STRUCTURE.kr.md
+++ b/docs/PROJECT_STRUCTURE.kr.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # Thread System 프로젝트 구조
 
+> **SSOT**: This document is the single source of truth for **Thread System 프로젝트 구조**.
+
 **버전**: 0.3.0
 **최종 업데이트**: 2026-01-11
 **언어**: [English](PROJECT_STRUCTURE.md) | **한국어**

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # Thread System Project Structure
 
+> **SSOT**: This document is the single source of truth for **Thread System Project Structure**.
+
 **Version**: 0.3.0.0
 **Last Updated**: 2026-01-11
 **Language**: [English] | [한국어](PROJECT_STRUCTURE.kr.md)

--- a/docs/QUEUE_BACKWARD_COMPATIBILITY.md
+++ b/docs/QUEUE_BACKWARD_COMPATIBILITY.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # Queue Backward Compatibility
 
+> **SSOT**: This document is the single source of truth for **Queue Backward Compatibility**.
+
 > **Language:** **English** | [한국어](QUEUE_BACKWARD_COMPATIBILITY.kr.md)
 
 ## TL;DR: Your Code (Probably) Still Works

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 ---
 doc_id: "THR-GUID-004"
-doc_title: "thread_system"
+doc_title: "Thread System Documentation Registry"
 doc_version: "1.0.0"
 doc_date: "2026-04-04"
 doc_status: "Released"
@@ -8,147 +8,234 @@ project: "thread_system"
 category: "GUID"
 ---
 
-# thread_system
+# Thread System — Documentation Registry
 
-> **Version**: 0.2.0.0
-> **Status**: Production
-> **Tier**: 1
+> **SSOT**: This file is the single source of truth for the documentation index
+> of **thread_system**.
 
-## 개요
+Total documents: **82**
 
-thread_system은 고성능 멀티스레드 프로그래밍을 위한 C++17/20 기반 스레드 관리 라이브러리입니다. thread_pool, typed_thread_pool, 다양한 동시성 큐 구현 및 서비스 인프라를 제공합니다.
+## Document Index
 
-## 주요 기능
+| # | doc_id | Topic | Authority Document | Status |
+|---|--------|-------|-------------------|--------|
+| 1 | THR-ARCH-001 | thread_system 아키텍처 | [ARCHITECTURE.kr.md](./ARCHITECTURE.kr.md) | Released |
+| 2 | THR-ARCH-002 | thread_system Architecture | [ARCHITECTURE.md](./ARCHITECTURE.md) | Released |
+| 3 | THR-ARCH-003 | Thread System - Architecture Diagrams & Visual Reference | [ARCHITECTURE_DIAGRAM.md](./ARCHITECTURE_DIAGRAM.md) | Released |
+| 4 | THR-ARCH-004 | Threading Ecosystem 아키텍처 | [ARCHITECTURE.kr.md](./advanced/ARCHITECTURE.kr.md) | Released |
+| 5 | THR-ARCH-005 | Threading Ecosystem Architecture | [ARCHITECTURE.md](./advanced/ARCHITECTURE.md) | Released |
+| 6 | THR-ARCH-006 | Hazard Pointer Design Document | [HAZARD_POINTER_DESIGN.md](./advanced/HAZARD_POINTER_DESIGN.md) | Released |
+| 7 | THR-ARCH-007 | Thread System - 새로운 구조 | [STRUCTURE.kr.md](./advanced/STRUCTURE.kr.md) | Released |
+| 8 | THR-ARCH-008 | Thread System - New Structure | [STRUCTURE.md](./advanced/STRUCTURE.md) | Released |
+| 9 | THR-ARCH-009 | Architecture - Thread System | [THREAD_SYSTEM_ARCHITECTURE.md](./advanced/THREAD_SYSTEM_ARCHITECTURE.md) | Released |
+| 10 | THR-ARCH-010 | Queue Policy Interface Design | [QUEUE_POLICY_DESIGN.md](./design/QUEUE_POLICY_DESIGN.md) | Released |
+| 11 | THR-API-001 | thread_system API 레퍼런스 | [API_REFERENCE.kr.md](./API_REFERENCE.kr.md) | Released |
+| 12 | THR-API-002 | thread_system API Reference | [API_REFERENCE.md](./API_REFERENCE.md) | Released |
+| 13 | THR-API-003 | Thread System API Reference | [API_REFERENCE.kr.md](./advanced/API_REFERENCE.kr.md) | Released |
+| 14 | THR-API-004 | Thread System API Reference | [API_REFERENCE.md](./advanced/API_REFERENCE.md) | Released |
+| 15 | THR-API-005 | C++20 Concepts 통합 | [CPP20_CONCEPTS.kr.md](./advanced/CPP20_CONCEPTS.kr.md) | Released |
+| 16 | THR-API-006 | C++20 Concepts Integration | [CPP20_CONCEPTS.md](./advanced/CPP20_CONCEPTS.md) | Released |
+| 17 | THR-FEAT-001 | Thread System 기능 상세 | [FEATURES.kr.md](./FEATURES.kr.md) | Released |
+| 18 | THR-FEAT-002 | Thread System Features | [FEATURES.md](./FEATURES.md) | Released |
+| 19 | THR-GUID-001 | Autoscaler and Scaling Policies Guide | [AUTOSCALER_GUIDE.md](./AUTOSCALER_GUIDE.md) | Released |
+| 20 | THR-GUID-002 | Diagnostics and Metrics Guide | [DIAGNOSTICS_METRICS_GUIDE.md](./DIAGNOSTICS_METRICS_GUIDE.md) | Released |
+| 21 | THR-GUID-003 | Policy Queue Combinations Guide | [POLICY_QUEUE_GUIDE.md](./POLICY_QUEUE_GUIDE.md) | Released |
+| 22 | THR-GUID-005 | Frequently Asked Questions (FAQ) | [FAQ.md](./advanced/FAQ.md) | Released |
+| 23 | THR-GUID-006 | Job Cancellation System | [JOB_CANCELLATION.md](./advanced/JOB_CANCELLATION.md) | Released |
+| 24 | THR-GUID-007 | Known Issues | [KNOWN_ISSUES.md](./advanced/KNOWN_ISSUES.md) | Released |
+| 25 | THR-GUID-008 | Thread System: 패턴, 모범 사례 및 문제 해결 가이드 | [PATTERNS.kr.md](./advanced/PATTERNS.kr.md) | Released |
+| 26 | THR-GUID-009 | Thread System: Patterns, Best Practices, and Troubleshooting Guide | [PATTERNS.md](./advanced/PATTERNS.md) | Released |
+| 27 | THR-GUID-010 | Queue Selection Guide | [QUEUE_SELECTION_GUIDE.md](./advanced/QUEUE_SELECTION_GUIDE.md) | Released |
+| 28 | THR-GUID-011 | Thread System 문서 | [README.kr.md](./advanced/README.kr.md) | Released |
+| 29 | THR-GUID-012 | Thread System Documentation | [README.md](./advanced/README.md) | Released |
+| 30 | THR-GUID-013 | Thread System 사용자 가이드 | [USER_GUIDE.kr.md](./advanced/USER_GUIDE.kr.md) | Released |
+| 31 | THR-GUID-014 | Thread System User Guide | [USER_GUIDE.md](./advanced/USER_GUIDE.md) | Released |
+| 32 | THR-GUID-015 | 자주 묻는 질문 (FAQ) | [faq.kr.md](./advanced/faq.kr.md) | Released |
+| 33 | THR-GUID-016 | Platform-Specific Build Guide | [BUILD_GUIDE.kr.md](./guides/BUILD_GUIDE.kr.md) | Released |
+| 34 | THR-GUID-017 | Platform-Specific Build Guide | [BUILD_GUIDE.md](./guides/BUILD_GUIDE.md) | Released |
+| 35 | THR-GUID-018 | Dependency Conflict Resolution Guide | [DEPENDENCY_CONFLICT_RESOLUTION_GUIDE.kr.md](./guides/DEPENDENCY_CONFLICT_RESOLUTION_GUIDE.kr.md) | Released |
+| 36 | THR-GUID-019 | Dependency Conflict Resolution Guide | [DEPENDENCY_CONFLICT_RESOLUTION_GUIDE.md](./guides/DEPENDENCY_CONFLICT_RESOLUTION_GUIDE.md) | Released |
+| 37 | THR-GUID-020 | Thread System - Frequently Asked Questions | [FAQ.md](./guides/FAQ.md) | Released |
+| 38 | THR-GUID-021 | 빠른 시작 가이드 | [QUICK_START.kr.md](./guides/QUICK_START.kr.md) | Released |
+| 39 | THR-GUID-022 | Quick Start Guide | [QUICK_START.md](./guides/QUICK_START.md) | Released |
+| 40 | THR-GUID-023 | 문제 해결 가이드 | [TROUBLESHOOTING.kr.md](./guides/TROUBLESHOOTING.kr.md) | Released |
+| 41 | THR-GUID-024 | Troubleshooting Guide | [TROUBLESHOOTING.md](./guides/TROUBLESHOOTING.md) | Released |
+| 42 | THR-GUID-025 | Thread System Integration Guide | [README.md](./integration/README.md) | Released |
+| 43 | THR-GUID-026 | Metrics System Audit | [metrics_audit.md](./metrics_audit.md) | Released |
+| 44 | THR-PERF-001 | Thread System 성능 벤치마크 | [BENCHMARKS.kr.md](./BENCHMARKS.kr.md) | Released |
+| 45 | THR-PERF-002 | Thread System Performance Benchmarks | [BENCHMARKS.md](./BENCHMARKS.md) | Released |
+| 46 | THR-PERF-003 | NUMA Topology and Work-Stealing Guide | [NUMA_GUIDE.md](./NUMA_GUIDE.md) | Released |
+| 47 | THR-PERF-004 | CI/CD Performance Metrics Integration | [CI_CD_PERFORMANCE.md](./advanced/CI_CD_PERFORMANCE.md) | Released |
+| 48 | THR-PERF-005 | Thread System Performance Guide | [PERFORMANCE.kr.md](./advanced/PERFORMANCE.kr.md) | Released |
+| 49 | THR-PERF-006 | Thread System Performance Guide | [PERFORMANCE.md](./advanced/PERFORMANCE.md) | Released |
+| 50 | THR-PERF-007 | Baseline Performance Metrics | [BASELINE.md](./performance/BASELINE.md) | Released |
+| 51 | THR-MIGR-001 | Error System Migration Guide | [ERROR_SYSTEM_MIGRATION_GUIDE.md](./advanced/ERROR_SYSTEM_MIGRATION_GUIDE.md) | Released |
+| 52 | THR-MIGR-002 | Thread System 마이그레이션 가이드 | [MIGRATION.kr.md](./advanced/MIGRATION.kr.md) | Released |
+| 53 | THR-MIGR-003 | Thread System Migration Guide | [MIGRATION.md](./advanced/MIGRATION.md) | Released |
+| 54 | THR-MIGR-004 | Migration Guide - Thread System | [USER_MIGRATION_GUIDE.md](./advanced/USER_MIGRATION_GUIDE.md) | Released |
+| 55 | THR-MIGR-005 | Queue Migration Guide | [QUEUE_MIGRATION_GUIDE.md](./design/QUEUE_MIGRATION_GUIDE.md) | Released |
+| 56 | THR-MIGR-006 | Logger Interface 마이그레이션 가이드 | [LOGGER_INTERFACE_MIGRATION_GUIDE.kr.md](./guides/LOGGER_INTERFACE_MIGRATION_GUIDE.kr.md) | Released |
+| 57 | THR-MIGR-007 | Logger Interface Migration Guide | [LOGGER_INTERFACE_MIGRATION_GUIDE.md](./guides/LOGGER_INTERFACE_MIGRATION_GUIDE.md) | Released |
+| 58 | THR-MIGR-008 | 로그 레벨 마이그레이션 가이드 | [LOG_LEVEL_MIGRATION_GUIDE.kr.md](./guides/LOG_LEVEL_MIGRATION_GUIDE.kr.md) | Released |
+| 59 | THR-MIGR-009 | Log Level Migration Guide | [LOG_LEVEL_MIGRATION_GUIDE.md](./guides/LOG_LEVEL_MIGRATION_GUIDE.md) | Released |
+| 60 | THR-MIGR-010 | Thread Pool API Migration Guide | [THREAD_POOL_API_MIGRATION_GUIDE.md](./guides/THREAD_POOL_API_MIGRATION_GUIDE.md) | Released |
+| 61 | THR-INTR-001 | Integration Guide - Thread System | [INTEGRATION.md](./advanced/INTEGRATION.md) | Released |
+| 62 | THR-QUAL-001 | Thread System 프로덕션 품질 | [PRODUCTION_QUALITY.kr.md](./PRODUCTION_QUALITY.kr.md) | Released |
+| 63 | THR-QUAL-002 | Thread System Production Quality | [PRODUCTION_QUALITY.md](./PRODUCTION_QUALITY.md) | Released |
+| 64 | THR-QUAL-003 | 품질 및 QA 가이드 | [QUALITY.kr.md](./advanced/QUALITY.kr.md) | Released |
+| 65 | THR-QUAL-004 | Quality & QA Guide | [QUALITY.md](./advanced/QUALITY.md) | Released |
+| 66 | THR-QUAL-005 | Test Coverage Guide | [COVERAGE_GUIDE.md](./guides/COVERAGE_GUIDE.md) | Released |
+| 67 | THR-ADR-001 | ADR-001: v3.0 API Surface and Compatibility Policy | [ADR-001-v3-api-surface.md](./adr/ADR-001-v3-api-surface.md) | Released |
+| 68 | THR-ADR-002 | ADR-002: typed_pool Template Hierarchy Evaluation | [ADR-002-typed-pool-evaluation.md](./adr/ADR-002-typed-pool-evaluation.md) | Released |
+| 69 | THR-PROJ-001 | thread_system 변경 이력 | [CHANGELOG.kr.md](./CHANGELOG.kr.md) | Released |
+| 70 | THR-PROJ-002 | thread_system Changelog | [CHANGELOG.md](./CHANGELOG.md) | Released |
+| 71 | THR-PROJ-003 | Thread System 프로젝트 구조 | [PROJECT_STRUCTURE.kr.md](./PROJECT_STRUCTURE.kr.md) | Released |
+| 72 | THR-PROJ-004 | Thread System Project Structure | [PROJECT_STRUCTURE.md](./PROJECT_STRUCTURE.md) | Released |
+| 73 | THR-PROJ-005 | Queue Backward Compatibility | [QUEUE_BACKWARD_COMPATIBILITY.md](./QUEUE_BACKWARD_COMPATIBILITY.md) | Released |
+| 74 | THR-PROJ-006 | SOUP List &mdash; thread_system | [SOUP.md](./SOUP.md) | Released |
+| 75 | THR-PROJ-007 | 변경 이력 | [CHANGELOG.kr.md](./advanced/CHANGELOG.kr.md) | Released |
+| 76 | THR-PROJ-008 | Changelog | [CHANGELOG.md](./advanced/CHANGELOG.md) | Released |
+| 77 | THR-PROJ-009 | Thread System에 기여하기 | [CONTRIBUTING.kr.md](./contributing/CONTRIBUTING.kr.md) | Released |
+| 78 | THR-PROJ-010 | Contributing to Thread System | [CONTRIBUTING.md](./contributing/CONTRIBUTING.md) | Released |
+| 79 | THR-PROJ-011 | Dependency Version Compatibility Matrix | [DEPENDENCY_COMPATIBILITY_MATRIX.kr.md](./guides/DEPENDENCY_COMPATIBILITY_MATRIX.kr.md) | Released |
+| 80 | THR-PROJ-012 | Dependency Version Compatibility Matrix | [DEPENDENCY_COMPATIBILITY_MATRIX.md](./guides/DEPENDENCY_COMPATIBILITY_MATRIX.md) | Released |
+| 81 | THR-PROJ-013 | License Compatibility Analysis | [LICENSE_COMPATIBILITY.kr.md](./guides/LICENSE_COMPATIBILITY.kr.md) | Released |
+| 82 | THR-PROJ-014 | License Compatibility Analysis | [LICENSE_COMPATIBILITY.md](./guides/LICENSE_COMPATIBILITY.md) | Released |
 
-- **Thread Pool**: 작업 기반 스레드 풀 (4.5x 성능 향상)
-- **Typed Thread Pool**: 타입 안전 스레드 풀 (3.8x 성능 향상)
-- **Lock-Free Queue**: MPMC 큐 구현 (5.2x 성능 향상)
-- **Adaptive Queue**: 부하 기반 자동 크기 조정
-- **Service Registry**: 서비스 라이프사이클 관리
-- **Thread Safety**: 포괄적인 동기화 원시 타입
+## Documents by Category
 
-## 빠른 시작
+### Architecture (10)
 
-### 설치
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| THR-ARCH-001 | thread_system 아키텍처 | [ARCHITECTURE.kr.md](./ARCHITECTURE.kr.md) | Released |
+| THR-ARCH-002 | thread_system Architecture | [ARCHITECTURE.md](./ARCHITECTURE.md) | Released |
+| THR-ARCH-003 | Thread System - Architecture Diagrams & Visual Reference | [ARCHITECTURE_DIAGRAM.md](./ARCHITECTURE_DIAGRAM.md) | Released |
+| THR-ARCH-004 | Threading Ecosystem 아키텍처 | [ARCHITECTURE.kr.md](./advanced/ARCHITECTURE.kr.md) | Released |
+| THR-ARCH-005 | Threading Ecosystem Architecture | [ARCHITECTURE.md](./advanced/ARCHITECTURE.md) | Released |
+| THR-ARCH-006 | Hazard Pointer Design Document | [HAZARD_POINTER_DESIGN.md](./advanced/HAZARD_POINTER_DESIGN.md) | Released |
+| THR-ARCH-007 | Thread System - 새로운 구조 | [STRUCTURE.kr.md](./advanced/STRUCTURE.kr.md) | Released |
+| THR-ARCH-008 | Thread System - New Structure | [STRUCTURE.md](./advanced/STRUCTURE.md) | Released |
+| THR-ARCH-009 | Architecture - Thread System | [THREAD_SYSTEM_ARCHITECTURE.md](./advanced/THREAD_SYSTEM_ARCHITECTURE.md) | Released |
+| THR-ARCH-010 | Queue Policy Interface Design | [QUEUE_POLICY_DESIGN.md](./design/QUEUE_POLICY_DESIGN.md) | Released |
 
-#### 통합 빌드
-```bash
-cd unified_system
-cmake -B build -DBUILD_TIER1=ON
-cmake --build build
-```
+### API Reference (6)
 
-#### 독립 빌드
-```bash
-cd thread_system
-cmake -B build
-cmake --build build
-```
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| THR-API-001 | thread_system API 레퍼런스 | [API_REFERENCE.kr.md](./API_REFERENCE.kr.md) | Released |
+| THR-API-002 | thread_system API Reference | [API_REFERENCE.md](./API_REFERENCE.md) | Released |
+| THR-API-003 | Thread System API Reference | [API_REFERENCE.kr.md](./advanced/API_REFERENCE.kr.md) | Released |
+| THR-API-004 | Thread System API Reference | [API_REFERENCE.md](./advanced/API_REFERENCE.md) | Released |
+| THR-API-005 | C++20 Concepts 통합 | [CPP20_CONCEPTS.kr.md](./advanced/CPP20_CONCEPTS.kr.md) | Released |
+| THR-API-006 | C++20 Concepts Integration | [CPP20_CONCEPTS.md](./advanced/CPP20_CONCEPTS.md) | Released |
 
-### 기본 사용법
+### Features (2)
 
-#### Thread Pool 사용
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| THR-FEAT-001 | Thread System 기능 상세 | [FEATURES.kr.md](./FEATURES.kr.md) | Released |
+| THR-FEAT-002 | Thread System Features | [FEATURES.md](./FEATURES.md) | Released |
 
-```cpp
-#include <kcenon/thread/thread_pool.h>
+### Guides (25)
 
-using namespace kcenon::thread;
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| THR-GUID-001 | Autoscaler and Scaling Policies Guide | [AUTOSCALER_GUIDE.md](./AUTOSCALER_GUIDE.md) | Released |
+| THR-GUID-002 | Diagnostics and Metrics Guide | [DIAGNOSTICS_METRICS_GUIDE.md](./DIAGNOSTICS_METRICS_GUIDE.md) | Released |
+| THR-GUID-003 | Policy Queue Combinations Guide | [POLICY_QUEUE_GUIDE.md](./POLICY_QUEUE_GUIDE.md) | Released |
+| THR-GUID-005 | Frequently Asked Questions (FAQ) | [FAQ.md](./advanced/FAQ.md) | Released |
+| THR-GUID-006 | Job Cancellation System | [JOB_CANCELLATION.md](./advanced/JOB_CANCELLATION.md) | Released |
+| THR-GUID-007 | Known Issues | [KNOWN_ISSUES.md](./advanced/KNOWN_ISSUES.md) | Released |
+| THR-GUID-008 | Thread System: 패턴, 모범 사례 및 문제 해결 가이드 | [PATTERNS.kr.md](./advanced/PATTERNS.kr.md) | Released |
+| THR-GUID-009 | Thread System: Patterns, Best Practices, and Troubleshooting Guide | [PATTERNS.md](./advanced/PATTERNS.md) | Released |
+| THR-GUID-010 | Queue Selection Guide | [QUEUE_SELECTION_GUIDE.md](./advanced/QUEUE_SELECTION_GUIDE.md) | Released |
+| THR-GUID-011 | Thread System 문서 | [README.kr.md](./advanced/README.kr.md) | Released |
+| THR-GUID-012 | Thread System Documentation | [README.md](./advanced/README.md) | Released |
+| THR-GUID-013 | Thread System 사용자 가이드 | [USER_GUIDE.kr.md](./advanced/USER_GUIDE.kr.md) | Released |
+| THR-GUID-014 | Thread System User Guide | [USER_GUIDE.md](./advanced/USER_GUIDE.md) | Released |
+| THR-GUID-015 | 자주 묻는 질문 (FAQ) | [faq.kr.md](./advanced/faq.kr.md) | Released |
+| THR-GUID-016 | Platform-Specific Build Guide | [BUILD_GUIDE.kr.md](./guides/BUILD_GUIDE.kr.md) | Released |
+| THR-GUID-017 | Platform-Specific Build Guide | [BUILD_GUIDE.md](./guides/BUILD_GUIDE.md) | Released |
+| THR-GUID-018 | Dependency Conflict Resolution Guide | [DEPENDENCY_CONFLICT_RESOLUTION_GUIDE.kr.md](./guides/DEPENDENCY_CONFLICT_RESOLUTION_GUIDE.kr.md) | Released |
+| THR-GUID-019 | Dependency Conflict Resolution Guide | [DEPENDENCY_CONFLICT_RESOLUTION_GUIDE.md](./guides/DEPENDENCY_CONFLICT_RESOLUTION_GUIDE.md) | Released |
+| THR-GUID-020 | Thread System - Frequently Asked Questions | [FAQ.md](./guides/FAQ.md) | Released |
+| THR-GUID-021 | 빠른 시작 가이드 | [QUICK_START.kr.md](./guides/QUICK_START.kr.md) | Released |
+| THR-GUID-022 | Quick Start Guide | [QUICK_START.md](./guides/QUICK_START.md) | Released |
+| THR-GUID-023 | 문제 해결 가이드 | [TROUBLESHOOTING.kr.md](./guides/TROUBLESHOOTING.kr.md) | Released |
+| THR-GUID-024 | Troubleshooting Guide | [TROUBLESHOOTING.md](./guides/TROUBLESHOOTING.md) | Released |
+| THR-GUID-025 | Thread System Integration Guide | [README.md](./integration/README.md) | Released |
+| THR-GUID-026 | Metrics System Audit | [metrics_audit.md](./metrics_audit.md) | Released |
 
-int main() {
-    // 4개 워커 스레드로 스레드 풀 생성
-    thread_pool pool(4);
+### Performance (7)
 
-    // 작업 큐에 추가
-    auto future = pool.enqueue([]() {
-        return 42;
-    });
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| THR-PERF-001 | Thread System 성능 벤치마크 | [BENCHMARKS.kr.md](./BENCHMARKS.kr.md) | Released |
+| THR-PERF-002 | Thread System Performance Benchmarks | [BENCHMARKS.md](./BENCHMARKS.md) | Released |
+| THR-PERF-003 | NUMA Topology and Work-Stealing Guide | [NUMA_GUIDE.md](./NUMA_GUIDE.md) | Released |
+| THR-PERF-004 | CI/CD Performance Metrics Integration | [CI_CD_PERFORMANCE.md](./advanced/CI_CD_PERFORMANCE.md) | Released |
+| THR-PERF-005 | Thread System Performance Guide | [PERFORMANCE.kr.md](./advanced/PERFORMANCE.kr.md) | Released |
+| THR-PERF-006 | Thread System Performance Guide | [PERFORMANCE.md](./advanced/PERFORMANCE.md) | Released |
+| THR-PERF-007 | Baseline Performance Metrics | [BASELINE.md](./performance/BASELINE.md) | Released |
 
-    // 결과 대기
-    int result = future.get();
+### Migration (10)
 
-    return 0;
-}
-```
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| THR-MIGR-001 | Error System Migration Guide | [ERROR_SYSTEM_MIGRATION_GUIDE.md](./advanced/ERROR_SYSTEM_MIGRATION_GUIDE.md) | Released |
+| THR-MIGR-002 | Thread System 마이그레이션 가이드 | [MIGRATION.kr.md](./advanced/MIGRATION.kr.md) | Released |
+| THR-MIGR-003 | Thread System Migration Guide | [MIGRATION.md](./advanced/MIGRATION.md) | Released |
+| THR-MIGR-004 | Migration Guide - Thread System | [USER_MIGRATION_GUIDE.md](./advanced/USER_MIGRATION_GUIDE.md) | Released |
+| THR-MIGR-005 | Queue Migration Guide | [QUEUE_MIGRATION_GUIDE.md](./design/QUEUE_MIGRATION_GUIDE.md) | Released |
+| THR-MIGR-006 | Logger Interface 마이그레이션 가이드 | [LOGGER_INTERFACE_MIGRATION_GUIDE.kr.md](./guides/LOGGER_INTERFACE_MIGRATION_GUIDE.kr.md) | Released |
+| THR-MIGR-007 | Logger Interface Migration Guide | [LOGGER_INTERFACE_MIGRATION_GUIDE.md](./guides/LOGGER_INTERFACE_MIGRATION_GUIDE.md) | Released |
+| THR-MIGR-008 | 로그 레벨 마이그레이션 가이드 | [LOG_LEVEL_MIGRATION_GUIDE.kr.md](./guides/LOG_LEVEL_MIGRATION_GUIDE.kr.md) | Released |
+| THR-MIGR-009 | Log Level Migration Guide | [LOG_LEVEL_MIGRATION_GUIDE.md](./guides/LOG_LEVEL_MIGRATION_GUIDE.md) | Released |
+| THR-MIGR-010 | Thread Pool API Migration Guide | [THREAD_POOL_API_MIGRATION_GUIDE.md](./guides/THREAD_POOL_API_MIGRATION_GUIDE.md) | Released |
 
-#### Typed Thread Pool 사용
+### Integration (1)
 
-```cpp
-#include <kcenon/thread/typed_thread_pool.h>
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| THR-INTR-001 | Integration Guide - Thread System | [INTEGRATION.md](./advanced/INTEGRATION.md) | Released |
 
-using namespace kcenon::thread;
+### Quality (5)
 
-int main() {
-    // int 타입 작업을 처리하는 스레드 풀
-    typed_thread_pool<int> pool(4);
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| THR-QUAL-001 | Thread System 프로덕션 품질 | [PRODUCTION_QUALITY.kr.md](./PRODUCTION_QUALITY.kr.md) | Released |
+| THR-QUAL-002 | Thread System Production Quality | [PRODUCTION_QUALITY.md](./PRODUCTION_QUALITY.md) | Released |
+| THR-QUAL-003 | 품질 및 QA 가이드 | [QUALITY.kr.md](./advanced/QUALITY.kr.md) | Released |
+| THR-QUAL-004 | Quality & QA Guide | [QUALITY.md](./advanced/QUALITY.md) | Released |
+| THR-QUAL-005 | Test Coverage Guide | [COVERAGE_GUIDE.md](./guides/COVERAGE_GUIDE.md) | Released |
 
-    // 타입 안전 작업 추가
-    pool.enqueue(10);
-    pool.enqueue(20);
-    pool.enqueue(30);
+### Architecture Decision Records (2)
 
-    // 작업 처리 함수 등록
-    pool.set_process_function([](int value) {
-        std::cout << "Processing: " << value << std::endl;
-    });
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| THR-ADR-001 | ADR-001: v3.0 API Surface and Compatibility Policy | [ADR-001-v3-api-surface.md](./adr/ADR-001-v3-api-surface.md) | Released |
+| THR-ADR-002 | ADR-002: typed_pool Template Hierarchy Evaluation | [ADR-002-typed-pool-evaluation.md](./adr/ADR-002-typed-pool-evaluation.md) | Released |
 
-    pool.start();
+### Project (14)
 
-    return 0;
-}
-```
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| THR-PROJ-001 | thread_system 변경 이력 | [CHANGELOG.kr.md](./CHANGELOG.kr.md) | Released |
+| THR-PROJ-002 | thread_system Changelog | [CHANGELOG.md](./CHANGELOG.md) | Released |
+| THR-PROJ-003 | Thread System 프로젝트 구조 | [PROJECT_STRUCTURE.kr.md](./PROJECT_STRUCTURE.kr.md) | Released |
+| THR-PROJ-004 | Thread System Project Structure | [PROJECT_STRUCTURE.md](./PROJECT_STRUCTURE.md) | Released |
+| THR-PROJ-005 | Queue Backward Compatibility | [QUEUE_BACKWARD_COMPATIBILITY.md](./QUEUE_BACKWARD_COMPATIBILITY.md) | Released |
+| THR-PROJ-006 | SOUP List &mdash; thread_system | [SOUP.md](./SOUP.md) | Released |
+| THR-PROJ-007 | 변경 이력 | [CHANGELOG.kr.md](./advanced/CHANGELOG.kr.md) | Released |
+| THR-PROJ-008 | Changelog | [CHANGELOG.md](./advanced/CHANGELOG.md) | Released |
+| THR-PROJ-009 | Thread System에 기여하기 | [CONTRIBUTING.kr.md](./contributing/CONTRIBUTING.kr.md) | Released |
+| THR-PROJ-010 | Contributing to Thread System | [CONTRIBUTING.md](./contributing/CONTRIBUTING.md) | Released |
+| THR-PROJ-011 | Dependency Version Compatibility Matrix | [DEPENDENCY_COMPATIBILITY_MATRIX.kr.md](./guides/DEPENDENCY_COMPATIBILITY_MATRIX.kr.md) | Released |
+| THR-PROJ-012 | Dependency Version Compatibility Matrix | [DEPENDENCY_COMPATIBILITY_MATRIX.md](./guides/DEPENDENCY_COMPATIBILITY_MATRIX.md) | Released |
+| THR-PROJ-013 | License Compatibility Analysis | [LICENSE_COMPATIBILITY.kr.md](./guides/LICENSE_COMPATIBILITY.kr.md) | Released |
+| THR-PROJ-014 | License Compatibility Analysis | [LICENSE_COMPATIBILITY.md](./guides/LICENSE_COMPATIBILITY.md) | Released |
 
-## 의존성
+---
 
-### 필수 의존성
-- **common_system** (Tier 0) - Result<T> 패턴, 인터페이스
-
-### 선택적 의존성
-- 없음 (모든 의존성 필수)
-
-## 성능
-
-| 구현 | Throughput | Latency | Improvement |
-|------|------------|---------|-------------|
-| thread_pool | 1.2M ops/sec | 0.8 μs | 4.5x |
-| typed_thread_pool | 980K ops/sec | 1.0 μs | 3.8x |
-| mpmc_queue | 2.1M ops/sec | 0.5 μs | 5.2x |
-| adaptive_queue | 1.5M ops/sec | 0.7 μs | 4.1x |
-
-**측정 환경**: Apple M1 Max, 10 cores, macOS 14
-
-자세한 벤치마크 결과는 [BENCHMARKS.md](BENCHMARKS.md)를 참조하세요.
-
-## 문서
-
-- [아키텍처](ARCHITECTURE.md) - 시스템 구조 및 설계
-- [기능 목록](FEATURES.md) - 전체 기능 설명
-- [벤치마크](BENCHMARKS.md) - 성능 측정 결과
-- [프로덕션 품질](PRODUCTION_QUALITY.md) - 프로덕션 체크리스트
-- [프로젝트 구조](PROJECT_STRUCTURE.md) - 프로젝트 구조
-- [변경 이력](CHANGELOG.md) - 버전별 변경 사항
-
-### 가이드
-- [빠른 시작](guides/QUICK_START.md)
-- [FAQ](guides/FAQ.md)
-- [문제 해결](guides/TROUBLESHOOTING.md)
-- [모범 사례](guides/BEST_PRACTICES.md)
-
-### 고급 주제
-- [아키텍처 결정 기록](advanced/ARCHITECTURE_DECISIONS.md)
-- [성능 튜닝](advanced/PERFORMANCE_TUNING.md)
-- [Lock-Free 알고리즘](advanced/LOCK_FREE_ALGORITHMS.md)
-
-### Architecture Decision Records (ADR)
-- [ADR-001: v3.0 API Surface and Compatibility Policy](adr/ADR-001-v3-api-surface.md)
-
-## 기여
-
-기여 가이드는 [CONTRIBUTING.md](contributing/CONTRIBUTING.md)를 참조하세요.
-
-## 라이선스
-
-MIT License
-
-## 연락처
-
-문제 보고: https://github.com/kcenon/thread_system/issues
+*Registry generated for issue [#563](https://github.com/kcenon/thread_system/issues/563).*

--- a/docs/SOUP.md
+++ b/docs/SOUP.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # SOUP List &mdash; thread_system
 
+> **SSOT**: This document is the single source of truth for **SOUP List &mdash; thread_system**.
+
 > **Software of Unknown Provenance (SOUP) Register per IEC 62304:2006+AMD1:2015 &sect;8.1.2**
 >
 > This document is the authoritative reference for all external software dependencies.

--- a/docs/adr/ADR-001-v3-api-surface.md
+++ b/docs/adr/ADR-001-v3-api-surface.md
@@ -10,6 +10,8 @@ category: "ADR"
 
 # ADR-001: v3.0 API Surface and Compatibility Policy
 
+> **SSOT**: This document is the single source of truth for **ADR-001: v3.0 API Surface and Compatibility Policy**.
+
 **Status:** Proposed
 **Date:** 2025-12-19
 **Authors:** thread_system maintainers

--- a/docs/adr/ADR-002-typed-pool-evaluation.md
+++ b/docs/adr/ADR-002-typed-pool-evaluation.md
@@ -10,6 +10,8 @@ category: "ADR"
 
 # ADR-002: typed_pool Template Hierarchy Evaluation
 
+> **SSOT**: This document is the single source of truth for **ADR-002: typed_pool Template Hierarchy Evaluation**.
+
 **Status:** Accepted
 **Date:** 2025-12-31
 **Authors:** thread_system maintainers

--- a/docs/advanced/API_REFERENCE.kr.md
+++ b/docs/advanced/API_REFERENCE.kr.md
@@ -10,6 +10,8 @@ category: "API"
 
 # Thread System API Reference
 
+> **SSOT**: This document is the single source of truth for **Thread System API Reference**.
+
 > **Language:** [English](API_REFERENCE.md) | **한국어**
 
 Thread System framework의 완전한 API 문서입니다.

--- a/docs/advanced/API_REFERENCE.md
+++ b/docs/advanced/API_REFERENCE.md
@@ -10,6 +10,8 @@ category: "API"
 
 # Thread System API Reference
 
+> **SSOT**: This document is the single source of truth for **Thread System API Reference**.
+
 > **Language:** **English** | [한국어](API_REFERENCE.kr.md)
 
 Complete API documentation for the Thread System framework.

--- a/docs/advanced/ARCHITECTURE.kr.md
+++ b/docs/advanced/ARCHITECTURE.kr.md
@@ -10,6 +10,8 @@ category: "ARCH"
 
 # Threading Ecosystem 아키텍처
 
+> **SSOT**: This document is the single source of truth for **Threading Ecosystem 아키텍처**.
+
 > **Language:** [English](ARCHITECTURE.md) | **한국어**
 
 ## 목차

--- a/docs/advanced/ARCHITECTURE.md
+++ b/docs/advanced/ARCHITECTURE.md
@@ -10,6 +10,8 @@ category: "ARCH"
 
 # Threading Ecosystem Architecture
 
+> **SSOT**: This document is the single source of truth for **Threading Ecosystem Architecture**.
+
 > **Language:** **English** | [한국어](ARCHITECTURE.kr.md)
 
 ## Table of Contents

--- a/docs/advanced/CHANGELOG.kr.md
+++ b/docs/advanced/CHANGELOG.kr.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # 변경 이력
 
+> **SSOT**: This document is the single source of truth for **변경 이력**.
+
 [English](CHANGELOG.md) | **한국어**
 
 Thread System 프로젝트의 주요 변경사항이 이 파일에 기록됩니다.

--- a/docs/advanced/CHANGELOG.md
+++ b/docs/advanced/CHANGELOG.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # Changelog
 
+> **SSOT**: This document is the single source of truth for **Changelog**.
+
 **English** | [한국어](CHANGELOG.kr.md)
 
 All notable changes to the Thread System project will be documented in this file.

--- a/docs/advanced/CI_CD_PERFORMANCE.md
+++ b/docs/advanced/CI_CD_PERFORMANCE.md
@@ -10,6 +10,8 @@ category: "PERF"
 
 # CI/CD Performance Metrics Integration
 
+> **SSOT**: This document is the single source of truth for **CI/CD Performance Metrics Integration**.
+
 ## Overview
 
 This document describes the automated performance metrics system integrated into the thread_system CI/CD pipeline. The system automatically measures, tracks, and reports performance metrics for every commit and pull request.

--- a/docs/advanced/CPP20_CONCEPTS.kr.md
+++ b/docs/advanced/CPP20_CONCEPTS.kr.md
@@ -10,6 +10,8 @@ category: "API"
 
 # C++20 Concepts 통합
 
+> **SSOT**: This document is the single source of truth for **C++20 Concepts 통합**.
+
 > **Language:** [English](CPP20_CONCEPTS.md) | **한국어**
 
 이 문서는 Thread System의 C++20 Concepts 통합에 대해 설명하며, 스레드 풀 작업에 대한 타입 안전 제약 조건을 제공합니다.

--- a/docs/advanced/CPP20_CONCEPTS.md
+++ b/docs/advanced/CPP20_CONCEPTS.md
@@ -10,6 +10,8 @@ category: "API"
 
 # C++20 Concepts Integration
 
+> **SSOT**: This document is the single source of truth for **C++20 Concepts Integration**.
+
 > **Language:** **English** | [한국어](CPP20_CONCEPTS.kr.md)
 
 This document describes the C++20 Concepts integration in Thread System, providing type-safe constraints for thread pool operations.

--- a/docs/advanced/ERROR_SYSTEM_MIGRATION_GUIDE.md
+++ b/docs/advanced/ERROR_SYSTEM_MIGRATION_GUIDE.md
@@ -10,6 +10,8 @@ category: "MIGR"
 
 # Error System Migration Guide
 
+> **SSOT**: This document is the single source of truth for **Error System Migration Guide**.
+
 **Version:** 1.0.0
 **Date:** 2025-12-19
 **Status:** Phase 3 Complete

--- a/docs/advanced/FAQ.md
+++ b/docs/advanced/FAQ.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Frequently Asked Questions (FAQ)
 
+> **SSOT**: This document is the single source of truth for **Frequently Asked Questions (FAQ)**.
+
 > **Language:** **English** | [한국어](faq.kr.md)
 
 ## General Questions

--- a/docs/advanced/HAZARD_POINTER_DESIGN.md
+++ b/docs/advanced/HAZARD_POINTER_DESIGN.md
@@ -10,6 +10,8 @@ category: "ARCH"
 
 # Hazard Pointer Design Document
 
+> **SSOT**: This document is the single source of truth for **Hazard Pointer Design Document**.
+
 **Version**: 0.1.0.0
 **Date**: 2025-11-08
 **Status**: Design Phase

--- a/docs/advanced/INTEGRATION.md
+++ b/docs/advanced/INTEGRATION.md
@@ -10,6 +10,8 @@ category: "INTR"
 
 # Integration Guide - Thread System
 
+> **SSOT**: This document is the single source of truth for **Integration Guide - Thread System**.
+
 > **Language:** **English** | [한국어](INTEGRATION.kr.md)
 
 ## Overview

--- a/docs/advanced/JOB_CANCELLATION.md
+++ b/docs/advanced/JOB_CANCELLATION.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Job Cancellation System
 
+> **SSOT**: This document is the single source of truth for **Job Cancellation System**.
+
 ## Overview
 
 The thread_system now provides a comprehensive job cancellation mechanism that allows running jobs to be cooperatively cancelled when workers or pools are stopped. This implements a graceful shutdown pattern that gives jobs the opportunity to clean up resources and terminate early.

--- a/docs/advanced/KNOWN_ISSUES.md
+++ b/docs/advanced/KNOWN_ISSUES.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Known Issues
 
+> **SSOT**: This document is the single source of truth for **Known Issues**.
+
 **Version**: 0.3.0.0
 **Last Updated**: 2026-01-11
 **Status**: Active Tracking

--- a/docs/advanced/MIGRATION.kr.md
+++ b/docs/advanced/MIGRATION.kr.md
@@ -10,6 +10,8 @@ category: "MIGR"
 
 # Thread System 마이그레이션 가이드
 
+> **SSOT**: This document is the single source of truth for **Thread System 마이그레이션 가이드**.
+
 > **Language:** [English](MIGRATION.md) | **한국어**
 
 ## 목차

--- a/docs/advanced/MIGRATION.md
+++ b/docs/advanced/MIGRATION.md
@@ -10,6 +10,8 @@ category: "MIGR"
 
 # Thread System Migration Guide
 
+> **SSOT**: This document is the single source of truth for **Thread System Migration Guide**.
+
 > **Language:** **English** | [한국어](MIGRATION.kr.md)
 
 ## Table of Contents

--- a/docs/advanced/PATTERNS.kr.md
+++ b/docs/advanced/PATTERNS.kr.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Thread System: 패턴, 모범 사례 및 문제 해결 가이드
 
+> **SSOT**: This document is the single source of truth for **Thread System: 패턴, 모범 사례 및 문제 해결 가이드**.
+
 > **Language:** [English](PATTERNS.md) | **한국어**
 
 이 포괄적인 가이드는 Thread System 작업 시 패턴, 모범 사례, 피해야 할 안티패턴 및 일반적인 동시성 문제에 대한 해결책을 다룹니다. 이러한 지침을 따르면 효율적이고 유지 관리가 가능하며 버그 없는 동시 애플리케이션을 작성할 수 있습니다.

--- a/docs/advanced/PATTERNS.md
+++ b/docs/advanced/PATTERNS.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Thread System: Patterns, Best Practices, and Troubleshooting Guide
 
+> **SSOT**: This document is the single source of truth for **Thread System: Patterns, Best Practices, and Troubleshooting Guide**.
+
 > **Language:** **English** | [한국어](PATTERNS.kr.md)
 
 This comprehensive guide covers patterns, best practices, antipatterns to avoid, and solutions to common concurrency issues when working with Thread System. Following these guidelines will help you write efficient, maintainable, and bug-free concurrent applications.

--- a/docs/advanced/PERFORMANCE.kr.md
+++ b/docs/advanced/PERFORMANCE.kr.md
@@ -10,6 +10,8 @@ category: "PERF"
 
 # Thread System Performance Guide
 
+> **SSOT**: This document is the single source of truth for **Thread System Performance Guide**.
+
 > **Language:** [English](PERFORMANCE.md) | **한국어**
 
 이 포괄적인 가이드는 Thread System framework의 성능 benchmark, 튜닝 전략 및 최적화 기법을 다룹니다. 모든 측정은 실제 benchmark 데이터와 광범위한 테스트를 기반으로 합니다.

--- a/docs/advanced/PERFORMANCE.md
+++ b/docs/advanced/PERFORMANCE.md
@@ -10,6 +10,8 @@ category: "PERF"
 
 # Thread System Performance Guide
 
+> **SSOT**: This document is the single source of truth for **Thread System Performance Guide**.
+
 > **Language:** **English** | [한국어](PERFORMANCE.kr.md)
 
 This comprehensive guide covers performance benchmarks, tuning strategies, and optimization techniques for the Thread System framework. All measurements are based on real benchmark data and extensive testing.

--- a/docs/advanced/QUALITY.kr.md
+++ b/docs/advanced/QUALITY.kr.md
@@ -10,6 +10,8 @@ category: "QUAL"
 
 # 품질 및 QA 가이드
 
+> **SSOT**: This document is the single source of truth for **품질 및 QA 가이드**.
+
 > **Language:** [English](QUALITY.md) | **한국어**
 
 ## 커버리지

--- a/docs/advanced/QUALITY.md
+++ b/docs/advanced/QUALITY.md
@@ -10,6 +10,8 @@ category: "QUAL"
 
 # Quality & QA Guide
 
+> **SSOT**: This document is the single source of truth for **Quality & QA Guide**.
+
 > **Language:** **English** | [한국어](QUALITY.kr.md)
 
 ## Coverage

--- a/docs/advanced/QUEUE_SELECTION_GUIDE.md
+++ b/docs/advanced/QUEUE_SELECTION_GUIDE.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Queue Selection Guide
 
+> **SSOT**: This document is the single source of truth for **Queue Selection Guide**.
+
 > **Language:** **English** | [한국어](QUEUE_SELECTION_GUIDE.kr.md)
 
 This guide helps you choose the right queue implementation for your use case.

--- a/docs/advanced/README.kr.md
+++ b/docs/advanced/README.kr.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Thread System 문서
 
+> **SSOT**: This document is the single source of truth for **Thread System 문서**.
+
 Thread System 프레임워크에 대한 포괄적인 문서에 오신 것을 환영합니다. 이 가이드는 여러분의 역할과 필요에 따라 올바른 문서를 찾는 데 도움을 줍니다.
 
 > **Language:** [English](README.md) | **한국어**

--- a/docs/advanced/README.md
+++ b/docs/advanced/README.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Thread System Documentation
 
+> **SSOT**: This document is the single source of truth for **Thread System Documentation**.
+
 > **Language:** **English** | [한국어](README.kr.md)
 
 Welcome to the comprehensive documentation for the Thread System framework. This guide helps you navigate to the right documentation based on your role and needs.

--- a/docs/advanced/STRUCTURE.kr.md
+++ b/docs/advanced/STRUCTURE.kr.md
@@ -10,6 +10,8 @@ category: "ARCH"
 
 # Thread System - 새로운 구조
 
+> **SSOT**: This document is the single source of truth for **Thread System - 새로운 구조**.
+
 [English](STRUCTURE.md) | **한국어**
 
 ## 디렉토리 구조

--- a/docs/advanced/STRUCTURE.md
+++ b/docs/advanced/STRUCTURE.md
@@ -10,6 +10,8 @@ category: "ARCH"
 
 # Thread System - New Structure
 
+> **SSOT**: This document is the single source of truth for **Thread System - New Structure**.
+
 **English** | [한국어](STRUCTURE.kr.md)
 
 ## Directory Layout

--- a/docs/advanced/THREAD_SYSTEM_ARCHITECTURE.md
+++ b/docs/advanced/THREAD_SYSTEM_ARCHITECTURE.md
@@ -10,6 +10,8 @@ category: "ARCH"
 
 # Architecture - Thread System
 
+> **SSOT**: This document is the single source of truth for **Architecture - Thread System**.
+
 > **Language:** **English** | [한국어](ARCHITECTURE.kr.md)
 
 ## Overview

--- a/docs/advanced/USER_GUIDE.kr.md
+++ b/docs/advanced/USER_GUIDE.kr.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Thread System 사용자 가이드
 
+> **SSOT**: This document is the single source of truth for **Thread System 사용자 가이드**.
+
 > **Language:** [English](USER_GUIDE.md) | **한국어**
 
 ## 빌드

--- a/docs/advanced/USER_GUIDE.md
+++ b/docs/advanced/USER_GUIDE.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Thread System User Guide
 
+> **SSOT**: This document is the single source of truth for **Thread System User Guide**.
+
 > **Language:** **English** | [한국어](USER_GUIDE.kr.md)
 
 ## Build

--- a/docs/advanced/USER_MIGRATION_GUIDE.md
+++ b/docs/advanced/USER_MIGRATION_GUIDE.md
@@ -10,6 +10,8 @@ category: "MIGR"
 
 # Migration Guide - Thread System
 
+> **SSOT**: This document is the single source of truth for **Migration Guide - Thread System**.
+
 > **Language:** **English** | [한국어](MIGRATION.kr.md)
 
 ## Overview

--- a/docs/advanced/faq.kr.md
+++ b/docs/advanced/faq.kr.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # 자주 묻는 질문 (FAQ)
 
+> **SSOT**: This document is the single source of truth for **자주 묻는 질문 (FAQ)**.
+
 > **Language:** [English](faq.md) | **한국어**
 
 ## 일반 질문

--- a/docs/contributing/CONTRIBUTING.kr.md
+++ b/docs/contributing/CONTRIBUTING.kr.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # Thread System에 기여하기
 
+> **SSOT**: This document is the single source of truth for **Thread System에 기여하기**.
+
 > **Language:** [English](CONTRIBUTING.md) | **한국어**
 
 ## 목차

--- a/docs/contributing/CONTRIBUTING.md
+++ b/docs/contributing/CONTRIBUTING.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # Contributing to Thread System
 
+> **SSOT**: This document is the single source of truth for **Contributing to Thread System**.
+
 > **Language:** **English** | [한국어](CONTRIBUTING.kr.md)
 
 ## Table of Contents

--- a/docs/design/QUEUE_MIGRATION_GUIDE.md
+++ b/docs/design/QUEUE_MIGRATION_GUIDE.md
@@ -10,6 +10,8 @@ category: "MIGR"
 
 # Queue Migration Guide
 
+> **SSOT**: This document is the single source of truth for **Queue Migration Guide**.
+
 **Version**: 0.1.0.0
 **Issue**: #439 (Phase 1.3), #448 (Phase 1.3.1)
 **Status**: Active

--- a/docs/design/QUEUE_POLICY_DESIGN.md
+++ b/docs/design/QUEUE_POLICY_DESIGN.md
@@ -10,6 +10,8 @@ category: "ARCH"
 
 # Queue Policy Interface Design
 
+> **SSOT**: This document is the single source of truth for **Queue Policy Interface Design**.
+
 **Version**: 0.1.1.0
 **Issue**: #437 (Phase 1.1), #438 (Phase 1.2)
 **Status**: Implementation Complete

--- a/docs/guides/BUILD_GUIDE.kr.md
+++ b/docs/guides/BUILD_GUIDE.kr.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Platform-Specific Build Guide
 
+> **SSOT**: This document is the single source of truth for **Platform-Specific Build Guide**.
+
 > **Language:** [English](BUILD_GUIDE.md) | **한국어**
 
 ## 개요

--- a/docs/guides/BUILD_GUIDE.md
+++ b/docs/guides/BUILD_GUIDE.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Platform-Specific Build Guide
 
+> **SSOT**: This document is the single source of truth for **Platform-Specific Build Guide**.
+
 > **Language:** **English** | [한국어](BUILD_GUIDE.kr.md)
 
 ## Overview

--- a/docs/guides/COVERAGE_GUIDE.md
+++ b/docs/guides/COVERAGE_GUIDE.md
@@ -10,6 +10,8 @@ category: "QUAL"
 
 # Test Coverage Guide
 
+> **SSOT**: This document is the single source of truth for **Test Coverage Guide**.
+
 ## Current Status
 
 - **Overall Coverage**: 72% (Target: 80%)

--- a/docs/guides/DEPENDENCY_COMPATIBILITY_MATRIX.kr.md
+++ b/docs/guides/DEPENDENCY_COMPATIBILITY_MATRIX.kr.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # Dependency Version Compatibility Matrix
 
+> **SSOT**: This document is the single source of truth for **Dependency Version Compatibility Matrix**.
+
 > **Language:** [English](DEPENDENCY_COMPATIBILITY_MATRIX.md) | **한국어**
 
 ## 핵심 의존성

--- a/docs/guides/DEPENDENCY_COMPATIBILITY_MATRIX.md
+++ b/docs/guides/DEPENDENCY_COMPATIBILITY_MATRIX.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # Dependency Version Compatibility Matrix
 
+> **SSOT**: This document is the single source of truth for **Dependency Version Compatibility Matrix**.
+
 > **Language:** **English** | [한국어](DEPENDENCY_COMPATIBILITY_MATRIX.kr.md)
 
 ## Core Dependencies

--- a/docs/guides/DEPENDENCY_CONFLICT_RESOLUTION_GUIDE.kr.md
+++ b/docs/guides/DEPENDENCY_CONFLICT_RESOLUTION_GUIDE.kr.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Dependency Conflict Resolution Guide
 
+> **SSOT**: This document is the single source of truth for **Dependency Conflict Resolution Guide**.
+
 > **Language:** [English](DEPENDENCY_CONFLICT_RESOLUTION_GUIDE.md) | **한국어**
 
 ## 개요

--- a/docs/guides/DEPENDENCY_CONFLICT_RESOLUTION_GUIDE.md
+++ b/docs/guides/DEPENDENCY_CONFLICT_RESOLUTION_GUIDE.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Dependency Conflict Resolution Guide
 
+> **SSOT**: This document is the single source of truth for **Dependency Conflict Resolution Guide**.
+
 > **Language:** **English** | [한국어](DEPENDENCY_CONFLICT_RESOLUTION_GUIDE.kr.md)
 
 ## Overview

--- a/docs/guides/FAQ.md
+++ b/docs/guides/FAQ.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Thread System - Frequently Asked Questions
 
+> **SSOT**: This document is the single source of truth for **Thread System - Frequently Asked Questions**.
+
 > **Version:** 0.1.0
 > **Last Updated:** 2025-11-11
 > **Audience:** Users, Developers

--- a/docs/guides/LICENSE_COMPATIBILITY.kr.md
+++ b/docs/guides/LICENSE_COMPATIBILITY.kr.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # License Compatibility Analysis
 
+> **SSOT**: This document is the single source of truth for **License Compatibility Analysis**.
+
 > **Language:** [English](LICENSE_COMPATIBILITY.md) | **한국어**
 
 ## 프로젝트 라이선스

--- a/docs/guides/LICENSE_COMPATIBILITY.md
+++ b/docs/guides/LICENSE_COMPATIBILITY.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # License Compatibility Analysis
 
+> **SSOT**: This document is the single source of truth for **License Compatibility Analysis**.
+
 > **Language:** **English** | [한국어](LICENSE_COMPATIBILITY.kr.md)
 
 ## Project License

--- a/docs/guides/LOGGER_INTERFACE_MIGRATION_GUIDE.kr.md
+++ b/docs/guides/LOGGER_INTERFACE_MIGRATION_GUIDE.kr.md
@@ -10,6 +10,8 @@ category: "MIGR"
 
 # Logger Interface 마이그레이션 가이드
 
+> **SSOT**: This document is the single source of truth for **Logger Interface 마이그레이션 가이드**.
+
 > **Language:** [English](LOGGER_INTERFACE_MIGRATION_GUIDE.md) | **한국어**
 
 **버전:** 1.0

--- a/docs/guides/LOGGER_INTERFACE_MIGRATION_GUIDE.md
+++ b/docs/guides/LOGGER_INTERFACE_MIGRATION_GUIDE.md
@@ -10,6 +10,8 @@ category: "MIGR"
 
 # Logger Interface Migration Guide
 
+> **SSOT**: This document is the single source of truth for **Logger Interface Migration Guide**.
+
 > **Language:** **English** | [한국어](LOGGER_INTERFACE_MIGRATION_GUIDE.kr.md)
 
 **Version:** 0.1.0

--- a/docs/guides/LOG_LEVEL_MIGRATION_GUIDE.kr.md
+++ b/docs/guides/LOG_LEVEL_MIGRATION_GUIDE.kr.md
@@ -10,6 +10,8 @@ category: "MIGR"
 
 # 로그 레벨 마이그레이션 가이드
 
+> **SSOT**: This document is the single source of truth for **로그 레벨 마이그레이션 가이드**.
+
 > **Language:** [English](LOG_LEVEL_MIGRATION_GUIDE.md) | **한국어**
 
 **버전:** 1.0

--- a/docs/guides/LOG_LEVEL_MIGRATION_GUIDE.md
+++ b/docs/guides/LOG_LEVEL_MIGRATION_GUIDE.md
@@ -10,6 +10,8 @@ category: "MIGR"
 
 # Log Level Migration Guide
 
+> **SSOT**: This document is the single source of truth for **Log Level Migration Guide**.
+
 > **Language:** **English** | [한국어](LOG_LEVEL_MIGRATION_GUIDE.kr.md)
 
 **Version:** 0.1.0

--- a/docs/guides/QUICK_START.kr.md
+++ b/docs/guides/QUICK_START.kr.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # 빠른 시작 가이드
 
+> **SSOT**: This document is the single source of truth for **빠른 시작 가이드**.
+
 > **Language:** [English](QUICK_START.md) | **한국어**
 
 Thread System을 5분 안에 시작해보세요.

--- a/docs/guides/QUICK_START.md
+++ b/docs/guides/QUICK_START.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Quick Start Guide
 
+> **SSOT**: This document is the single source of truth for **Quick Start Guide**.
+
 > **Language:** **English** | [한국어](QUICK_START.kr.md)
 
 Get up and running with Thread System in 5 minutes.

--- a/docs/guides/THREAD_POOL_API_MIGRATION_GUIDE.md
+++ b/docs/guides/THREAD_POOL_API_MIGRATION_GUIDE.md
@@ -10,6 +10,8 @@ category: "MIGR"
 
 # Thread Pool API Migration Guide
 
+> **SSOT**: This document is the single source of truth for **Thread Pool API Migration Guide**.
+
 This guide helps you migrate from deprecated `thread_pool` methods to their recommended replacements. All deprecated methods will be removed in v2.0.
 
 ## Deprecated Methods Overview

--- a/docs/guides/TROUBLESHOOTING.kr.md
+++ b/docs/guides/TROUBLESHOOTING.kr.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # 문제 해결 가이드
 
+> **SSOT**: This document is the single source of truth for **문제 해결 가이드**.
+
 > **Language:** [English](TROUBLESHOOTING.md) | **한국어**
 
 Thread System 작업 시 자주 발생하는 문제와 해결 방법을 다룹니다.

--- a/docs/guides/TROUBLESHOOTING.md
+++ b/docs/guides/TROUBLESHOOTING.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Troubleshooting Guide
 
+> **SSOT**: This document is the single source of truth for **Troubleshooting Guide**.
+
 > **Language:** **English** | [한국어](TROUBLESHOOTING.kr.md)
 
 This guide covers common issues and their solutions when working with Thread System.

--- a/docs/integration/README.md
+++ b/docs/integration/README.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Thread System Integration Guide
 
+> **SSOT**: This document is the single source of truth for **Thread System Integration Guide**.
+
 ## Overview
 
 This directory contains integration guides for using thread_system with other KCENON systems.

--- a/docs/metrics_audit.md
+++ b/docs/metrics_audit.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Metrics System Audit
 
+> **SSOT**: This document is the single source of truth for **Metrics System Audit**.
+
 ## Overview
 
 This document provides a comprehensive audit of the metrics system in thread_system,

--- a/docs/performance/BASELINE.md
+++ b/docs/performance/BASELINE.md
@@ -10,6 +10,8 @@ category: "PERF"
 
 # Baseline Performance Metrics
 
+> **SSOT**: This document is the single source of truth for **Baseline Performance Metrics**.
+
 **Document Version**: 1.0
 **Created**: 2025-10-07
 **System**: thread_system


### PR DESCRIPTION
## Summary

- Create `docs/README.md` as the single source of truth documentation index for thread_system
- Add SSOT declarations (`> **SSOT**: ...`) to each authoritative document header
- Registry table lists all 82 documents with doc_id, topic, authority document link, and status
- Documents grouped by category (Architecture, API, Features, Guides, etc.)
- Verified no duplicate doc_id values and all file links are valid

## Test Plan

- [x] All 82 document entries have valid file links
- [x] No duplicate doc_id values within the project
- [x] SSOT declarations added to authoritative documents
- [x] Registry follows the format specified in kcenon/common_system#563

Closes kcenon/common_system#563