### PR TITLE
docs(tutorials): add tutorials, FAQ and troubleshooting guide

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -100,7 +100,12 @@ INPUT                  = ./core \
                          ./src \
                          ./include \
                          ./examples \
-                         ./docs/mainpage.dox
+                         ./docs/mainpage.dox \
+                         ./docs/tutorial_threadpool.dox \
+                         ./docs/tutorial_dag.dox \
+                         ./docs/tutorial_lockfree.dox \
+                         ./docs/faq.dox \
+                         ./docs/troubleshooting.dox
 INPUT_ENCODING         = UTF-8
 FILE_PATTERNS          = *.c \
                          *.cc \

--- a/docs/faq.dox
+++ b/docs/faq.dox
@@ -1,0 +1,127 @@
+/**
+@page faq Frequently Asked Questions
+
+@tableofcontents
+
+This FAQ collects the most common questions from developers integrating Thread
+System into their projects. For longer walkthroughs, see the
+@ref tutorial_threadpool, @ref tutorial_dag, and @ref tutorial_lockfree pages.
+
+@section faq_threads How many threads should I use?
+
+Start with @c std::thread::hardware_concurrency() for CPU-bound work. For
+I/O-bound or mixed workloads, oversubscribe by a factor proportional to the
+average wait time over compute time — a 2x to 4x multiplier is a reasonable
+starting point. Avoid setting a fixed worker count without measuring; the
+optimal number depends on the workload, the host, and other processes
+contending for the same cores. The autoscaler can adjust the count over time
+based on queue depth and observed latency.
+
+@section faq_cancel How do I handle task cancellation?
+
+Use a @c kcenon::thread::cancellation_token. Pass the token to long-running
+jobs and check @c is_cancellation_requested() between work units. Cancellation
+is cooperative — the runtime cannot interrupt arbitrary code, so jobs must poll
+periodically. Tokens form a hierarchy: cancelling a parent cancels all linked
+children, which is useful for shutting down a request and all of its background
+fan-out.
+
+@code{.cpp}
+auto token = kcenon::thread::cancellation_token::create();
+pool->submit_task([token]() -> kcenon::thread::result_void {
+    while (!token->is_cancellation_requested()) {
+        // do a chunk of work
+    }
+    return {};
+});
+// later
+token->cancel();
+@endcode
+
+@section faq_async Thread pool vs. std::async — which is better?
+
+@c std::async on most implementations either spawns a new thread per call or
+uses an opaque process-wide pool with no scheduling controls. A dedicated
+thread pool gives you:
+- Bounded resource use.
+- Visibility into queue depth and latency.
+- Priority routing via @c typed_thread_pool.
+- Cooperative cancellation and structured shutdown.
+
+Use @c std::async only for one-off background work in small programs. Anything
+that runs in production with predictable load should use a thread pool.
+
+@section faq_monitoring How do I integrate with monitoring_system?
+
+Thread System exposes its diagnostic counters through the @c diagnostics and
+@c metrics modules. monitoring_system depends on Thread System and consumes
+these counters directly — you do not need to wire anything by hand. If you
+want to publish custom metrics, register a callback with
+@c thread_pool_diagnostics::observe(). Counters include queue depth, worker
+utilization, completed jobs, and per-priority latency histograms.
+
+@section faq_deadlock How do I avoid deadlocks when using the pool?
+
+A few rules prevent the most common cases:
+- Do not call @c future.get() from inside a job submitted to the same pool if
+  the awaited job depends on a worker from that pool — this can starve the
+  pool. Use the DAG scheduler for in-pool dependencies instead.
+- Acquire locks in a consistent global order across jobs.
+- Prefer @c std::scoped_lock to lock multiple mutexes atomically.
+- Avoid holding a mutex across @c submit_task — release first, then submit.
+- Watch for hidden blocking inside callbacks (logging, allocators, mutexes
+  used by other threads). The thread pool diagnostics can flag long-running
+  jobs that point at hidden contention.
+
+@section faq_perf How do I tune the pool for performance?
+
+1. Measure first. Use the included benchmarks or your own to capture baseline
+   throughput and latency.
+2. Right-size the worker count for your workload class.
+3. Try @c adaptive_job_queue (the default) before forcing a specific queue.
+4. Enable work stealing for highly imbalanced workloads only.
+5. Use @c typed_thread_pool to give latency-sensitive work a dedicated worker.
+6. Profile contention with @c perf or @c vtune to spot accidentally shared
+   state inside callbacks.
+
+@section faq_platform Are there platform differences I should know about?
+
+Thread System works on Linux, macOS, and Windows. Notable differences:
+- Linux supports NUMA-aware work stealing; macOS and Windows builds compile
+  the same code but treat the host as a single NUMA node.
+- Windows requires MSVC 2022 or newer for full @c std::format support.
+- macOS uses Grand Central Dispatch underneath @c std::thread, but the
+  thread pool itself does not depend on GCD.
+- ARMv7 and RISC-V are untested. AArch64 (Apple Silicon, Linux ARM64) is
+  supported and benchmarked.
+
+@section faq_memory How does memory management work for jobs and queues?
+
+Jobs are heap-allocated by the queue (typically as @c std::unique_ptr nodes).
+Lock-free queues defer node deletion until hazard pointer scanning confirms
+no thread is reading them. As a user you do not need to manage queue node
+lifetimes; just pass a callable into @c submit_task or build a typed job and
+the framework owns it from there. Avoid capturing very large objects by value
+in the lambda — capture by @c std::shared_ptr or move into the job.
+
+@section faq_errors How are errors propagated from jobs?
+
+Jobs return @c kcenon::thread::result_void or @c result<T>, which wrap the
+@c common_system Result type. Failures surface through the future returned by
+@c submit_task — calling @c .get() rethrows nothing; instead inspect the
+result and call @c get_error() (note: not @c error()) to read the failure
+detail. The DAG scheduler aggregates failures across nodes and exposes them
+through the run result.
+
+@section faq_testing How do I test code that uses the thread pool?
+
+- For unit tests, prefer the @c minimal_thread_pool example as a lightweight
+  fixture: it has predictable startup and shutdown costs.
+- Use a small worker count (1 or 2) so concurrency bugs surface deterministically.
+- Wait on futures returned from @c submit_task; never sleep-and-hope.
+- For races, run the test under TSan (@c cmake --preset tsan) and inside
+  Valgrind on Linux (@c valgrind --tool=helgrind).
+- The repository includes stress and sanitizer presets — use them in CI to
+  catch regressions in your downstream code as well.
+
+*/

