### PR TITLE
docs: add @file Doxygen blocks to public API headers

### DIFF
--- a/include/kcenon/thread/adapters/job_queue_adapter.h
+++ b/include/kcenon/thread/adapters/job_queue_adapter.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file job_queue_adapter.h
+ * @brief Adapter bridging job_queue to pool_queue_adapter_interface.
+ *
+ * @see pool_queue_adapter_interface
+ */
+
 #pragma once
 
 #include <kcenon/thread/interfaces/pool_queue_adapter.h>

--- a/include/kcenon/thread/adapters/policy_queue_adapter.h
+++ b/include/kcenon/thread/adapters/policy_queue_adapter.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file policy_queue_adapter.h
+ * @brief Adapter bridging policy_queue to pool_queue_adapter_interface.
+ *
+ * @see pool_queue_adapter_interface
+ */
+
 #pragma once
 
 #include <kcenon/thread/interfaces/pool_queue_adapter.h>

--- a/include/kcenon/thread/compatibility.h
+++ b/include/kcenon/thread/compatibility.h
@@ -2,6 +2,12 @@
 // Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file compatibility.h
+ * @brief Backward-compatible type aliases for renamed thread system components.
+ *
+ */
+
 #pragma once
 
 // Forward declare canonical namespaces to allow aliasing without including

--- a/include/kcenon/thread/concurrent/concurrent_queue.h
+++ b/include/kcenon/thread/concurrent/concurrent_queue.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file concurrent_queue.h
+ * @brief Thread-safe MPMC queue with blocking wait support.
+ *
+ * @see job_queue For the public queue API
+ */
+
 #pragma once
 
 #include <atomic>

--- a/include/kcenon/thread/core/atomic_shared_ptr.h
+++ b/include/kcenon/thread/core/atomic_shared_ptr.h
@@ -2,6 +2,12 @@
 // Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file atomic_shared_ptr.h
+ * @brief Thread-safe atomic shared_ptr wrapper with explicit memory ordering.
+ *
+ */
+
 #pragma once
 
 #include <atomic>

--- a/include/kcenon/thread/core/backpressure_config.h
+++ b/include/kcenon/thread/core/backpressure_config.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file backpressure_config.h
+ * @brief Configuration for backpressure and queue overflow policies.
+ *
+ * @see backpressure_job_queue
+ */
+
 #pragma once
 
 /**

--- a/include/kcenon/thread/core/backpressure_job_queue.h
+++ b/include/kcenon/thread/core/backpressure_job_queue.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file backpressure_job_queue.h
+ * @brief Job queue with backpressure mechanisms for overflow and rate limiting.
+ *
+ * @see job_queue For the base queue implementation
+ */
+
 #pragma once
 
 /**

--- a/include/kcenon/thread/core/callback_job.h
+++ b/include/kcenon/thread/core/callback_job.h
@@ -2,6 +2,14 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file callback_job.h
+ * @brief Specialized job class that encapsulates user-defined callbacks.
+ *
+ * @see job For the base job class
+ * @see job_builder For fluent job construction
+ */
+
 #pragma once
 
 #include <functional>

--- a/include/kcenon/thread/core/configuration_manager.h
+++ b/include/kcenon/thread/core/configuration_manager.h
@@ -2,6 +2,12 @@
 // Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file configuration_manager.h
+ * @brief Runtime configuration management with typed key-value storage.
+ *
+ */
+
 #pragma once
 
 #include <any>

--- a/include/kcenon/thread/core/event_bus.h
+++ b/include/kcenon/thread/core/event_bus.h
@@ -2,6 +2,12 @@
 // Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file event_bus.h
+ * @brief Type-safe publish-subscribe event bus for thread system events.
+ *
+ */
+
 #pragma once
 
 #include <any>

--- a/include/kcenon/thread/core/hazard_pointer.h
+++ b/include/kcenon/thread/core/hazard_pointer.h
@@ -2,6 +2,14 @@
 // Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file hazard_pointer.h
+ * @brief Hazard pointer implementation for lock-free memory reclamation.
+ *
+ * @see safe_hazard_pointer For the improved thread-local variant
+ * @see lockfree_job_queue For the primary consumer
+ */
+
 #pragma once
 
 #include <algorithm>

--- a/include/kcenon/thread/core/job.h
+++ b/include/kcenon/thread/core/job.h
@@ -2,6 +2,18 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file job.h
+ * @brief Base job class for schedulable work units in the thread system.
+ *
+ * Defines the core job abstraction used throughout the thread system.
+ * Jobs support composition via a fluent interface for attaching callbacks,
+ * priority, retry policies, timeout, and cancellation tokens.
+ *
+ * @see thread_base For the worker thread that executes jobs
+ * @see job_queue For the thread-safe queue that stores jobs
+ */
+
 #pragma once
 
 #include <kcenon/thread/utils/formatter.h>

