### PR TITLE
chore(vcpkg): sync source-local portfile with registry

### DIFF
--- a/vcpkg-ports/kcenon-thread-system/portfile.cmake
+++ b/vcpkg-ports/kcenon-thread-system/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO kcenon/thread_system
     REF "v${VERSION}"
-    SHA512 9e1bc834b3f523b55f948bc62d1496a0cfb61babe8258f6041e27b790ce8be51cbc8d495e9bdafb2d5bbc1148f05fca69542a1b97c36f030b688e8a022227d51
+    SHA512 7ff506e34c22d5e5c2e517e8dd8085513ed867a3f2eaa596d8adbe503ec39a79b36a26841c85611a96d0fd4b6c5ca4d9fa71587c4eea382af6c08b9fb7d7ccd6
     HEAD_REF main
 )
 
@@ -25,6 +25,16 @@ vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(
     PACKAGE_NAME thread_system
     CONFIG_PATH lib/cmake/thread_system
+)
+
+# In legacy/component build mode the config does not create a
+# thread_system::thread_system umbrella target.  Downstream projects
+# (monitoring_system) link against that canonical name, so inject the
+# alias when it is missing after the config has been installed.
+vcpkg_replace_string(
+    "${CURRENT_PACKAGES_DIR}/share/thread_system/thread_system-config.cmake"
+    "check_required_components(thread_system)"
+    "# Canonical umbrella alias (added by vcpkg portfile)\nif(TARGET thread_system::thread_base AND NOT TARGET thread_system::thread_system)\n    add_library(thread_system::thread_system ALIAS thread_system::thread_base)\nendif()\n\ncheck_required_components(thread_system)"
 )
 
 # Remove empty directories that cause vcpkg post-build validation errors

--- a/vcpkg-ports/kcenon-thread-system/vcpkg.json
+++ b/vcpkg-ports/kcenon-thread-system/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "kcenon-thread-system",
-  "version-semver": "0.3.1",
+  "version-semver": "0.3.2",
   "port-version": 0,
   "description": "High-performance C++20 multithreading framework with lock-free queues and adaptive optimization",
   "homepage": "https://github.com/kcenon/thread_system",


### PR DESCRIPTION
## What

Sync source-local vcpkg portfile with the central vcpkg-registry to ensure consistency.

### Changes
- **vcpkg.json**: Update `version-semver` from `0.3.1` to `0.3.2`
- **portfile.cmake**: Update SHA512 hash for v0.3.2 release tarball
- **portfile.cmake**: Add `vcpkg_replace_string` block to inject `thread_system::thread_system` umbrella target alias

## Why

The source-local portfile had drifted from the registry version. The umbrella target alias is needed because downstream projects (e.g., `monitoring_system`) link against `thread_system::thread_system`, which does not exist in legacy/component build mode without the alias shim.

## Where

| File | Change |
|------|--------|
| `vcpkg-ports/kcenon-thread-system/vcpkg.json` | Version bump to 0.3.2 |
| `vcpkg-ports/kcenon-thread-system/portfile.cmake` | SHA512 update + umbrella alias shim |

## How

- The umbrella alias maps `thread_system::thread_system` to `thread_system::thread_base` when only the base component target exists
- SHA512 hash updated to match the v0.3.2 release archive

## Related Issues

Part of kcenon/vcpkg-registry#75