### PR TITLE
docs: fix traceability matrix doc_id collision with production quality

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -82,7 +82,7 @@ Total documents: **84**
 | 61 | THR-INTR-001 | Integration Guide - Thread System | [INTEGRATION.md](./advanced/INTEGRATION.md) | Released |
 | 62 | THR-QUAL-001 | Thread System 프로덕션 품질 | [PRODUCTION_QUALITY.kr.md](./PRODUCTION_QUALITY.kr.md) | Released |
 | 63 | THR-QUAL-002 | Thread System Production Quality | [PRODUCTION_QUALITY.md](./PRODUCTION_QUALITY.md) | Released |
-| 64 | THR-QUAL-002 | Feature-Test-Module Traceability Matrix | [TRACEABILITY.md](./TRACEABILITY.md) | Released |
+| 64 | THR-QUAL-006 | Feature-Test-Module Traceability Matrix | [TRACEABILITY.md](./TRACEABILITY.md) | Released |
 | 65 | THR-QUAL-003 | 품질 및 QA 가이드 | [QUALITY.kr.md](./advanced/QUALITY.kr.md) | Released |
 | 66 | THR-QUAL-004 | Quality & QA Guide | [QUALITY.md](./advanced/QUALITY.md) | Released |
 | 67 | THR-QUAL-005 | Test Coverage Guide | [COVERAGE_GUIDE.md](./guides/COVERAGE_GUIDE.md) | Released |
@@ -208,7 +208,7 @@ Total documents: **84**
 |--------|-------|----------|--------|
 | THR-QUAL-001 | Thread System 프로덕션 품질 | [PRODUCTION_QUALITY.kr.md](./PRODUCTION_QUALITY.kr.md) | Released |
 | THR-QUAL-002 | Thread System Production Quality | [PRODUCTION_QUALITY.md](./PRODUCTION_QUALITY.md) | Released |
-| THR-QUAL-002 | Feature-Test-Module Traceability Matrix | [TRACEABILITY.md](./TRACEABILITY.md) | Released |
+| THR-QUAL-006 | Feature-Test-Module Traceability Matrix | [TRACEABILITY.md](./TRACEABILITY.md) | Released |
 | THR-QUAL-003 | 품질 및 QA 가이드 | [QUALITY.kr.md](./advanced/QUALITY.kr.md) | Released |
 | THR-QUAL-004 | Quality & QA Guide | [QUALITY.md](./advanced/QUALITY.md) | Released |
 | THR-QUAL-005 | Test Coverage Guide | [COVERAGE_GUIDE.md](./guides/COVERAGE_GUIDE.md) | Released |

--- a/docs/TRACEABILITY.md
+++ b/docs/TRACEABILITY.md
@@ -1,5 +1,5 @@
 ---
-doc_id: "THR-QUAL-002"
+doc_id: "THR-QUAL-006"
 doc_title: "Feature-Test-Module Traceability Matrix"
 doc_version: "1.0.0"
 doc_date: "2026-04-04"


### PR DESCRIPTION
## Summary

- Fix doc_id collision: `TRACEABILITY.md` and `PRODUCTION_QUALITY.md` both used `THR-QUAL-002`
- Assign unique `THR-QUAL-006` to `TRACEABILITY.md` (next available QUAL number)
- Update SSOT registry (`docs/README.md`) to reflect the corrected doc_id

Related to kcenon/common_system#566

## What

The traceability matrix document (`docs/TRACEABILITY.md`) was sharing `THR-QUAL-002` with `PRODUCTION_QUALITY.md`. Each document in the SSOT registry must have a unique `doc_id`. This PR assigns `THR-QUAL-006` to the traceability matrix.

## How

- Updated `doc_id` in `docs/TRACEABILITY.md` YAML frontmatter from `THR-QUAL-002` to `THR-QUAL-006`
- Updated both entries in `docs/README.md` (numbered table and category index)

## Test Plan

- [x] Verify `THR-QUAL-006` is not used by any other document
- [x] Verify TRACEABILITY.md YAML frontmatter matches README.md registry entry
- [x] Verify all feature-test mappings are accurate (test files exist)
- [x] Verify coverage summary totals match actual feature count (52)