--- a/include/kcenon/thread/core/job_builder.h
+++ b/include/kcenon/thread/core/job_builder.h
@@ -2,6 +2,14 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file job_builder.h
+ * @brief Fluent builder for creating and configuring jobs with composition.
+ *
+ * @see job For the base job class
+ * @see callback_job For lambda-based jobs
+ */
+
 #pragma once
 
 #include "job.h"

--- a/include/kcenon/thread/core/job_queue.h
+++ b/include/kcenon/thread/core/job_queue.h
@@ -2,6 +2,18 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file job_queue.h
+ * @brief Thread-safe FIFO job queue with optional bounded size.
+ *
+ * Provides a mutex-based job queue supporting enqueue, blocking/non-blocking
+ * dequeue, batch operations, and graceful shutdown. Implements both
+ * scheduler_interface and queue_capabilities_interface.
+ *
+ * @see adaptive_job_queue For the auto-switching mutex/lock-free queue
+ * @see lockfree_job_queue For the lock-free Michael-Scott queue
+ */
+
 #pragma once
 
 #include "job.h"

--- a/include/kcenon/thread/core/job_types.h
+++ b/include/kcenon/thread/core/job_types.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file job_types.h
+ * @brief Job priority levels and type definitions for type-based scheduling.
+ *
+ * @see typed_thread_pool For the pool that uses these types
+ */
+
 #pragma once
 
 #include <memory>

--- a/include/kcenon/thread/core/lifecycle_controller.h
+++ b/include/kcenon/thread/core/lifecycle_controller.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file lifecycle_controller.h
+ * @brief Centralized thread lifecycle state and synchronization management.
+ *
+ * @see thread_base For the class that uses this controller
+ */
+
 #pragma once
 
 #include "thread_conditions.h"

--- a/include/kcenon/thread/core/log_level.h
+++ b/include/kcenon/thread/core/log_level.h
@@ -1,6 +1,12 @@
 // BSD 3-Clause License
 // Copyright (c) 2024, kcenon
 
+/**
+ * @file log_level.h
+ * @brief Logging severity levels for the thread system.
+ *
+ */
+
 #pragma once
 
 #include <cstdint>

--- a/include/kcenon/thread/core/numa_thread_pool.h
+++ b/include/kcenon/thread/core/numa_thread_pool.h
@@ -2,6 +2,14 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file numa_thread_pool.h
+ * @brief NUMA-aware thread pool optimized for Non-Uniform Memory Access architectures.
+ *
+ * @see thread_pool For the standard thread pool
+ * @see numa_topology For NUMA node detection
+ */
+
 #pragma once
 
 #include <kcenon/thread/core/thread_pool.h>

--- a/include/kcenon/thread/core/retry_policy.h
+++ b/include/kcenon/thread/core/retry_policy.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file retry_policy.h
+ * @brief Retry policy with configurable strategies: fixed, linear, and exponential backoff.
+ *
+ * @see job For retry integration via composition
+ */
+
 #pragma once
 
 #include <chrono>

--- a/include/kcenon/thread/core/safe_hazard_pointer.h
+++ b/include/kcenon/thread/core/safe_hazard_pointer.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file safe_hazard_pointer.h
+ * @brief Thread-local hazard pointer with explicit memory ordering for safe reclamation.
+ *
+ * @see hazard_pointer For the basic implementation
+ */
+
 #pragma once
 
 #include <algorithm>

--- a/include/kcenon/thread/core/service_registry.h
+++ b/include/kcenon/thread/core/service_registry.h
@@ -3,6 +3,12 @@
  * Copyright (c) 2025, DongCheol Shin
  */
 
+/**
+ * @file service_registry.h
+ * @brief Lightweight service registry for dependency lookup within the thread system.
+ *
+ */
+
 #pragma once
 
 #include <any>

--- a/include/kcenon/thread/core/sync_primitives.h
+++ b/include/kcenon/thread/core/sync_primitives.h
@@ -2,6 +2,12 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file sync_primitives.h
+ * @brief RAII-based synchronization primitives including scoped lock with timeout.
+ *
+ */
+
 #pragma once
 
 #include <mutex>

