### PR TITLE
docs: add ecosystem cross-references and dependency diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,28 @@ cmake --build build --target docs
 
 ## Ecosystem Integration
 
+### Ecosystem Dependency Map
+
+```mermaid
+graph TD
+    A[common_system] --> B[thread_system]
+    A --> C[container_system]
+    B --> D[logger_system]
+    B --> E[monitoring_system]
+    D --> F[database_system]
+    E --> F
+    F --> G[network_system]
+    G --> H[pacs_system]
+
+    style B fill:#f9f,stroke:#333,stroke-width:3px
+```
+
+> **Ecosystem reference**:
+> [common_system](https://github.com/kcenon/common_system) — Tier 0: IExecutor interface and Result&lt;T&gt; pattern
+> [logger_system](https://github.com/kcenon/logger_system) — Tier 2: Async logging (optional consumer)
+> [monitoring_system](https://github.com/kcenon/monitoring_system) — Tier 3: Metrics collection (consumer)
+> [network_system](https://github.com/kcenon/network_system) — Tier 4: Transport layer (consumer)
+
 ### Project Ecosystem
 
 This project is part of a modular ecosystem:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -27,6 +27,15 @@ category: "ARCH"
 
 ## Overview
 
+> **Cross-reference**:
+> [API Reference](./API_REFERENCE.md) — Thread pool, job queue, and DAG scheduler APIs
+> [Benchmarks](./BENCHMARKS.md) — Performance measurements and scalability data
+> [Autoscaler Guide](./AUTOSCALER_GUIDE.md) — Dynamic thread pool scaling configuration
+
+> **Ecosystem reference**:
+> [common_system API](https://github.com/kcenon/common_system/blob/main/docs/API_REFERENCE.md) — IExecutor interface implemented by thread_pool
+> [common_system Architecture](https://github.com/kcenon/common_system/blob/main/docs/ARCHITECTURE.md) — Foundation layer architecture
+
 ### Purpose
 
 thread_system is a modern C++ thread management library designed for high-performance multithreaded application development.
@@ -463,6 +472,32 @@ struct alignas(64) WorkerThread {
 - [x] Thread pool diagnostics (implemented: `thread_pool_diagnostics`, health checks, bottleneck detection)
 - [ ] GPU task offloading
 - [ ] Heterogeneous computing support
+
+---
+
+## Ecosystem Dependencies
+
+thread_system sits at **Tier 1** in the kcenon ecosystem, providing core threading primitives.
+
+```mermaid
+graph TD
+    A[common_system] --> B[thread_system]
+    A --> C[container_system]
+    B --> D[logger_system]
+    B --> E[monitoring_system]
+    D --> F[database_system]
+    E --> F
+    F --> G[network_system]
+    G --> H[pacs_system]
+
+    style B fill:#f9f,stroke:#333,stroke-width:3px
+```
+
+> **Ecosystem reference**:
+> [common_system](https://github.com/kcenon/common_system) — Tier 0: IExecutor interface, Result&lt;T&gt;
+> [logger_system](https://github.com/kcenon/logger_system) — Tier 2: Async logging (consumer)
+> [monitoring_system](https://github.com/kcenon/monitoring_system) — Tier 3: Metrics collection (consumer)
+> [network_system](https://github.com/kcenon/network_system) — Tier 4: Transport layer (consumer)
 
 ---
 


### PR DESCRIPTION
Closes kcenon/common_system#564

## Summary
- Add intra-project cross-references (blockquote format) to ARCHITECTURE.md Overview section
- Add inter-project ecosystem references to common_system documentation
- Add Mermaid ecosystem dependency diagram to both README.md and ARCHITECTURE.md
- thread_system highlighted as Tier 1 in the dependency graph

## Test Plan
- [ ] Verify all intra-project links resolve correctly
- [ ] Verify Mermaid diagram renders properly on GitHub
- [ ] Verify inter-project GitHub URLs point to valid documents