### PR TITLE
refactor(api): replace throw statements with Result<T> in public headers

### DIFF
--- a/core/sync/include/cancellation_token.h
+++ b/core/sync/include/cancellation_token.h
@@ -9,6 +9,8 @@
  * @brief Implementation of a cancellation token for cooperative cancellation
  */
 
+#include <kcenon/thread/core/error_handling.h>
+
 #include <atomic>
 #include <functional>
 #include <memory>
@@ -130,13 +132,15 @@ public:
     }
     
     /**
-     * @brief Throws an exception if the token has been canceled
-     * @throws std::runtime_error if the token has been canceled
+     * @brief Checks if the token has been canceled and returns an error result
+     * @return common::VoidResult — error with operation_canceled if cancelled,
+     *         success otherwise
      */
-    void throw_if_cancelled() const {
+    [[nodiscard]] common::VoidResult check_cancelled() const {
         if (is_cancelled()) {
-            throw std::runtime_error("Operation cancelled");
+            return make_error_result(error_code::operation_canceled);
         }
+        return common::ok();
     }
     
     /**

--- a/include/kcenon/thread/core/cancellable_future.h
+++ b/include/kcenon/thread/core/cancellable_future.h
@@ -13,11 +13,11 @@
  */
 
 #include <kcenon/thread/core/cancellation_token.h>
+#include <kcenon/thread/core/error_handling.h>
 
 #include <chrono>
 #include <future>
 #include <optional>
-#include <stdexcept>
 
 namespace kcenon::thread {
 
@@ -82,42 +82,55 @@ public:
     /**
      * @brief Wait for and retrieve the result
      *
-     * @return The result value
-     * @throws std::runtime_error if the operation was cancelled
-     * @throws Any exception thrown by the callable
+     * @return common::Result<R> containing the value on success, or an error
+     *         if the operation was cancelled or threw an exception
      *
      * This method blocks until the result is ready or the operation
      * is cancelled.
      */
-    [[nodiscard]] auto get() -> R {
+    [[nodiscard]] auto get() -> common::Result<R> {
         if (token_.is_cancelled()) {
-            throw std::runtime_error("Operation cancelled");
+            return make_error_result<R>(error_code::operation_canceled);
         }
-        return future_.get();
+        try {
+            return common::Result<R>::ok(future_.get());
+        } catch (const std::exception& e) {
+            return make_error_result<R>(error_code::job_execution_failed, e.what());
+        } catch (...) {
+            return make_error_result<R>(error_code::unknown_error, "Unknown exception in future");
+        }
     }
 
     /**
      * @brief Wait for the result with timeout
      *
      * @param timeout Maximum time to wait
-     * @return The result if ready within timeout, std::nullopt otherwise
-     * @throws std::runtime_error if the operation was cancelled
+     * @return common::Result<std::optional<R>> containing the value if ready,
+     *         std::nullopt on timeout, or an error if cancelled/failed
      *
      * This method waits up to the specified timeout for the result.
-     * Returns std::nullopt if the timeout expires before the result is ready.
+     * Returns std::nullopt in the Result if the timeout expires.
      */
     [[nodiscard]] auto get_for(std::chrono::milliseconds timeout)
-        -> std::optional<R>
+        -> common::Result<std::optional<R>>
     {
         if (token_.is_cancelled()) {
-            throw std::runtime_error("Operation cancelled");
+            return make_error_result<std::optional<R>>(error_code::operation_canceled);
         }
 
         auto status = future_.wait_for(timeout);
         if (status == std::future_status::ready) {
-            return future_.get();
+            try {
+                return common::Result<std::optional<R>>::ok(future_.get());
+            } catch (const std::exception& e) {
+                return make_error_result<std::optional<R>>(
+                    error_code::job_execution_failed, e.what());
+            } catch (...) {
+                return make_error_result<std::optional<R>>(
+                    error_code::unknown_error, "Unknown exception in future");
+            }
         }
-        return std::nullopt;
+        return common::Result<std::optional<R>>::ok(std::nullopt);
     }
 
     /**
@@ -215,24 +228,37 @@ public:
     cancellable_future(cancellable_future&&) noexcept = default;
     cancellable_future& operator=(cancellable_future&&) noexcept = default;
 
-    void get() {
+    [[nodiscard]] auto get() -> common::VoidResult {
         if (token_.is_cancelled()) {
-            throw std::runtime_error("Operation cancelled");
+            return make_error_result(error_code::operation_canceled);
         }
-        future_.get();
+        try {
+            future_.get();
+            return common::ok();
+        } catch (const std::exception& e) {
+            return make_error_result(error_code::job_execution_failed, e.what());
+        } catch (...) {
+            return make_error_result(error_code::unknown_error, "Unknown exception in future");
+        }
     }
 
-    [[nodiscard]] auto get_for(std::chrono::milliseconds timeout) -> bool {
+    [[nodiscard]] auto get_for(std::chrono::milliseconds timeout) -> common::Result<bool> {
         if (token_.is_cancelled()) {
-            throw std::runtime_error("Operation cancelled");
+            return make_error_result<bool>(error_code::operation_canceled);
         }
 
         auto status = future_.wait_for(timeout);
         if (status == std::future_status::ready) {
-            future_.get();
-            return true;
+            try {
+                future_.get();
+                return common::Result<bool>::ok(true);
+            } catch (const std::exception& e) {
+                return make_error_result<bool>(error_code::job_execution_failed, e.what());
+            } catch (...) {
+                return make_error_result<bool>(error_code::unknown_error, "Unknown exception in future");
+            }
         }
-        return false;
+        return common::Result<bool>::ok(false);
     }
 
     [[nodiscard]] auto is_ready() const -> bool {

--- a/include/kcenon/thread/core/cancellation_exception.h
+++ b/include/kcenon/thread/core/cancellation_exception.h
@@ -22,9 +22,11 @@ namespace kcenon::thread
 	 *
 	 * @ingroup cancellation
 	 *
-	 * This exception is thrown by throw_if_cancelled() when the associated
-	 * cancellation token has been cancelled. It carries the cancellation_reason
-	 * for inspection by catch handlers.
+	 * This exception type represents a cancelled operation. It carries the
+	 * cancellation_reason for inspection by catch handlers.
+	 *
+	 * @note As of v1.0, public APIs use common::VoidResult via check_cancelled()
+	 *       instead of throwing this exception directly.
 	 *
 	 * ### Design Principles
 	 * - **Rich Information**: Carries full cancellation_reason for debugging
@@ -33,16 +35,15 @@ namespace kcenon::thread
 	 *
 	 * ### Usage Example
 	 * @code
-	 * try {
-	 *     token.throw_if_cancelled();
-	 *     do_work();
-	 * } catch (const operation_cancelled_exception& ex) {
-	 *     auto reason = ex.reason();
-	 *     LOG_INFO("Operation cancelled: {}", reason.to_string());
+	 * auto result = token.check_cancelled();
+	 * if (result.is_err()) {
+	 *     LOG_INFO("Operation cancelled: {}", result.error().message);
+	 *     return result;
 	 * }
+	 * do_work();
 	 * @endcode
 	 *
-	 * @see enhanced_cancellation_token::throw_if_cancelled()
+	 * @see enhanced_cancellation_token::check_cancelled()
 	 * @see cancellation_reason
 	 */
 	class operation_cancelled_exception : public std::exception

--- a/include/kcenon/thread/core/cancellation_token.h
+++ b/include/kcenon/thread/core/cancellation_token.h
@@ -9,6 +9,8 @@
  * @brief Implementation of a cancellation token for cooperative cancellation
  */
 
+#include <kcenon/thread/core/error_handling.h>
+
 #include <atomic>
 #include <functional>
 #include <memory>
@@ -139,13 +141,15 @@ public:
     }
     
     /**
-     * @brief Throws an exception if the token has been canceled
-     * @throws std::runtime_error if the token has been canceled
+     * @brief Checks if the token has been canceled and returns an error result
+     * @return common::VoidResult — error with operation_canceled if cancelled,
+     *         success otherwise
      */
-    void throw_if_cancelled() const {
+    [[nodiscard]] common::VoidResult check_cancelled() const {
         if (is_cancelled()) {
-            throw std::runtime_error("Operation cancelled");
+            return make_error_result(error_code::operation_canceled);
         }
+        return common::ok();
     }
     
     /**

--- a/include/kcenon/thread/core/enhanced_cancellation_token.h
+++ b/include/kcenon/thread/core/enhanced_cancellation_token.h
@@ -11,6 +11,7 @@
 
 #include "cancellation_exception.h"
 #include "cancellation_reason.h"
+#include "error_handling.h"
 
 #include <atomic>
 #include <chrono>
@@ -230,10 +231,11 @@ namespace kcenon::thread
 		[[nodiscard]] auto get_reason() const -> std::optional<cancellation_reason>;
 
 		/**
-		 * @brief Throws if the token has been cancelled.
-		 * @throws operation_cancelled_exception if cancelled.
+		 * @brief Checks if the token has been cancelled and returns an error result.
+		 * @return common::VoidResult — error with operation_canceled if cancelled,
+		 *         success otherwise
 		 */
-		auto throw_if_cancelled() const -> void;
+		[[nodiscard]] auto check_cancelled() const -> common::VoidResult;
 
 		// ====================================================================
 		// Timeout/Deadline
@@ -404,13 +406,13 @@ namespace kcenon::thread
 	 * void process_request(enhanced_cancellation_token token) {
 	 *     cancellation_scope scope(token);
 	 *
-	 *     scope.check_cancelled();  // Throws if cancelled
+	 *     if (scope.check_cancelled().is_err()) return;
 	 *     step_1();
 	 *
-	 *     scope.check_cancelled();
+	 *     if (scope.check_cancelled().is_err()) return;
 	 *     step_2();
 	 *
-	 *     scope.check_cancelled();
+	 *     if (scope.check_cancelled().is_err()) return;
 	 *     step_3();
 	 * }
 	 * @endcode
@@ -442,10 +444,11 @@ namespace kcenon::thread
 		[[nodiscard]] auto is_cancelled() const -> bool;
 
 		/**
-		 * @brief Throws if the token is cancelled.
-		 * @throws operation_cancelled_exception if cancelled.
+		 * @brief Checks if the token is cancelled and returns an error result.
+		 * @return common::VoidResult — error with operation_canceled if cancelled,
+		 *         success otherwise
 		 */
-		auto check_cancelled() const -> void;
+		[[nodiscard]] auto check_cancelled() const -> common::VoidResult;
 
 		/**
 		 * @brief Gets the underlying token.

--- a/include/kcenon/thread/core/thread_pool.h
+++ b/include/kcenon/thread/core/thread_pool.h
@@ -488,12 +488,13 @@ namespace kcenon::thread
 		 * @tparam R Return type (automatically deduced)
 		 * @param callables Vector of functions to execute
 		 * @param opts Submit options (wait_any is implicitly true)
-		 * @return First completed result
+		 * @return common::Result<R> containing the first completed result, or an
+		 *         error if callables is empty or execution failed
 		 */
 		template<typename F, typename R = std::invoke_result_t<std::decay_t<F>>>
 		[[nodiscard]] auto submit_wait_any(std::vector<F>&& callables,
 		                                   const submit_options& opts = {})
-		    -> R;
+		    -> common::Result<R>;
 
 		/**
 		 * @brief Check if the thread pool is currently running

--- a/include/kcenon/thread/core/thread_pool_impl.h
+++ b/include/kcenon/thread/core/thread_pool_impl.h
@@ -15,6 +15,7 @@
  * Separated from thread_pool.h to reduce header size and improve compilation times.
  */
 
+#include <kcenon/thread/core/error_handling.h>
 #include <kcenon/thread/core/future_job.h>
 #include <kcenon/thread/utils/batch_operations.h>
 
@@ -23,7 +24,6 @@
 #include <thread>
 #include <memory>
 #include <atomic>
-#include <stdexcept>
 
 namespace kcenon::thread {
 
@@ -77,10 +77,10 @@ auto thread_pool::submit_wait_all(std::vector<F>&& callables, const submit_optio
 
 template<typename F, typename R>
 auto thread_pool::submit_wait_any(std::vector<F>&& callables, const submit_options& opts)
-    -> R
+    -> common::Result<R>
 {
     if (callables.empty()) {
-        throw std::invalid_argument("Empty callables vector");
+        return make_error_result<R>(error_code::invalid_argument, "Empty callables vector");
     }
 
     auto futures = submit<F, R>(std::move(callables), opts);
@@ -105,7 +105,13 @@ auto thread_pool::submit_wait_any(std::vector<F>&& callables, const submit_optio
         }).detach();
     }
 
-    return result_future.get();
+    try {
+        return common::Result<R>::ok(result_future.get());
+    } catch (const std::exception& e) {
+        return make_error_result<R>(error_code::job_execution_failed, e.what());
+    } catch (...) {
+        return make_error_result<R>(error_code::unknown_error, "Unknown exception in submit_wait_any");
+    }
 }
 
 template<typename T>

--- a/src/core/enhanced_cancellation_token.cpp
+++ b/src/core/enhanced_cancellation_token.cpp
@@ -297,21 +297,19 @@ namespace kcenon::thread
 		return state_->reason;
 	}
 
-	auto enhanced_cancellation_token::throw_if_cancelled() const -> void
+	auto enhanced_cancellation_token::check_cancelled() const -> common::VoidResult
 	{
 		if (is_cancelled())
 		{
 			auto reason = get_reason();
-			if (reason)
+			std::string msg = "Operation cancelled";
+			if (reason && !reason->message.empty())
 			{
-				throw operation_cancelled_exception(*reason);
+				msg += ": " + reason->message;
 			}
-			throw operation_cancelled_exception(
-				cancellation_reason{cancellation_reason::type::user_requested,
-									"Operation cancelled",
-									std::chrono::steady_clock::now(),
-									std::nullopt});
+			return make_error_result(error_code::operation_canceled, msg);
 		}
+		return common::ok();
 	}
 
 	auto enhanced_cancellation_token::has_timeout() const -> bool
@@ -586,9 +584,9 @@ namespace kcenon::thread
 		return token_.is_cancelled();
 	}
 
-	auto cancellation_scope::check_cancelled() const -> void
+	auto cancellation_scope::check_cancelled() const -> common::VoidResult
 	{
-		token_.throw_if_cancelled();
+		return token_.check_cancelled();
 	}
 
 	auto cancellation_scope::token() const -> const enhanced_cancellation_token&

--- a/tests/unit/thread_base_test/enhanced_cancellation_token_test.cpp
+++ b/tests/unit/thread_base_test/enhanced_cancellation_token_test.cpp
@@ -104,26 +104,23 @@ TEST_F(enhanced_cancellation_token_test, CancelWithException)
 	EXPECT_TRUE(reason->exception.has_value());
 }
 