--- a/include/kcenon/thread/core/thread_base.h
+++ b/include/kcenon/thread/core/thread_base.h
@@ -2,6 +2,19 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file thread_base.h
+ * @brief Foundational worker thread class with lifecycle management.
+ *
+ * Provides the base class for all worker threads in the thread system.
+ * Supports both std::jthread (C++20) and std::thread with unified
+ * start/stop lifecycle, periodic wake intervals, and customizable
+ * work hooks (before_start, do_work, after_stop).
+ *
+ * @see job For the work units processed by threads
+ * @see thread_worker For the specialized worker that processes job_queue
+ */
+
 #pragma once
 
 /**

--- a/include/kcenon/thread/core/thread_conditions.h
+++ b/include/kcenon/thread/core/thread_conditions.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file thread_conditions.h
+ * @brief Enumeration of thread lifecycle states (starting, running, stopping, stopped).
+ *
+ * @see thread_base For the class that uses these states
+ */
+
 #pragma once
 
 #include <kcenon/thread/utils/formatter.h>

--- a/include/kcenon/thread/core/thread_impl.h
+++ b/include/kcenon/thread/core/thread_impl.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file thread_impl.h
+ * @brief Thread implementation abstraction bridging std::jthread and std::thread.
+ *
+ * @see thread_base For the public API built on this abstraction
+ */
+
 #pragma once
 
 #include <memory>

--- a/include/kcenon/thread/core/thread_logger.h
+++ b/include/kcenon/thread/core/thread_logger.h
@@ -2,6 +2,12 @@
 // Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file thread_logger.h
+ * @brief Internal logging interface for the thread system.
+ *
+ */
+
 #pragma once
 
 #include <string>

--- a/include/kcenon/thread/core/thread_pool_builder.h
+++ b/include/kcenon/thread/core/thread_pool_builder.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file thread_pool_builder.h
+ * @brief Fluent builder for creating and configuring thread pools.
+ *
+ * @see thread_pool For the resulting pool type
+ */
+
 #pragma once
 
 #include <kcenon/thread/core/thread_pool.h>

--- a/include/kcenon/thread/core/thread_worker.h
+++ b/include/kcenon/thread/core/thread_worker.h
@@ -1,3 +1,11 @@
+/**
+ * @file thread_worker.h
+ * @brief Specialized worker thread that processes jobs from a job_queue.
+ *
+ * @see thread_base For the base worker class
+ * @see job_queue For the queue this worker consumes
+ */
+
 #pragma once
 
 // BSD 3-Clause License

--- a/include/kcenon/thread/core/token_bucket.h
+++ b/include/kcenon/thread/core/token_bucket.h
@@ -2,6 +2,12 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file token_bucket.h
+ * @brief Lock-free token bucket rate limiter for controlling throughput.
+ *
+ */
+
 #pragma once
 
 #include <atomic>

--- a/include/kcenon/thread/core/typed_thread_worker.h
+++ b/include/kcenon/thread/core/typed_thread_worker.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file typed_thread_worker.h
+ * @brief Worker thread specialized for typed_thread_pool with priority queues.
+ *
+ * @see typed_thread_pool For the pool that manages these workers
+ */
+
 #pragma once
 
 // Public forwarding header for typed_thread_worker

--- a/include/kcenon/thread/dag/dag_config.h
+++ b/include/kcenon/thread/dag/dag_config.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file dag_config.h
+ * @brief Configuration for DAG scheduler including failure handling policies.
+ *
+ * @see dag_scheduler For the scheduler that uses this config
+ */
+
 #pragma once
 
 /**

--- a/include/kcenon/thread/dag/dag_job.h
+++ b/include/kcenon/thread/dag/dag_job.h
@@ -2,6 +2,14 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file dag_job.h
+ * @brief DAG-aware job with dependency tracking and unique identifiers.
+ *
+ * @see dag_scheduler For dependency-based execution
+ * @see dag_job_builder For fluent job construction
+ */
+
 #pragma once
 
 #include <kcenon/thread/core/job.h>

--- a/include/kcenon/thread/dag/dag_job_builder.h
+++ b/include/kcenon/thread/dag/dag_job_builder.h
@@ -2,6 +2,14 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file dag_job_builder.h
+ * @brief Fluent builder for creating dag_job instances with dependencies.
+ *
+ * @see dag_job For the job type
+ * @see dag_scheduler For the scheduler
+ */
+
 #pragma once
 
 #include "dag_job.h"

--- a/include/kcenon/thread/dag/dag_scheduler.h
+++ b/include/kcenon/thread/dag/dag_scheduler.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file dag_scheduler.h
+ * @brief DAG-based job scheduler with dependency management and topological execution.
+ *
+ * @see dag_job For the dependency-aware job type
+ */
+
 #pragma once
 
 #include "dag_job.h"