--- a/docs/mainpage.dox
+++ b/docs/mainpage.dox
@@ -202,6 +202,19 @@ cd thread_system
 | **Adapters** | `adapters/` | common_executor_adapter.h, job_queue_adapter.h | Bridges to common_system IExecutor |
 | **Concepts** | `concepts/` | thread_concepts.h | C++20 concepts for thread domain |
 
+@section learning Learning Resources
+
+New to Thread System? Start here. These pages walk through the most common
+integration scenarios and answer the questions developers ask most often.
+
+| Resource | Description |
+|----------|-------------|
+| @ref tutorial_threadpool | Choosing between basic and typed pools, work-stealing, sizing |
+| @ref tutorial_dag | Defining task dependencies, execution order, error handling |
+| @ref tutorial_lockfree | MPMC vs SPSC selection, hazard pointers, performance |
+| @ref faq | Quick answers to the 10 most common integration questions |
+| @ref troubleshooting | Diagnosing deadlocks, leaks, hangs, and performance issues |
+
 @section examples Examples
 
 | Example | Source | Description |

--- a/docs/troubleshooting.dox
+++ b/docs/troubleshooting.dox
@@ -1,0 +1,147 @@
+/**
+@page troubleshooting Troubleshooting Guide
+
+@tableofcontents
+
+When something goes wrong with concurrent code, the symptoms are often vague —
+a hang, a crash without a stack trace, or a slowdown that only appears under
+load. This page collects the most frequent issues we see with Thread System and
+the diagnostic steps that resolve them.
+
+@section ts_deadlock 1. Deadlock detection
+
+**Symptoms**: The pool stops making progress, queue depth grows, futures never
+complete.
+
+**Common causes**:
+- A job calls @c future.get() on another job submitted to the same pool, but
+  every worker is blocked waiting on a future, so nothing can run the
+  awaited job.
+- Two jobs acquire the same locks in different orders.
+- A callback blocks on a mutex held elsewhere in user code.
+
+**Diagnostic steps**:
+1. Use @c kcenon::thread::diagnostics::dump_pool_state() (or your debugger) to
+   list worker stack traces. If every worker is parked in @c std::future::wait,
+   you have an in-pool dependency cycle.
+2. Run under @c gdb / @c lldb and inspect each worker's backtrace. Look for
+   matching mutex addresses across two threads.
+3. Enable thread sanitizer (@c cmake --preset tsan) and re-run the failing
+   test. TSan detects most lock-order inversions automatically.
+
+**Fix**: Use the DAG scheduler for in-pool dependencies. Adopt @c std::scoped_lock
+to lock multiple mutexes atomically. Never hold a mutex across @c submit_task.
+
+@section ts_leak 2. Memory leak with futures
+
+**Symptoms**: RSS grows steadily under load even though jobs complete.
+
+**Common causes**:
+- The pool returns a future from @c submit_task and the caller never reads or
+  drops it. The shared state stays alive until the future is destroyed.
+- Lambdas capture large objects by value; the lambda lives until the job
+  finishes, pinning the captures.
+- The hazard pointer retire list never reaches the reclamation threshold
+  because one thread rarely runs.
+
+**Diagnostic steps**:
+1. Run under @c valgrind --tool=memcheck or AddressSanitizer
+   (@c cmake --preset asan).
+2. Use @c heaptrack or @c jemalloc statistics to find the call site that
+   allocates the leaked memory.
+3. Check job lifetimes — long-running jobs delay cleanup of everything they
+   capture.
+
+**Fix**: Drop futures you do not need (or call @c .wait() and let them go).
+Capture large state by @c std::shared_ptr or move it. For hazard pointer
+buildup, occasionally call @c hazard_domain::scan_now() from a maintenance
+thread.
+
+@section ts_platform 3. Platform-specific threading issues
+
+**Symptoms**: The code runs on Linux but hangs on Windows, or works on x86_64
+but crashes on AArch64.
+
+**Common causes**:
+- Relying on a particular memory ordering that is enforced on x86 but not on
+  weakly ordered architectures.
+- Using thread-local storage that is destroyed in a different order on
+  different platforms during shutdown.
+- Differences in @c std::thread::hardware_concurrency() reporting (cgroups on
+  Linux containers, hybrid cores on Windows).
+
+**Diagnostic steps**:
+1. Reproduce on the failing platform under TSan if available.
+2. Audit any custom @c std::atomic usage; default to
+   @c std::memory_order_seq_cst until proven slow.
+3. On Linux containers, check @c /sys/fs/cgroup limits — they affect what
+   @c hardware_concurrency() returns.
+
+**Fix**: Use @c std::memory_order_seq_cst by default, then relax with care
+after profiling. Pin thread-local cleanup order using explicit
+@c thread_local destructors. Configure the pool's worker count from a runtime
+setting instead of trusting platform defaults.
+
+@section ts_perf 4. Performance problems
+
+**Symptoms**: Throughput is lower than expected, tail latency spikes, CPU
+utilization is high without forward progress.
+
+**Common causes**:
+- Workers spend most time in the kernel waking up from condition variables.
+- A single hot lock inside a callback bottlenecks every worker.
+- The job queue is mutex-backed under high contention; switching to lock-free
+  helps.
+- False sharing between counters or job control blocks placed on the same
+  cache line.
+
+**Diagnostic steps**:
+1. Run the @c benchmarks/thread_pool_benchmark and compare against the
+   shipped baseline numbers.
+2. Use @c perf record -F 999 -g to find the hottest functions.
+3. Check @c thread_pool_diagnostics::queue_depth and worker idle counters —
+   if workers are idle while the queue is non-empty, there is a wakeup or
+   stealing problem.
+4. Run the autoscaler in observation-only mode and compare its
+   recommendation to your static configuration.
+
+**Fix**: Switch to @c adaptive_job_queue, enable work stealing for skewed
+loads, split CPU and I/O work into separate pools, and align hot counters to
+cache lines (@c alignas(64)).
+
+@section ts_hang 5. Hang on shutdown
+
+**Symptoms**: The program reaches @c pool->stop() but never returns.
+
+**Common causes**:
+- Pending jobs that wait on a cancellation token nobody cancelled.
+- Futures still held by the caller; the pool destructor blocks until the
+  shared state is released.
+- A worker thread holds a hazard pointer to a node and never reaches the
+  reclamation point.
+- Nested pools — pool A's worker waits on a future from pool B, which is
+  already shutting down.
+
+**Diagnostic steps**:
+1. Attach a debugger and dump every thread's backtrace. Workers parked in
+   @c condition_variable::wait inside @c stop() indicate jobs that never
+   completed.
+2. Confirm cancellation tokens are actually cancelled before @c stop().
+3. Look for futures captured by other long-lived objects.
+
+**Fix**: Cancel any cancellation tokens before stopping the pool. Use
+@c stop(std::chrono::seconds(N)) to bound the wait. Shut down dependent pools
+in reverse dependency order — outermost first.
+
+@section ts_more More help
+
+If these steps do not isolate the issue, open a GitHub issue with:
+- The exact build configuration (compiler, version, CMake preset).
+- A minimal reproduction (the smaller the better).
+- Sanitizer output if available (TSan, ASan, UBSan).
+- @c thread_pool_diagnostics dump captured at the failure point.
+
+See also @ref faq for quick answers and @ref tutorial_threadpool for usage
+patterns that prevent these issues in the first place.
+
+*/