-TEST_F(enhanced_cancellation_token_test, ThrowIfCancelled)
+TEST_F(enhanced_cancellation_token_test, CheckCancelled)
 {
 	auto token = enhanced_cancellation_token::create();
 
-	// Should not throw when not cancelled
-	EXPECT_NO_THROW(token.throw_if_cancelled());
+	// Should return success when not cancelled
+	auto ok_result = token.check_cancelled();
+	EXPECT_TRUE(ok_result.is_ok());
 
 	token.cancel("Test cancellation");
 
-	// Should throw when cancelled
-	EXPECT_THROW(token.throw_if_cancelled(), operation_cancelled_exception);
-
-	try
-	{
-		token.throw_if_cancelled();
-	}
-	catch (const operation_cancelled_exception& ex)
-	{
-		EXPECT_EQ(ex.reason().reason_type, cancellation_reason::type::user_requested);
-	}
+	// Should return error when cancelled
+	auto err_result = token.check_cancelled();
+	EXPECT_TRUE(err_result.is_err());
+	EXPECT_EQ(get_error_code(err_result.error()),
+			  error_code::operation_canceled);
+	EXPECT_TRUE(err_result.error().message.find("Test cancellation")
+				!= std::string::npos);
 }
 
 // ============================================================================
@@ -431,12 +428,20 @@ TEST_F(enhanced_cancellation_token_test, CancellationScope)
 	cancellation_scope scope(token);
 
 	EXPECT_FALSE(scope.is_cancelled());