--- a/include/kcenon/thread/diagnostics/bottleneck_report.h
+++ b/include/kcenon/thread/diagnostics/bottleneck_report.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file bottleneck_report.h
+ * @brief Bottleneck detection and reporting for thread pool performance analysis.
+ *
+ * @see thread_pool_diagnostics
+ */
+
 #pragma once
 
 #include <cstddef>

--- a/include/kcenon/thread/diagnostics/execution_event.h
+++ b/include/kcenon/thread/diagnostics/execution_event.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file execution_event.h
+ * @brief Job execution event types and listener interface for tracing.
+ *
+ * @see thread_pool_diagnostics
+ */
+
 #pragma once
 
 #include <chrono>

--- a/include/kcenon/thread/diagnostics/health_status.h
+++ b/include/kcenon/thread/diagnostics/health_status.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file health_status.h
+ * @brief Health status thresholds and monitoring for thread pools.
+ *
+ * @see thread_pool_diagnostics
+ */
+
 #pragma once
 
 #include <chrono>

--- a/include/kcenon/thread/diagnostics/job_info.h
+++ b/include/kcenon/thread/diagnostics/job_info.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file job_info.h
+ * @brief Job information snapshot for diagnostics and monitoring.
+ *
+ * @see thread_pool_diagnostics
+ */
+
 #pragma once
 
 #include <chrono>

--- a/include/kcenon/thread/diagnostics/thread_info.h
+++ b/include/kcenon/thread/diagnostics/thread_info.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file thread_info.h
+ * @brief Worker thread state information for diagnostics.
+ *
+ * @see thread_pool_diagnostics
+ */
+
 #pragma once
 
 #include "job_info.h"

--- a/include/kcenon/thread/diagnostics/thread_pool_diagnostics.h
+++ b/include/kcenon/thread/diagnostics/thread_pool_diagnostics.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file thread_pool_diagnostics.h
+ * @brief Runtime diagnostics, health monitoring, and execution tracing for thread pools.
+ *
+ * @see thread_pool For the pool being diagnosed
+ */
+
 #pragma once
 
 /**

--- a/include/kcenon/thread/impl/typed_pool/aging_typed_job.h
+++ b/include/kcenon/thread/impl/typed_pool/aging_typed_job.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file aging_typed_job.h
+ * @brief Typed job with priority aging support to prevent starvation.
+ *
+ * @see aging_typed_job_queue_t For the queue that ages these jobs
+ */
+
 #pragma once
 
 #include "typed_job.h"

--- a/include/kcenon/thread/impl/typed_pool/aging_typed_job_queue.h
+++ b/include/kcenon/thread/impl/typed_pool/aging_typed_job_queue.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file aging_typed_job_queue.h
+ * @brief Priority queue with aging to prevent low-priority job starvation.
+ *
+ * @see typed_thread_pool For the pool that uses this queue
+ */
+
 #pragma once
 
 #include "aging_typed_job.h"

--- a/include/kcenon/thread/impl/typed_pool/callback_typed_job.h
+++ b/include/kcenon/thread/impl/typed_pool/callback_typed_job.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file callback_typed_job.h
+ * @brief Callback-based typed job for priority-aware lambda execution.
+ *
+ * @see typed_thread_pool
+ */
+
 #pragma once
 
 #include "typed_job.h"

--- a/include/kcenon/thread/impl/typed_pool/job_types.h
+++ b/include/kcenon/thread/impl/typed_pool/job_types.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file job_types.h
+ * @brief Job type definitions for the typed thread pool.
+ *
+ * @see typed_thread_pool
+ */
+
 #pragma once
 
 #include <kcenon/thread/utils/formatter.h>

--- a/include/kcenon/thread/impl/typed_pool/priority_aging_config.h
+++ b/include/kcenon/thread/impl/typed_pool/priority_aging_config.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file priority_aging_config.h
+ * @brief Configuration for priority aging and starvation prevention.
+ *
+ * @see aging_typed_job_queue_t
+ */
+
 #pragma once
 
 /**

--- a/include/kcenon/thread/impl/typed_pool/typed_job.h
+++ b/include/kcenon/thread/impl/typed_pool/typed_job.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file typed_job.h
+ * @brief Base typed job carrying a specific priority level.
+ *
+ * @see typed_thread_pool
+ */
+
 #pragma once
 
 #include <kcenon/thread/core/job.h>