--- a/docs/tutorial_dag.dox
+++ b/docs/tutorial_dag.dox
@@ -1,0 +1,150 @@
+/**
+@page tutorial_dag Tutorial: DAG Scheduling
+
+@tableofcontents
+
+The DAG scheduler executes jobs that form a Directed Acyclic Graph of
+dependencies. Each node runs at most once, and only after all of its
+predecessors have completed successfully. This page shows how to define a graph,
+reason about execution order, and handle errors that propagate through the
+chain.
+
+@section tutorial_dag_intro Introduction
+
+A DAG is appropriate when the work has structured dependencies that go beyond a
+simple FIFO queue — for example, build pipelines, data processing stages, or
+fan-out/fan-in workloads. Thread System's @c dag_scheduler runs DAG nodes on top
+of an existing @c thread_pool, so you keep the same worker model while gaining
+dependency tracking.
+
+@section tutorial_dag_dependencies Defining Dependencies
+
+Use @c dag_job_builder to declare nodes and edges. Edges express
+"must-finish-before" relationships:
+
+@code{.cpp}
+#include <kcenon/thread/dag/dag_job_builder.h>
+
+auto builder = kcenon::thread::dag::dag_job_builder{};
+
+auto load   = builder.add_node("load",   [] { return load_input(); });
+auto parse  = builder.add_node("parse",  [] { return parse_data(); });
+auto verify = builder.add_node("verify", [] { return verify_data(); });
+auto store  = builder.add_node("store",  [] { return persist(); });
+
+builder.add_edge(load,  parse);
+builder.add_edge(parse, verify);
+builder.add_edge(verify, store);
+
+auto dag = std::move(builder).build();
+@endcode
+
+The builder validates that the resulting graph contains no cycles. Adding an
+edge that introduces a cycle returns an error result rather than throwing.
+
+@section tutorial_dag_order Execution Order Guarantees
+
+The scheduler provides two guarantees:
+1. A node never starts before all of its predecessors have transitioned to a
+   terminal state (success, failed, or cancelled).
+2. Nodes that share no transitive ordering may run concurrently, subject to the
+   underlying thread pool capacity.
+
+The scheduler does **not** guarantee a particular order between independent
+nodes. If two parsers have no edge between them, either may run first. Encode
+ordering you actually require as edges.
+
+@section tutorial_dag_errors Error Handling
+
+When a node returns an error result, the scheduler:
+- Marks the node as failed.
+- Cancels all transitive successors that have not started yet.
+- Aggregates failures into the final scheduler result.
+
+You can opt into "best-effort" mode, where independent branches continue to run
+even if a sibling branch fails. This is useful when each branch produces an
+independently consumable artifact (e.g., parallel report generators).
+
+@code{.cpp}
+auto config = kcenon::thread::dag::dag_config{};
+config.failure_mode = kcenon::thread::dag::failure_mode::best_effort;
+
+auto scheduler = kcenon::thread::dag::dag_scheduler{pool, config};
+auto result = scheduler.run(dag);
+if (!result) {
+    // result.get_error() contains aggregated failure info.
+}
+@endcode
+
+@section tutorial_dag_example1 Example 1: Linear Pipeline
+
+@code{.cpp}
+#include <kcenon/thread/thread_pool.h>
+#include <kcenon/thread/dag/dag_job_builder.h>
+#include <kcenon/thread/dag/dag_scheduler.h>
+
+int main() {
+    auto pool = kcenon::thread::thread_pool::create();
+    pool->start();
+
+    auto b = kcenon::thread::dag::dag_job_builder{};
+    auto a = b.add_node("a", [] { return kcenon::thread::result_void{}; });
+    auto c = b.add_node("b", [] { return kcenon::thread::result_void{}; });
+    auto d = b.add_node("c", [] { return kcenon::thread::result_void{}; });
+    b.add_edge(a, c);
+    b.add_edge(c, d);
+
+    auto dag = std::move(b).build();
+    kcenon::thread::dag::dag_scheduler{pool}.run(dag);
+
+    pool->stop();
+    return 0;
+}
+@endcode
+
+@section tutorial_dag_example2 Example 2: Fan-out / Fan-in
+
+@code{.cpp}
+auto b = kcenon::thread::dag::dag_job_builder{};
+auto split   = b.add_node("split",   [] { return split_input(); });
+auto worker1 = b.add_node("worker1", [] { return process_chunk(0); });
+auto worker2 = b.add_node("worker2", [] { return process_chunk(1); });
+auto worker3 = b.add_node("worker3", [] { return process_chunk(2); });
+auto join    = b.add_node("join",    [] { return merge_results(); });
+
+b.add_edge(split, worker1);
+b.add_edge(split, worker2);
+b.add_edge(split, worker3);
+b.add_edge(worker1, join);
+b.add_edge(worker2, join);
+b.add_edge(worker3, join);
+
+auto dag = std::move(b).build();
+@endcode
+
+The three worker nodes run in parallel after @c split completes; @c join waits
+for all three.
+
+@section tutorial_dag_example3 Example 3: Best-Effort Failure Handling
+
+@code{.cpp}
+auto config = kcenon::thread::dag::dag_config{};
+config.failure_mode = kcenon::thread::dag::failure_mode::best_effort;
+
+auto scheduler = kcenon::thread::dag::dag_scheduler{pool, config};
+auto result = scheduler.run(dag);
+
+if (!result) {
+    auto err = result.get_error();
+    // err.failed_nodes lists nodes that did not complete successfully.
+    // err.completed_nodes lists nodes that did finish.
+}
+@endcode
+
+@section tutorial_dag_next Next Steps
+
+- @ref tutorial_threadpool to understand the underlying executor.
+- @ref troubleshooting for diagnosing stuck or slow DAGs.
+- @ref faq for additional patterns.
+
+*/

