### PR TITLE
refactor(api): add deprecation markers for v1.0 API freeze

### DIFF
--- a/docs/advanced/MIGRATION.md
+++ b/docs/advanced/MIGRATION.md
@@ -16,6 +16,7 @@ category: "MIGR"
 
 ## Table of Contents
 
+- [v1.0.0 API Freeze (current)](#v100-api-freeze-current)
 - [v3.0.0 Migration (common_system)](#v300-migration-common_system)
 - [Overview](#overview)
 - [Migration Status](#migration-status)
@@ -34,6 +35,78 @@ category: "MIGR"
 - [Timeline](#timeline)
   - [Current Status (2025-09-13)](#current-status-2025-09-13)
   - [Detailed Status Log](#detailed-status-log)
+
+## v1.0.0 API Freeze (current)
+
+**Release Date:** 2026-04-14
+
+v1.0.0 is an **API stability commitment**. From v1.0.0 onward, any breaking change
+to the public API requires a major version bump. This section records the surface
+that was frozen and the legacy APIs that remain only for migration support.
+
+### Frozen Public Surface
+
+The authoritative public headers live under `include/kcenon/thread/`:
+
+| Subsystem | Path | Notes |
+|-----------|------|-------|
+| Core threading | `core/` | `thread_pool`, `thread_worker`, `job`, `job_queue`, `cancellation_token`, `future_job`, `submit_options` |
+| Queues | `queue/`, `concurrent/` | `adaptive_job_queue`, `concurrent_queue`, `queue_factory` |
+| DAG | `dag/` | `dag_scheduler`, `dag_job`, `dag_job_builder` |
+| Configuration | `thread_config.h`, `config/` | Unified builder for pool, DAG, and aging settings |
+| Error handling | `core/error_handling.h` | `error_code` enum + `common::Result<T>` / `common::VoidResult` helpers |
+| Synchronization | `core/sync_primitives.h`, `core/hazard_pointer.h` | Lock-free reclamation helpers |
+
+### Deprecated in v1.0.0 (slated for removal in v2.0.0)
+
+The following APIs emit compiler warnings in v1.0.0 and will be removed in v2.0.0.
+
+| Symbol | Replacement | Trigger |
+|--------|-------------|---------|
+| `thread_system::` / `thread_module::` / `thread_namespace::` namespace aliases | Use `kcenon::thread::` directly | `#pragma message` on `compatibility.h` include |
+| `utility_module::` namespace alias | Use `kcenon::thread::utils::` directly | `#pragma message` on `compatibility.h` include |
+| `kcenon::thread::log_level` (enum in `thread_logger.h`) | `kcenon::thread::log_level_v2` or `common::interfaces::log_level` | Warnings via the deprecated `thread_logger` methods that consume it |
+| `kcenon::thread::thread_logger::log()`, `log_error()`, `set_enabled()`, `is_enabled()`, `set_level()`, `set_lightweight_mode()`, `is_lightweight_mode()` | `thread_context::log()` with `common::interfaces::ILogger` | `[[deprecated]]` attribute |
+| `<kcenon/thread/lockfree/lockfree_queue.h>` (forwarding header) | `<kcenon/thread/concurrent/concurrent_queue.h>` | `#pragma message` on include |
+| `<kcenon/thread/core/thread_pool_fmt.h>` (forwarding header) | `<kcenon/thread/formatters.h>` | `#pragma message` on include (pre-existing) |
+| `<kcenon/thread/dag/dag_config.h>` (documentation-only deprecation) | `<kcenon/thread/thread_config.h>` builder | Doxygen `@deprecated` |
+| `<kcenon/thread/impl/typed_pool/priority_aging_config.h>` (documentation-only deprecation) | `<kcenon/thread/thread_config.h>` builder | Doxygen `@deprecated` |
+
+### Silencing Legacy Warnings During Migration
+
+While migrating a dependent project, warnings emitted by legacy headers can be
+silenced by defining the following macros **before** the `#include`:
+
+```cpp
+// Legacy namespace aliases in compatibility.h
+#define THREAD_SUPPRESS_LEGACY_NAMESPACE_WARNING 1
+#include <kcenon/thread/compatibility.h>
+
+// Legacy forwarding header lockfree_queue.h
+#define THREAD_SUPPRESS_LEGACY_LOCKFREE_QUEUE_WARNING 1
+#include <kcenon/thread/lockfree/lockfree_queue.h>
+```
+
+These macros must be removed before v2.0.0 adoption.
+
+### API Changes Since v3.0.0
+
+- `cancellation_token::check_cancelled()` returns `common::VoidResult`
+  (previously `throw_if_cancelled()` threw `std::runtime_error`). See #671.
+- `cancellable_future<T>::get()` / `get_for()` return
+  `common::Result<T>` / `common::Result<std::optional<T>>`. See #671.
+- `thread_pool::submit_wait_any()` returns `common::Result<R>` with
+  `error_code::invalid_argument` for empty input. See #671.
+
+### Removed in v1.0.0
+
+Previously removed in v3.0.0 (kept for reference):
+
+- `kcenon::thread::result<T>` / `result_void` / `error` — use `common::Result<T>` / `common::VoidResult` / `common::error_info`.
+- `kcenon::thread::logger_interface` / `monitoring_interface` / `monitorable_interface` — use `common::interfaces::ILogger` / `IMonitor` / `IMonitorable`.
+- `kcenon::thread::throw_if_cancelled()` — removed in #671, replaced by `check_cancelled()` returning `common::VoidResult`.
+
+---
 
 ## v3.0.0 Migration (common_system)
 

--- a/include/kcenon/thread/compatibility.h
+++ b/include/kcenon/thread/compatibility.h
@@ -24,9 +24,28 @@ namespace detail {}
 
 // Legacy namespace aliases. These remain until dependent projects
 // migrate to the unified kcenon::thread namespace.
+//
+// @deprecated Since v1.0.0. These aliases will be removed in v2.0.0.
+// Use `kcenon::thread` and `kcenon::thread::utils` directly instead.
+//
+// NOTE: The C++ standard does not support `[[deprecated]]` on namespace
+// aliases (only on namespace definitions). Consumers that need compile-time
+// warnings should migrate include-by-include; an include-guard warning is
+// emitted once per translation unit below (suppressible by defining
+// THREAD_SUPPRESS_LEGACY_NAMESPACE_WARNING before the include).
 namespace thread_system = kcenon::thread;
 namespace thread_module = kcenon::thread;
 namespace thread_namespace = kcenon::thread;
 
 // Legacy utility namespace names still expected by some consumers.
 namespace utility_module = kcenon::thread::utils;
+
+#if !defined(THREAD_SUPPRESS_LEGACY_NAMESPACE_WARNING) \
+    && !defined(KCENON_THREAD_COMPATIBILITY_H_WARNED)
+#define KCENON_THREAD_COMPATIBILITY_H_WARNED 1
+#if defined(_MSC_VER)
+#pragma message("thread_system/thread_module/thread_namespace/utility_module namespace aliases are deprecated since v1.0.0 and will be removed in v2.0.0. Use 'kcenon::thread' directly. Define THREAD_SUPPRESS_LEGACY_NAMESPACE_WARNING to silence this warning.")
+#elif defined(__GNUC__) || defined(__clang__)
+#pragma message "thread_system/thread_module/thread_namespace/utility_module namespace aliases are deprecated since v1.0.0 and will be removed in v2.0.0. Use 'kcenon::thread' directly. Define THREAD_SUPPRESS_LEGACY_NAMESPACE_WARNING to silence this warning."
+#endif
+#endif

--- a/include/kcenon/thread/core/thread_logger.h
+++ b/include/kcenon/thread/core/thread_logger.h
@@ -26,7 +26,18 @@ namespace kcenon::thread {
 
 /**
  * @enum log_level
- * @brief Logging severity levels
+ * @brief Logging severity levels (legacy).
+ *
+ * @deprecated Since v1.0.0. Use `kcenon::thread::log_level_v2` (from
+ * `<kcenon/thread/core/log_level.h>`) or `common::interfaces::log_level`
+ * (from common_system) instead. Will be removed in v2.0.0.
+ * See Issue #261 for migration details.
+ *
+ * NOTE: `[[deprecated]]` is applied at the `thread_logger` member-function
+ * level (log/set_level/log_error) rather than on this enum itself, because
+ * this type is still referenced internally by the SDOF-safe shutdown
+ * helpers. Using `log_level` via a deprecated API emits a warning; direct
+ * use without the logger does not.
  */
 enum class log_level {
     trace,
@@ -108,34 +119,60 @@ public:
     }
 
     /**
-     * @brief Enable/disable logging
+     * @brief Enable/disable logging.
+     *
+     * @deprecated Since v1.0.0. Inject a `common::interfaces::ILogger`
+     * via `thread_context` and control logging through its implementation
+     * instead. Will be removed in v2.0.0.
      */
+    [[deprecated(
+        "Use 'common::interfaces::ILogger' via thread_context instead. "
+        "Will be removed in v2.0.")]]
     void set_enabled(bool enabled) {
         enabled_ = enabled;
     }
 
     /**
-     * @brief Check if logging is enabled
+     * @brief Check if logging is enabled.
+     *
+     * @deprecated Since v1.0.0. Check availability through
+     * `thread_context::has_logger()` instead. Will be removed in v2.0.0.
      */
+    [[deprecated(
+        "Use 'thread_context::has_logger()' instead. "
+        "Will be removed in v2.0.")]]
     bool is_enabled() const {
         return enabled_;
     }
 
     /**
-     * @brief Set minimum log level
+     * @brief Set minimum log level.
+     *
+     * @deprecated Since v1.0.0. Configure log level on the injected
+     * `common::interfaces::ILogger` implementation instead.
+     * Will be removed in v2.0.0.
      */
+    [[deprecated(
+        "Configure log level on 'common::interfaces::ILogger' instead. "
+        "Will be removed in v2.0.")]]
     void set_level(log_level level) {
         min_level_ = level;
     }
 
     /**
-     * @brief Log a message with context
+     * @brief Log a message with context.
      *
      * @param level Severity level
      * @param thread_name Thread identifier
      * @param message Log message
      * @param context Additional context (optional)
+     *
+     * @deprecated Since v1.0.0. Use `thread_context::log()` backed by
+     * `common::interfaces::ILogger` instead. Will be removed in v2.0.0.
      */
+    [[deprecated(
+        "Use 'thread_context::log()' with 'common::interfaces::ILogger' "
+        "instead. Will be removed in v2.0.")]]
     void log(log_level level, std::string_view thread_name,
              std::string_view message, std::string_view context = "") {
         // Early return during shutdown to avoid accessing potentially destroyed resources
@@ -179,9 +216,16 @@ public:
     }
 
     /**
-     * @brief Log error with error code
+     * @brief Log error with error code.
+     *
+     * @deprecated Since v1.0.0. Use `thread_context::log()` with a
+     * `common::interfaces::ILogger` implementation instead. Will be
+     * removed in v2.0.0.
      */
     template<typename ErrorType>
+    [[deprecated(
+        "Use 'thread_context::log()' with 'common::interfaces::ILogger' "
+        "instead. Will be removed in v2.0.")]]
     void log_error(std::string_view thread_name, const ErrorType& error) {
         // Early return during shutdown
         if (is_shutting_down_.load(std::memory_order_acquire) || !enabled_) {
@@ -229,14 +273,21 @@ private:
 
 public:
     /**
-     * @brief Enable lightweight mode (disables all logging for maximum performance)
+     * @brief Enable lightweight mode (disables all logging for maximum performance).
      *
      * In lightweight mode, all log calls become no-ops with minimal overhead.
      * Useful for performance-critical production deployments where diagnostics
      * are handled externally.
      *
      * @param enabled true to enable lightweight mode, false to use normal logging
+     *
+     * @deprecated Since v1.0.0. With `common::interfaces::ILogger`, a
+     * null logger in `thread_context` achieves the same effect without
+     * this toggle. Will be removed in v2.0.0.
      */
+    [[deprecated(
+        "Use a null 'common::interfaces::ILogger' in thread_context to "
+        "disable logging. Will be removed in v2.0.")]]
     void set_lightweight_mode(bool enabled) {
         lightweight_mode_ = enabled;
         // Disable logging when in lightweight mode
@@ -246,8 +297,14 @@ public:
     }
 
     /**
-     * @brief Check if in lightweight mode
+     * @brief Check if in lightweight mode.
+     *
+     * @deprecated Since v1.0.0. See `set_lightweight_mode` deprecation.
+     * Will be removed in v2.0.0.
      */
+    [[deprecated(
+        "Superseded by 'common::interfaces::ILogger' injection. "
+        "Will be removed in v2.0.")]]
     bool is_lightweight_mode() const {
         return lightweight_mode_;
     }

--- a/include/kcenon/thread/lockfree/lockfree_queue.h
+++ b/include/kcenon/thread/lockfree/lockfree_queue.h
@@ -48,5 +48,15 @@
 
 #pragma once
 
+#if !defined(THREAD_SUPPRESS_LEGACY_LOCKFREE_QUEUE_WARNING) \
+    && !defined(KCENON_THREAD_LOCKFREE_QUEUE_H_WARNED)
+#define KCENON_THREAD_LOCKFREE_QUEUE_H_WARNED 1
+#if defined(_MSC_VER)
+#pragma message("<kcenon/thread/lockfree/lockfree_queue.h> is deprecated since v1.0.0 and will be removed in v2.0.0. Include <kcenon/thread/concurrent/concurrent_queue.h> instead. Define THREAD_SUPPRESS_LEGACY_LOCKFREE_QUEUE_WARNING to silence this warning.")
+#elif defined(__GNUC__) || defined(__clang__)
+#pragma message "<kcenon/thread/lockfree/lockfree_queue.h> is deprecated since v1.0.0 and will be removed in v2.0.0. Include <kcenon/thread/concurrent/concurrent_queue.h> instead. Define THREAD_SUPPRESS_LEGACY_LOCKFREE_QUEUE_WARNING to silence this warning."
+#endif
+#endif
+
 // Include the new location
 #include <kcenon/thread/concurrent/concurrent_queue.h>

--- a/src/modules/queue.cppm
+++ b/src/modules/queue.cppm
@@ -38,6 +38,11 @@ module;
 #include <kcenon/thread/core/job_queue.h>
 #include <kcenon/thread/queue/adaptive_job_queue.h>
 #include <kcenon/thread/queue/queue_factory.h>
+
+// The legacy lockfree_queue.h re-exports concurrent_queue under the old
+// name for backward compatibility. Suppress its deprecation notice here
+// because the module itself is the authorized re-exporter.
+#define THREAD_SUPPRESS_LEGACY_LOCKFREE_QUEUE_WARNING 1
 #include <kcenon/thread/lockfree/lockfree_queue.h>
 #include <kcenon/thread/lockfree/lockfree_job_queue.h>
 #include <kcenon/thread/lockfree/work_stealing_deque.h>


### PR DESCRIPTION
Closes #672
Part of #670

## Summary

- Attach `[[deprecated]]` attributes to legacy `thread_logger` user-facing methods (`log`, `log_error`, `set_level`, `set_enabled`, `set_lightweight_mode`, `is_lightweight_mode`) so consumers of the legacy logging path see compiler warnings. Internal SDOF-safe helpers (`instance`, `is_shutting_down`, `prepare_shutdown`) remain stable because `thread_context` still depends on them.
- Emit `#pragma message` warnings on include of `compatibility.h` (namespace aliases `thread_system`, `thread_module`, `thread_namespace`, `utility_module`) and `lockfree/lockfree_queue.h` (forwarding header for `concurrent_queue.h`). Namespace aliases cannot carry a portable `[[deprecated]]` attribute, so pragma-based warnings are the only viable signal.
- Provide suppression macros (`THREAD_SUPPRESS_LEGACY_NAMESPACE_WARNING`, `THREAD_SUPPRESS_LEGACY_LOCKFREE_QUEUE_WARNING`) for consumers that need a quiet migration window.
- `queue.cppm` defines `THREAD_SUPPRESS_LEGACY_LOCKFREE_QUEUE_WARNING` before including `lockfree_queue.h` so the module re-export path stays quiet.
- Add a `v1.0.0 API Freeze` section to `docs/advanced/MIGRATION.md` that records the frozen public surface, the legacy APIs scheduled for removal in v2.0.0, and the suppression macros consumers can use during migration.

## Context

The v3.0.0 pass removed legacy types (`thread::result<T>`, `result_void`, `error`, `logger_interface`, `monitoring_interface`) but left transitional compatibility surfaces without compiler-visible deprecation signals. Issue #672 is the v1.0 freeze audit — surface-wide review of 129 public headers to add `[[deprecated]]` markers and migration paths before v2.0 can make breaking changes. No dead code was found; the freeze is additive only.

## What changed

| File | Change |
|------|--------|
| `include/kcenon/thread/compatibility.h` | Add `#pragma message` for namespace aliases + suppression macro |
| `include/kcenon/thread/core/thread_logger.h` | `[[deprecated]]` on 7 user-facing methods; strengthen `log_level` enum doc |
| `include/kcenon/thread/lockfree/lockfree_queue.h` | Add `#pragma message` for forwarding header + suppression macro |
| `src/modules/queue.cppm` | Define suppression macro before legacy include |
| `docs/advanced/MIGRATION.md` | New v1.0.0 API Freeze section with deprecation table and suppression guide |

## Test plan

- [x] `cmake --build build-debug` succeeds with exit code 0
- [x] Build emits 11 deprecation warnings from consumers that still touch the legacy methods — proves attributes are effective
- [x] `ctest --test-dir build-debug` — 382/383 thread_base_unit tests pass (same pre-existing `LifecycleControllerTest.InitialStateIsCreated` failure as before #671; unrelated to this PR)
- [x] No changes to functional behavior; only attribute/message additions and doc updates
- [x] `queue.cppm` module re-export path stays quiet (suppression macro applied before include)

## Notes for reviewers

- The `log_level` enum itself does **not** carry `[[deprecated]]`. Applying it at the enum level would trigger warnings inside `thread_logger.h` itself (member initializer, internal signatures, `level_to_string`). The deprecation still propagates because every user-facing method that accepts `log_level` is itself `[[deprecated]]`. The rationale is documented in the enum's doc comment.
- Namespace aliases (`thread_system`, `thread_module`, etc.) can't be marked `[[deprecated]]` in portable C++ — the standard permits the attribute on namespace *definitions* but not on *aliases*. `#pragma message` is the only portable fallback.
- v3.0.0 migration section in MIGRATION.md is preserved unchanged for historical context. The new v1.0.0 section is additive.