--- a/include/kcenon/thread/impl/typed_pool/typed_thread_pool.h
+++ b/include/kcenon/thread/impl/typed_pool/typed_thread_pool.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file typed_thread_pool.h
+ * @brief Type-based thread pool with priority scheduling and job type routing.
+ *
+ * @see thread_pool For the standard pool
+ */
+
 #pragma once
 
 #include <kcenon/thread/utils/formatter.h>

--- a/include/kcenon/thread/impl/typed_pool/typed_thread_worker.h
+++ b/include/kcenon/thread/impl/typed_pool/typed_thread_worker.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file typed_thread_worker.h
+ * @brief Worker thread for typed_thread_pool processing priority job queues.
+ *
+ * @see typed_thread_pool
+ */
+
 #pragma once
 
 #include <kcenon/thread/utils/formatter.h>

--- a/include/kcenon/thread/interfaces/crash_handler.h
+++ b/include/kcenon/thread/interfaces/crash_handler.h
@@ -1,3 +1,9 @@
+/**
+ * @file crash_handler.h
+ * @brief Crash safety levels and handler interface for thread failure recovery.
+ *
+ */
+
 #pragma once
 
 /*****************************************************************************

--- a/include/kcenon/thread/interfaces/error_handler.h
+++ b/include/kcenon/thread/interfaces/error_handler.h
@@ -2,6 +2,12 @@
 // Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file error_handler.h
+ * @brief Error handler interface for customizable error handling strategies.
+ *
+ */
+
 #pragma once
 
 #include <functional>

--- a/include/kcenon/thread/interfaces/pool_queue_adapter.h
+++ b/include/kcenon/thread/interfaces/pool_queue_adapter.h
@@ -2,6 +2,14 @@
 // Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file pool_queue_adapter.h
+ * @brief Abstract interface for queue adapters used by thread_pool.
+ *
+ * @see job_queue_adapter
+ * @see policy_queue_adapter
+ */
+
 #pragma once
 
 #include <memory>

--- a/include/kcenon/thread/interfaces/queue_capabilities.h
+++ b/include/kcenon/thread/interfaces/queue_capabilities.h
@@ -3,6 +3,12 @@
  * Copyright (c) 2025, DongCheol Shin
  */
 