--- a/docs/tutorial_lockfree.dox
+++ b/docs/tutorial_lockfree.dox
@@ -1,0 +1,108 @@
+/**
+@page tutorial_lockfree Tutorial: Lock-Free Queue Patterns
+
+@tableofcontents
+
+Thread System ships several lock-free queues for cases where mutex-based
+synchronization is too expensive. This tutorial explains how to choose between
+the available types, how hazard pointers reclaim memory safely, and what
+performance characteristics to expect.
+
+@section tutorial_lf_intro Introduction
+
+A "lock-free" queue makes progress without acquiring a mutex. Producers and
+consumers coordinate through atomic operations on shared state. Lock-free
+queues are not always faster than mutex queues — they shine under high
+contention with short critical sections, while a well-tuned mutex queue may
+beat them when contention is low.
+
+Thread System provides:
+- @c adaptive_job_queue — Auto-switches between mutex and lock-free modes based
+  on observed contention. Use this by default.
+- @c lockfree_job_queue — Multi-producer / multi-consumer (MPMC) Michael-Scott
+  queue with hazard pointer reclamation.
+- @c work_stealing_deque — Single-producer / multi-consumer Chase-Lev deque
+  used by the work-stealing scheduler.
+- A single-producer / single-consumer (SPSC) ring buffer for the highest
+  throughput on dedicated producer/consumer pairs.
+
+@section tutorial_lf_mpmc_spsc MPMC vs SPSC: Choosing the Right Queue
+
+| Property | MPMC (lockfree_job_queue) | SPSC (ring buffer) |
+|----------|---------------------------|--------------------|
+| Producers | Many | Exactly one |
+| Consumers | Many | Exactly one |
+| Throughput | High under contention | Highest possible |
+| Latency | Bounded | Lowest |
+| Memory model | Hazard pointers | No reclamation needed |
+| Bounded? | Optional | Always |
+
+Rules of thumb:
+- Pick **SPSC** when you can guarantee one producer and one consumer (e.g., a
+  per-thread inbox, an audio render thread). It is the fastest option.
+- Pick **MPMC** when multiple producers feed multiple consumers, such as a
+  shared job queue.
+- Pick **adaptive_job_queue** when you do not know the contention pattern
+  ahead of time, or when contention varies across workloads.
+- Pick **work_stealing_deque** only inside scheduler internals; it is not
+  intended as a general-purpose queue.
+
+@section tutorial_lf_hazard Hazard Pointer Usage
+
+Lock-free queues cannot free a node immediately after popping it because
+another thread might still be reading the same node. Hazard pointers solve this
+by letting each thread publish the addresses it is currently reading. A node is
+only freed once no thread holds a hazard pointer to it.
+
+Thread System's hazard pointer subsystem is mostly transparent — the lockfree
+queue manages slots automatically. If you implement your own lock-free
+structure, the API looks like this:
+
+@code{.cpp}
+#include <kcenon/thread/core/hazard_pointer.h>
+
+auto& hp = kcenon::thread::hazard_pointer_for(this_thread);
+auto guard = hp.protect(slot_ptr); // marks slot_ptr as in-use
+// ... read through slot_ptr ...
+// guard goes out of scope -> slot can later be reclaimed.
+@endcode
+
+Each thread holds a small fixed array of hazard slots (4 by default). Retired
+nodes accumulate on a per-thread retire list and are scanned periodically;
+nodes whose addresses do not appear in any thread's hazard array are freed in
+batch.
+
+Common pitfalls:
+- Forgetting to reload the hazard pointer after retrying a CAS — always
+  republish before re-reading shared state.
+- Holding a guard for too long blocks reclamation; keep critical sections
+  short.
+
+@section tutorial_lf_perf Performance Characteristics
+
+Approximate behavior under typical x86_64 conditions (your numbers will vary):
+
+- **SPSC ring buffer**: Tens of nanoseconds per enqueue/dequeue when both
+  endpoints stay hot in cache.
+- **Lockfree MPMC queue**: Roughly 100 to 300 ns per operation under moderate
+  contention; degrades gracefully as producers/consumers scale.
+- **Mutex-based job_queue**: Comparable to lockfree at low contention, slower
+  beyond about 4 contending threads.
+- **Adaptive job queue**: Adds a small overhead (single atomic load) over the
+  underlying mode, but avoids the worst case in either direction.
+
+Memory:
+- Lock-free queues hold extra retired nodes until reclamation runs. Expect a
+  small per-thread overhead proportional to the retire list threshold.
+- SPSC ring buffers preallocate the full capacity; choose the size carefully.
+
+When in doubt, run the @c benchmarks/queue_benchmark target on your target
+hardware before committing to a specific queue type.
+
+@section tutorial_lf_next Next Steps
+
+- @ref tutorial_threadpool — see how the pool consumes these queues.
+- @ref faq — answers to common lock-free questions.
+- @ref troubleshooting — debugging hazard pointer leaks and contention spikes.
+
+*/