-	EXPECT_NO_THROW(scope.check_cancelled());
+	{
+		auto result = scope.check_cancelled();
+		EXPECT_TRUE(result.is_ok());
+	}
 
 	token.cancel();
 
 	EXPECT_TRUE(scope.is_cancelled());
-	EXPECT_THROW(scope.check_cancelled(), operation_cancelled_exception);
+	{
+		auto result = scope.check_cancelled();
+		EXPECT_TRUE(result.is_err());
+		EXPECT_EQ(get_error_code(result.error()),
+				  error_code::operation_canceled);
+	}
 }
 
 TEST_F(enhanced_cancellation_token_test, CancellationContext)

--- a/tests/unit/thread_pool_test/future_promise_test.cpp
+++ b/tests/unit/thread_pool_test/future_promise_test.cpp
@@ -158,12 +158,14 @@ TEST_F(FuturePromiseTest, SubmitWaitAnyReturnsFirstResult) {
     auto result = pool_->submit_wait_any(std::move(tasks));
 
     // Should return quickly (the fast task)
-    EXPECT_TRUE(result == 1 || result == 2);
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_TRUE(result.unwrap() == 1 || result.unwrap() == 2);
 }
 
-TEST_F(FuturePromiseTest, SubmitWaitAnyThrowsOnEmptyVector) {
+TEST_F(FuturePromiseTest, SubmitWaitAnyReturnsErrorOnEmptyVector) {
     std::vector<std::function<int()>> empty_tasks;
-    EXPECT_THROW(pool_->submit_wait_any(std::move(empty_tasks)), std::invalid_argument);
+    auto result = pool_->submit_wait_any(std::move(empty_tasks));
+    EXPECT_TRUE(result.is_err());
 }
 
 // ============================================================================
@@ -248,7 +250,9 @@ TEST_F(FuturePromiseTest, CancellableFutureBasicUsage) {
 
     cancellable_future<int> cf(std::move(future), token);
     EXPECT_FALSE(cf.is_cancelled());
-    EXPECT_EQ(cf.get(), 42);
+    auto result = cf.get();
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_EQ(result.unwrap(), 42);
 }
 
 TEST_F(FuturePromiseTest, CancellableFutureCancel) {
@@ -273,9 +277,10 @@ TEST_F(FuturePromiseTest, CancellableFutureGetForWithTimeout) {
 
     cancellable_future<int> cf(std::move(future), token);
 
-    // Short timeout - should return nullopt
+    // Short timeout - should return ok(nullopt)
     auto result = cf.get_for(std::chrono::milliseconds(10));
-    EXPECT_FALSE(result.has_value());
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_FALSE(result.unwrap().has_value());
 }
 
 TEST_F(FuturePromiseTest, CancellableFutureIsReady) {

--- a/tests/unit/thread_pool_test/unified_submit_test.cpp
+++ b/tests/unit/thread_pool_test/unified_submit_test.cpp
@@ -225,12 +225,14 @@ TEST_F(UnifiedSubmitTest, SubmitWaitAnyReturnsFirstResult) {
 
     auto result = pool_->submit_wait_any(std::move(tasks));
 
-    EXPECT_TRUE(result == 1 || result == 2);
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_TRUE(result.unwrap() == 1 || result.unwrap() == 2);
 }
 
-TEST_F(UnifiedSubmitTest, SubmitWaitAnyThrowsOnEmptyVector) {
+TEST_F(UnifiedSubmitTest, SubmitWaitAnyReturnsErrorOnEmptyVector) {
     std::vector<std::function<int()>> empty_tasks;
-    EXPECT_THROW(pool_->submit_wait_any(std::move(empty_tasks)), std::invalid_argument);
+    auto result = pool_->submit_wait_any(std::move(empty_tasks));
+    EXPECT_TRUE(result.is_err());
 }
 
 TEST_F(UnifiedSubmitTest, SubmitWaitAnyWithOptions) {
@@ -240,7 +242,8 @@ TEST_F(UnifiedSubmitTest, SubmitWaitAnyWithOptions) {
 
     auto result = pool_->submit_wait_any(std::move(tasks), submit_options::named("any_job"));
 
-    EXPECT_TRUE(result == 10 || result == 20);
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_TRUE(result.unwrap() == 10 || result.unwrap() == 20);
 }
 
 }  // namespace kcenon::thread::test


### PR DESCRIPTION
## What

### Summary
Replace all `throw` statements in public API headers with `common::Result<T>` or `common::VoidResult` return types, ensuring consistent error handling before the v1.0 API freeze.

### Change Type
- [x] Refactor (no functional changes in error behavior, but API signatures changed)

### Affected Components
- `include/kcenon/thread/core/cancellation_token.h` — `throw_if_cancelled()` → `check_cancelled()` returning `VoidResult`
- `include/kcenon/thread/core/enhanced_cancellation_token.h` — same rename + `cancellation_scope::check_cancelled()` return type
- `include/kcenon/thread/core/cancellable_future.h` — `get()` and `get_for()` return Result types
- `include/kcenon/thread/core/thread_pool_impl.h` — `submit_wait_any()` returns `Result<R>`
- `include/kcenon/thread/core/thread_pool.h` — declaration update
- `core/sync/include/cancellation_token.h` — module build copy sync

## Why

### Related Issues
- Closes #671
- Part of #670 (Prepare thread_system for v1.0 release)

### Motivation
- Public API mixed exception-based and Result<T>-based error handling inconsistently
- `error_handling.h` provides comprehensive `make_error_result<T>()` infrastructure but it was not applied in all public methods
- v1.0 API stability requires a single, predictable error handling pattern
- Exceptions in threading libraries can cause undefined behavior at thread boundaries if uncaught

## Where

### Files Changed

| Directory | Files | Type of Change |
|-----------|-------|----------------|
| `include/kcenon/thread/core/` | 6 | API signature changes |
| `core/sync/include/` | 1 | Module build sync |
| `src/core/` | 1 | Implementation update |
| `tests/unit/` | 3 | Test assertions updated |

### API Changes

| API | Before | After |
|-----|--------|-------|
| `cancellation_token::throw_if_cancelled()` | `void` (throws) | **Removed** → `check_cancelled()` returns `VoidResult` |
| `enhanced_cancellation_token::throw_if_cancelled()` | `void` (throws) | **Removed** → `check_cancelled()` returns `VoidResult` |
| `cancellation_scope::check_cancelled()` | `void` (throws) | Returns `VoidResult` |
| `cancellable_future<R>::get()` | `R` (throws) | `common::Result<R>` |
| `cancellable_future<R>::get_for()` | `optional<R>` (throws) | `common::Result<optional<R>>` |
| `cancellable_future<void>::get()` | `void` (throws) | `common::VoidResult` |
| `cancellable_future<void>::get_for()` | `bool` (throws) | `common::Result<bool>` |
| `thread_pool::submit_wait_any()` | `R` (throws) | `common::Result<R>` |

## How

### Implementation Details
1. Each `throw` site mapped to appropriate `error_code` from `error_handling.h`
2. Functions returning values changed to `common::Result<T>` wrapping both cancellation errors and future exceptions
3. `std::future::get()` exceptions caught and converted to `error_code::job_execution_failed`
4. All tests updated from `EXPECT_THROW` to `EXPECT_TRUE(result.is_err())` pattern

### Testing Done
- [x] Full build passes (debug preset)
- [x] 382/383 unit tests pass (1 pre-existing failure: `LifecycleControllerTest.InitialStateIsCreated`)
- [x] All modified tests verified with new Result-based assertions

### Breaking Changes
- `throw_if_cancelled()` renamed to `check_cancelled()` (both token types)
- `cancellable_future::get()` return type changed from `R` to `common::Result<R>`
- `cancellable_future::get_for()` return type changed
- `thread_pool::submit_wait_any()` return type changed from `R` to `common::Result<R>`

### Test Plan
1. Build: `cmake --preset debug && cmake --build build-debug`
2. Run tests: `cd build-debug && ctest --output-on-failure`
3. Verify zero `throw` in public headers: `grep -rn '\bthrow\b' include/kcenon/thread/core/`