+/**
+ * @file queue_capabilities.h
+ * @brief Runtime-queryable queue capabilities descriptor.
+ *
+ */
+
 #pragma once
 
 namespace kcenon::thread {

--- a/include/kcenon/thread/interfaces/queue_capabilities_interface.h
+++ b/include/kcenon/thread/interfaces/queue_capabilities_interface.h
@@ -3,6 +3,13 @@
  * Copyright (c) 2025, DongCheol Shin
  */
 
+/**
+ * @file queue_capabilities_interface.h
+ * @brief Mixin interface for queue capability introspection.
+ *
+ * @see queue_capabilities
+ */
+
 #pragma once
 
 #include <kcenon/thread/interfaces/queue_capabilities.h>

--- a/include/kcenon/thread/interfaces/queue_traits.h
+++ b/include/kcenon/thread/interfaces/queue_traits.h
@@ -2,6 +2,12 @@
 // Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file queue_traits.h
+ * @brief Type traits for detecting queue synchronization policy tags.
+ *
+ */
+
 #pragma once
 
 #include <type_traits>

--- a/include/kcenon/thread/interfaces/scheduler_interface.h
+++ b/include/kcenon/thread/interfaces/scheduler_interface.h
@@ -3,6 +3,13 @@
  * Copyright (c) 2025, DongCheol Shin
  */
 
+/**
+ * @file scheduler_interface.h
+ * @brief Abstract scheduler interface for queuing and retrieving jobs.
+ *
+ * @see job_queue For the primary implementation
+ */
+
 #pragma once
 
 #include <memory>

--- a/include/kcenon/thread/interfaces/service_container.h
+++ b/include/kcenon/thread/interfaces/service_container.h
@@ -1,3 +1,9 @@
+/**
+ * @file service_container.h
+ * @brief Service container for dependency injection within the thread system.
+ *
+ */
+
 #pragma once
 
 // BSD 3-Clause License

--- a/include/kcenon/thread/interfaces/thread_context.h
+++ b/include/kcenon/thread/interfaces/thread_context.h
@@ -1,3 +1,9 @@
+/**
+ * @file thread_context.h
+ * @brief Context object providing access to optional thread system services.
+ *
+ */
+
 #pragma once
 
 // BSD 3-Clause License

--- a/include/kcenon/thread/lockfree/lockfree_job_queue.h
+++ b/include/kcenon/thread/lockfree/lockfree_job_queue.h
@@ -2,6 +2,14 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file lockfree_job_queue.h
+ * @brief Lock-free MPMC job queue using Michael-Scott algorithm with hazard pointers.
+ *
+ * @see job_queue For the mutex-based alternative
+ * @see adaptive_job_queue For the auto-switching wrapper
+ */
+
 #pragma once
 
 #include <kcenon/thread/core/job.h>

--- a/include/kcenon/thread/lockfree/work_stealing_deque.h
+++ b/include/kcenon/thread/lockfree/work_stealing_deque.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file work_stealing_deque.h
+ * @brief Dynamic circular array work-stealing deque for lock-free task distribution.
+ *
+ * @see numa_work_stealer For NUMA-aware stealing
+ */
+
 #pragma once
 
 #include <algorithm>

--- a/include/kcenon/thread/metrics/enhanced_metrics.h
+++ b/include/kcenon/thread/metrics/enhanced_metrics.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file enhanced_metrics.h
+ * @brief Enhanced metrics snapshot with latency percentiles and throughput.
+ *
+ * @see metrics_base
+ */
+
 #pragma once
 
 #include <kcenon/thread/metrics/latency_histogram.h>

--- a/include/kcenon/thread/metrics/latency_histogram.h
+++ b/include/kcenon/thread/metrics/latency_histogram.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file latency_histogram.h
+ * @brief HDR-style histogram for latency distribution with logarithmic buckets.
+ *
+ * @see enhanced_metrics
+ */
+
 #pragma once
 
 #include <array>

--- a/include/kcenon/thread/metrics/metrics_backend.h
+++ b/include/kcenon/thread/metrics/metrics_backend.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file metrics_backend.h
+ * @brief Abstract interface for metrics export backends.
+ *
+ * @see metrics_service
+ */
+
 #pragma once
 
 #include <kcenon/thread/metrics/enhanced_metrics.h>

--- a/include/kcenon/thread/metrics/metrics_base.h
+++ b/include/kcenon/thread/metrics/metrics_base.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file metrics_base.h
+ * @brief Thread pool metrics collection, histograms, and observability.
+ *
+ * @see thread_pool_metrics For the lightweight shared container
+ */
+
 #pragma once
 
 /**

--- a/include/kcenon/thread/metrics/metrics_service.h
+++ b/include/kcenon/thread/metrics/metrics_service.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file metrics_service.h
+ * @brief Centralized metrics service for thread pool metrics management.
+ *
+ * @see metrics_backend For export backends
+ */
+
 #pragma once
 
 #include <kcenon/thread/metrics/thread_pool_metrics.h>

--- a/include/kcenon/thread/metrics/sliding_window_counter.h
+++ b/include/kcenon/thread/metrics/sliding_window_counter.h
@@ -2,6 +2,12 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file sliding_window_counter.h
+ * @brief Sliding window counter for throughput measurement.
+ *
+ */
+
 #pragma once
 
 #include <atomic>

--- a/include/kcenon/thread/metrics/thread_pool_metrics.h
+++ b/include/kcenon/thread/metrics/thread_pool_metrics.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file thread_pool_metrics.h
+ * @brief Lightweight metrics container shared between thread_pool and workers.
+ *
+ * @see metrics_base For detailed observability
+ */
+
 #pragma once
 
 #include <kcenon/thread/metrics/metrics_base.h>

--- a/include/kcenon/thread/policies/bound_policies.h
+++ b/include/kcenon/thread/policies/bound_policies.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file bound_policies.h
+ * @brief Bound policies for queue capacity: unbounded or fixed-size.
+ *
+ * @see policy_queue
+ */
+
 #pragma once
 
 #include <cstddef>

--- a/include/kcenon/thread/policies/overflow_policies.h
+++ b/include/kcenon/thread/policies/overflow_policies.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file overflow_policies.h
+ * @brief Overflow handling policies: reject, drop-oldest, or block.
+ *
+ * @see policy_queue
+ */
+
 #pragma once
 
 #include <chrono>

--- a/include/kcenon/thread/policies/policy_queue.h
+++ b/include/kcenon/thread/policies/policy_queue.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file policy_queue.h
+ * @brief Policy-based job queue template with customizable sync, bound, and overflow.
+ *
+ * @see job_queue For the default implementation
+ */
+
 #pragma once
 
 #include <type_traits>

--- a/include/kcenon/thread/policies/sync_policies.h
+++ b/include/kcenon/thread/policies/sync_policies.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file sync_policies.h
+ * @brief Synchronization policies: mutex-based or spinlock-based.
+ *
+ * @see policy_queue
+ */
+
 #pragma once
 
 #include <atomic>

--- a/include/kcenon/thread/pool_policies/autoscaling_pool_policy.h
+++ b/include/kcenon/thread/pool_policies/autoscaling_pool_policy.h
@@ -2,6 +2,14 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file autoscaling_pool_policy.h
+ * @brief Pool policy implementing automatic worker scaling based on load.
+ *
+ * @see pool_policy For the base interface
+ * @see autoscaler
+ */
+
 #pragma once
 
 #include "pool_policy.h"

--- a/include/kcenon/thread/pool_policies/circuit_breaker_policy.h
+++ b/include/kcenon/thread/pool_policies/circuit_breaker_policy.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file circuit_breaker_policy.h
+ * @brief Pool policy implementing circuit breaker pattern for failure protection.
+ *
+ * @see pool_policy For the base interface
+ */
+
 #pragma once
 
 #include "pool_policy.h"

--- a/include/kcenon/thread/pool_policies/pool_policy.h
+++ b/include/kcenon/thread/pool_policies/pool_policy.h
@@ -2,6 +2,12 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file pool_policy.h
+ * @brief Base interface for extensible thread pool behavior policies.
+ *
+ */
+
 #pragma once
 
 /**

--- a/include/kcenon/thread/pool_policies/work_stealing_pool_policy.h
+++ b/include/kcenon/thread/pool_policies/work_stealing_pool_policy.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file work_stealing_pool_policy.h
+ * @brief Pool policy implementing work-stealing for load balancing.
+ *
+ * @see pool_policy For the base interface
+ */
+
 #pragma once
 
 #include "pool_policy.h"

--- a/include/kcenon/thread/queue/adaptive_job_queue.h
+++ b/include/kcenon/thread/queue/adaptive_job_queue.h
@@ -2,6 +2,14 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file adaptive_job_queue.h
+ * @brief Adaptive queue that auto-switches between mutex and lock-free modes.
+ *
+ * @see job_queue For mutex mode
+ * @see lockfree_job_queue For lock-free mode
+ */
+
 #pragma once
 
 #include <kcenon/thread/core/job_queue.h>

--- a/include/kcenon/thread/queue/queue_factory.h
+++ b/include/kcenon/thread/queue/queue_factory.h
@@ -2,6 +2,14 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file queue_factory.h
+ * @brief Factory for creating queue instances based on configuration.
+ *
+ * @see adaptive_job_queue
+ * @see job_queue
+ */
+
 #pragma once
 
 #include <kcenon/thread/core/job_queue.h>

--- a/include/kcenon/thread/resilience/protected_job.h
+++ b/include/kcenon/thread/resilience/protected_job.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file protected_job.h
+ * @brief Job wrapper integrating circuit breaker protection.
+ *
+ * @see circuit_breaker_policy
+ */
+
 #pragma once
 
 #include <kcenon/common/resilience/circuit_breaker.h>

--- a/include/kcenon/thread/scaling/autoscaler.h
+++ b/include/kcenon/thread/scaling/autoscaler.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file autoscaler.h
+ * @brief Automatic scaling of thread pool workers based on load metrics.
+ *
+ * @see autoscaling_policy For configuration
+ */
+
 #pragma once
 
 #include "autoscaling_policy.h"

--- a/include/kcenon/thread/scaling/autoscaling_policy.h
+++ b/include/kcenon/thread/scaling/autoscaling_policy.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file autoscaling_policy.h
+ * @brief Configuration for autoscaling behavior and thresholds.
+ *
+ * @see autoscaler
+ */
+
 #pragma once
 
 #include "scaling_metrics.h"

--- a/include/kcenon/thread/scaling/scaling_metrics.h
+++ b/include/kcenon/thread/scaling/scaling_metrics.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file scaling_metrics.h
+ * @brief Scaling direction and metrics for autoscaling decisions.
+ *
+ * @see autoscaler
+ */
+
 #pragma once
 
 #include <chrono>

--- a/include/kcenon/thread/stealing/enhanced_steal_policy.h
+++ b/include/kcenon/thread/stealing/enhanced_steal_policy.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file enhanced_steal_policy.h
+ * @brief Enhanced policies for selecting work-stealing victims.
+ *
+ * @see numa_work_stealer
+ */
+
 #pragma once
 
 #include <cstdint>

--- a/include/kcenon/thread/stealing/enhanced_work_stealing_config.h
+++ b/include/kcenon/thread/stealing/enhanced_work_stealing_config.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file enhanced_work_stealing_config.h
+ * @brief Configuration for enhanced work-stealing with NUMA awareness.
+ *
+ * @see numa_work_stealer
+ */
+
 #pragma once
 
 #include "enhanced_steal_policy.h"

--- a/include/kcenon/thread/stealing/numa_topology.h
+++ b/include/kcenon/thread/stealing/numa_topology.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file numa_topology.h
+ * @brief NUMA node topology detection and information.
+ *
+ * @see numa_work_stealer
+ */
+
 #pragma once
 
 #include <cstddef>

--- a/include/kcenon/thread/stealing/numa_work_stealer.h
+++ b/include/kcenon/thread/stealing/numa_work_stealer.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file numa_work_stealer.h
+ * @brief NUMA-aware work stealer with enhanced victim selection policies.
+ *
+ * @see work_stealing_deque
+ */
+
 #pragma once
 
 #include "enhanced_work_stealing_config.h"

--- a/include/kcenon/thread/stealing/steal_backoff_strategy.h
+++ b/include/kcenon/thread/stealing/steal_backoff_strategy.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file steal_backoff_strategy.h
+ * @brief Backoff strategies for work-stealing operations.
+ *
+ * @see numa_work_stealer
+ */
+
 #pragma once
 
 #include <algorithm>

--- a/include/kcenon/thread/stealing/work_affinity_tracker.h
+++ b/include/kcenon/thread/stealing/work_affinity_tracker.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file work_affinity_tracker.h
+ * @brief Tracks cooperation patterns between workers for locality-aware stealing.
+ *
+ * @see numa_work_stealer
+ */
+
 #pragma once
 
 #include <atomic>

--- a/include/kcenon/thread/stealing/work_stealing_stats.h
+++ b/include/kcenon/thread/stealing/work_stealing_stats.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file work_stealing_stats.h
+ * @brief Statistics snapshot for work-stealing performance monitoring.
+ *
+ * @see numa_work_stealer
+ */
+
 #pragma once
 
 #include <atomic>

--- a/include/kcenon/thread/utils/convert_string.h
+++ b/include/kcenon/thread/utils/convert_string.h
@@ -2,6 +2,12 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file convert_string.h
+ * @brief String encoding conversion, Base64 encoding/decoding utilities.
+ *
+ */
+
 #pragma once
 
 #include <tuple>

--- a/include/kcenon/thread/utils/formatter.h
+++ b/include/kcenon/thread/utils/formatter.h
@@ -2,6 +2,12 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file formatter.h
+ * @brief Generic formatter for enum types using user-provided converter functors.
+ *
+ */
+
 #pragma once
 
 #include <format>

--- a/include/kcenon/thread/utils/platform_detection.h
+++ b/include/kcenon/thread/utils/platform_detection.h
@@ -5,6 +5,12 @@ Copyright (c) 2024, kcenon
 All rights reserved.
 *****************************************************************************/
 
+/**
+ * @file platform_detection.h
+ * @brief CPU architecture and platform detection utilities.
+ *
+ */
+
 #pragma once
 
 #include <cstdint>

--- a/include/kcenon/thread/utils/span.h
+++ b/include/kcenon/thread/utils/span.h
@@ -2,6 +2,12 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file span.h
+ * @brief Polyfill for std::span on pre-C++20 compilers.
+ *
+ */
+
 #pragma once
 
 #include <array>


### PR DESCRIPTION
## Summary

Add `@file` Doxygen documentation blocks to 91 public API headers that were missing them, achieving 100% `@file` coverage across all headers in thread_system.

### Directories Updated
- `core/` — thread pool, job queue, lifecycle, sync primitives, etc.
- `interfaces/` — scheduler, crash/error handlers, queue traits
- `metrics/` — thread pool metrics, latency histograms, sliding window
- `policies/` — overflow, sync, bound policies
- `pool_policies/` — autoscaling, circuit breaker, work stealing
- `lockfree/` — lock-free job queue, work stealing deque
- `dag/` — DAG scheduler, DAG job builder
- `diagnostics/` — bottleneck reports, health status, execution events
- `scaling/` — autoscaler, scaling metrics
- `stealing/` — NUMA work stealer, affinity tracker, backoff strategy
- `resilience/` — protected job
- `queue/` — adaptive job queue, queue factory
- `impl/typed_pool/` — typed thread pool, aging typed jobs
- `adapters/` — job queue adapter, policy queue adapter
- `utils/` — string conversion, formatter, platform detection

Closes #568

## Test Plan
- [ ] Verify Doxygen generation produces no warnings on updated headers
- [ ] Confirm existing CI checks pass