--- a/docs/tutorial_threadpool.dox
+++ b/docs/tutorial_threadpool.dox
@@ -1,0 +1,177 @@
+/**
+@page tutorial_threadpool Tutorial: Thread Pool
+
+@tableofcontents
+
+This tutorial walks through the practical use of Thread System's two thread pool
+flavors: the basic @c thread_pool and the priority-aware @c typed_thread_pool. It
+covers when to choose each, how to configure work-stealing, and how to size the
+pool appropriately for the workload.
+
+@section tutorial_tp_intro Introduction
+
+A thread pool amortizes the cost of thread creation by reusing a fixed (or
+adaptive) set of worker threads. Submitting a task to the pool is significantly
+cheaper than spawning a new thread per task, and the pool can apply scheduling
+strategies that improve throughput, fairness, and cache locality.
+
+Thread System provides two pool flavors:
+- @c kcenon::thread::thread_pool — FIFO scheduling with an adaptive job queue.
+- @c kcenon::thread::typed_thread_pool_t<JobType> — Priority/type-aware
+  scheduling with per-type workers and aging to prevent starvation.
+
+@section tutorial_tp_when_basic When to Use thread_pool
+
+Reach for the basic @c thread_pool when:
+- All tasks are roughly equal in importance and latency requirements.
+- You need a simple submit-and-forget API with @c std::future return values.
+- The workload does not benefit from priority differentiation.
+- Throughput is the primary metric, not tail latency for hot work classes.
+
+The basic pool is the right default for most applications.
+
+@section tutorial_tp_when_typed When to Use typed_thread_pool
+
+Use @c typed_thread_pool_t when:
+- Tasks have distinct priority classes (e.g., interactive vs. background).
+- Some workers should be dedicated to a single priority to bound latency.
+- You want priority aging to prevent starvation of low-priority work.
+- You need explicit job type routing for instrumentation or rate limiting.
+
+The cost is a slightly more complex API and per-type queues, which trade
+throughput for predictable latency.
+
+@section tutorial_tp_workstealing Work-Stealing Configuration
+
+Work stealing lets idle workers pull jobs from busy peers. It is opt-in because
+the implementation introduces additional synchronization and is most useful for
+highly imbalanced workloads.
+
+Build with @c THREAD_ENABLE_WORK_STEALING=ON, then configure the pool:
+
+@code{.cpp}
+#include <kcenon/thread/stealing/work_stealing_pool.h>
+
+auto pool = kcenon::thread::stealing::work_stealing_pool::builder{}
+    .worker_count(std::thread::hardware_concurrency())
+    .numa_aware(true)        // Pin per-NUMA-node workers when available
+    .steal_attempts(4)       // Tries before parking the worker
+    .build();
+pool->start();
+@endcode
+
+Guidelines:
+- Enable NUMA awareness only on multi-socket Linux hosts; the topology probe is
+  cheap but unnecessary on consumer hardware.
+- Keep @c steal_attempts in the 2 to 8 range; higher values waste cycles, lower
+  values miss steal opportunities.
+- Profile both modes (mutex queue vs. work stealing) — work stealing is not
+  always faster for short, evenly distributed jobs.
+
+@section tutorial_tp_sizing Sizing the Pool
+
+The optimal worker count depends on whether the workload is CPU-bound or
+I/O-bound.
+
+- **CPU-bound**: Use @c std::thread::hardware_concurrency(). Adding more workers
+  than physical (or logical) cores rarely helps and increases context switching.
+- **I/O-bound**: A larger pool is fine. A common starting point is
+  @c hardware_concurrency() * (1 + average_wait_time / average_compute_time).
+- **Mixed**: Split the workload across two pools — one CPU-sized for compute
+  tasks and one larger pool for blocking I/O — to keep the compute pool free of
+  blocked workers.
+
+When in doubt, measure with your actual workload. The autoscaler can adjust the
+worker count over time based on queue depth and latency.
+
+@section tutorial_tp_example1 Example 1: Basic Thread Pool
+
+@code{.cpp}
+#include <kcenon/thread/thread_pool.h>
+#include <iostream>
+
+int main() {
+    auto pool = kcenon::thread::thread_pool::create();
+    pool->start();
+
+    auto fut = pool->submit_task([]() -> kcenon::thread::result_void {
+        std::cout << "Hello from a worker thread\n";
+        return {};
+    });
+    fut.wait();
+
+    pool->stop();
+    return 0;
+}
+@endcode
+
+@section tutorial_tp_example2 Example 2: Typed Thread Pool with Priorities
+
+@code{.cpp}
+#include <kcenon/thread/typed_thread_pool.h>
+
+int main() {
+    using job_types = kcenon::thread::job_types;
+    auto pool = std::make_shared<
+        kcenon::thread::typed_thread_pool_t<job_types>>();
+
+    // Dedicated high-priority worker bounds tail latency for interactive jobs.
+    pool->add_worker(job_types::High);
+    // Mixed worker handles normal and background work.
+    pool->add_worker({job_types::Normal, job_types::Background});
+    pool->start();
+
+    pool->enqueue(
+        std::make_unique<kcenon::thread::callback_typed_job_t<job_types>>(
+            []() -> kcenon::thread::result_void {
+                // Latency-sensitive interactive task
+                return {};
+            }, job_types::High));
+
+    pool->enqueue(
+        std::make_unique<kcenon::thread::callback_typed_job_t<job_types>>(
+            []() -> kcenon::thread::result_void {
+                // Lower priority background task
+                return {};
+            }, job_types::Background));
+
+    pool->stop();
+    return 0;
+}
+@endcode
+
+@section tutorial_tp_example3 Example 3: Sizing for an I/O-Bound Workload
+
+@code{.cpp}
+#include <kcenon/thread/thread_pool.h>
+#include <thread>
+
+int main() {
+    // I/O-bound workload: roughly 4x oversubscription is a reasonable start.
+    const std::size_t cores  = std::thread::hardware_concurrency();
+    const std::size_t workers = std::max<std::size_t>(cores * 4, 8);
+
+    auto pool = kcenon::thread::thread_pool::builder{}
+        .worker_count(workers)
+        .build();
+    pool->start();
+
+    for (int i = 0; i < 100; ++i) {
+        pool->submit_task([i]() -> kcenon::thread::result_void {
+            // Blocking network or disk operation here.
+            return {};
+        });
+    }
+
+    pool->stop();
+    return 0;
+}
+@endcode
+
+@section tutorial_tp_next Next Steps
+
+- @ref tutorial_dag for orchestrating work with explicit dependencies.
+- @ref tutorial_lockfree for choosing the right underlying queue.
+- @ref faq for quick answers to common pool questions.
+
+*/


### PR DESCRIPTION
Closes #659

## Summary
- Add 3 tutorials: thread pool, DAG, lock-free patterns
- Add FAQ page with 10+ entries
- Add troubleshooting guide
- Update mainpage.dox with Learning Resources section

## Test plan
- [ ] Doxygen builds without warnings against the new pages
- [ ] @ref cross-links resolve in mainpage Learning Resources section
- [ ] CI passes on all platforms