### PR TITLE
docs(version): update documentation, CHANGELOG, and version for v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Documentation
+## [1.0.0] - 2026-04-15
 
-- Modernize Doxygen documentation with doxygen-awesome-css theme and refactored mainpage ([#652](https://github.com/kcenon/thread_system/issues/652))
+### Added
+
+- vcpkg CMake preset for streamlined builds ([#632](https://github.com/kcenon/thread_system/issues/632))
+- Tutorials, FAQ, and troubleshooting guide ([#661](https://github.com/kcenon/thread_system/issues/661))
+- Getting Started guide with categorized examples ([#655](https://github.com/kcenon/thread_system/issues/655))
+- Architecture Decision Records (ADR) ([#648](https://github.com/kcenon/thread_system/issues/648))
+- SSOT documentation registry ([#646](https://github.com/kcenon/thread_system/issues/646))
+- Issue/PR templates, CONTRIBUTING, CODE_OF_CONDUCT, SECURITY ([#628](https://github.com/kcenon/thread_system/issues/628))
+- CHANGELOG.md and CONTRIBUTING.md ([#596](https://github.com/kcenon/thread_system/issues/596))
+- Documentation audit CI workflow for PRs ([#650](https://github.com/kcenon/thread_system/issues/650))
+- Automated vcpkg registry sync on release ([#629](https://github.com/kcenon/thread_system/issues/629))
+
+### Changed
+
+- **BREAKING**: Rename CMake project from `ThreadSystem` to `thread_system` ([#642](https://github.com/kcenon/thread_system/issues/642))
+- Replace `throw` statements with `Result<T>` in all public API headers ([#675](https://github.com/kcenon/thread_system/issues/675))
+- Add deprecation markers for v1.0 API freeze ([#676](https://github.com/kcenon/thread_system/issues/676))
+- Remove deprecated job classes, resilience headers, and policy methods ([#611](https://github.com/kcenon/thread_system/issues/611))
+- Standardize license headers to short BSD-3-Clause format ([#641](https://github.com/kcenon/thread_system/issues/641))
+- Standardize CMake export naming to `thread_system-targets` ([#588](https://github.com/kcenon/thread_system/issues/588))
+- Standardize minimum CMake version to 3.20 ([#621](https://github.com/kcenon/thread_system/issues/621))
+- Migrate vcpkg version field to `version-semver` ([#624](https://github.com/kcenon/thread_system/issues/624))
+
+### Fixed
+
+- Thread-safe diagnostics initialization with `std::call_once` ([#669](https://github.com/kcenon/thread_system/issues/669))
+- vcpkg usage target name mismatch and stale fmt dependency ([#664](https://github.com/kcenon/thread_system/issues/664))
+- `hazard_pointer` memory ordering issues for lock-free correctness
+- pkg-config template for unified library ([#634](https://github.com/kcenon/thread_system/issues/634))
+- Missing port-version in vcpkg overlay manifest ([#636](https://github.com/kcenon/thread_system/issues/636))
 
 ### Performance
 
-- Replace mutex with atomic counter for `job_queue` read-only query APIs ([#607](https://github.com/kcenon/thread_system/issues/607))
-- Add exponential backoff to `lockfree_job_queue` CAS retry loops to reduce CPU spin waste ([#608](https://github.com/kcenon/thread_system/issues/608))
+- Replace mutex with atomic counter for `job_queue` read-only query APIs ([#609](https://github.com/kcenon/thread_system/issues/609))
+- Add exponential backoff to `lockfree_job_queue` CAS retry loops ([#610](https://github.com/kcenon/thread_system/issues/610))
+- Lock-free freelist pool for queue node allocation
+- Cap affinity matrix growth and add diagnostics sampling
+- Replace 10ms polling sleep with `condition_variable` blocking in thread pool
+
+### Documentation
+
+- Modernize Doxygen with doxygen-awesome-css theme ([#654](https://github.com/kcenon/thread_system/issues/654))
+- Split oversized documents into focused sub-documents ([#666](https://github.com/kcenon/thread_system/issues/666))
+- Add ecosystem navigation and dependency map ([#657](https://github.com/kcenon/thread_system/issues/657))
+- Add `@file` Doxygen blocks to public API headers ([#647](https://github.com/kcenon/thread_system/issues/647))
+- Add YAML frontmatter to all docs/ markdown files ([#644](https://github.com/kcenon/thread_system/issues/644))
+- Standardize README badge set and Table of Contents ([#593](https://github.com/kcenon/thread_system/issues/593), [#595](https://github.com/kcenon/thread_system/issues/595))
+
+### Infrastructure
+
+- Upgrade dependencies: spdlog 1.15.3, gtest 1.17.0, benchmark 1.9.5
+- Adopt setup-vcpkg composite action for CI standardization ([#622](https://github.com/kcenon/thread_system/issues/622))
+- Bump codecov/codecov-action to v6 ([#637](https://github.com/kcenon/thread_system/issues/637))
 
 ## [0.3.1] - 2026-03-14
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ cmake_minimum_required(VERSION 3.20)
 
 # Define the project
 project(thread_system
-    VERSION 0.3.1
+    VERSION 1.0.0
     DESCRIPTION "High-performance C++20 multithreading framework"
     HOMEPAGE_URL "https://github.com/kcenon/thread_system"
     LANGUAGES CXX

--- a/README.kr.md
+++ b/README.kr.md
@@ -165,7 +165,7 @@ include(FetchContent)
 FetchContent_Declare(
     thread_system
     GIT_REPOSITORY https://github.com/kcenon/thread_system.git
-    GIT_TAG v0.3.0  # 특정 릴리스 태그에 고정; main 사용 금지
+    GIT_TAG v1.0.0  # 특정 릴리스 태그에 고정; main 사용 금지
 )
 FetchContent_MakeAvailable(thread_system)
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A modern C++20 multithreading framework designed to democratize concurrent progr
 Thread System is a comprehensive multithreading framework that provides intuitive abstractions and robust implementations for building high-performance, thread-safe applications.
 
 **Key Value Propositions**:
-- **Well-Tested**: 95%+ CI/CD success rate, zero ThreadSanitizer warnings, 72% code coverage
+- **Well-Tested**: 95%+ CI/CD success rate, zero ThreadSanitizer warnings, 49% code coverage
 - **High Performance**: 1.16M jobs/second baseline, 4x faster lock-free queues, adaptive optimization
 - **Developer Friendly**: Intuitive API, comprehensive documentation, rich examples
 - **Flexible Architecture**: Modular design with optional logger/monitoring integration
@@ -409,7 +409,7 @@ include(FetchContent)
 FetchContent_Declare(
     thread_system
     GIT_REPOSITORY https://github.com/kcenon/thread_system.git
-    GIT_TAG v0.3.0  # Pin to a specific release tag; do NOT use main
+    GIT_TAG v1.0.0  # Pin to a specific release tag; do NOT use main
 )
 FetchContent_MakeAvailable(thread_system)
 
@@ -481,7 +481,7 @@ cmake --build build
 ### Quality Metrics
 
 - ✅ **95%+ CI/CD Success Rate** across all platforms
-- ✅ **72% Code Coverage** with comprehensive test suite
+- ✅ **49% Code Coverage** with comprehensive test suite
 - ✅ **Zero ThreadSanitizer Warnings** in production code
 - ✅ **Zero AddressSanitizer Leaks** - 100% RAII compliance
 - ✅ **Multi-Platform Support**: Linux, macOS, Windows

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -12,7 +12,7 @@ category: "API"
 
 > **SSOT**: This document is the single source of truth for **thread_system API Reference**.
 
-> **Version**: 0.3.1.0
+> **Version**: 1.0.0
 > **Last Updated**: 2025-01-09
 > **Language**: [English]
 
@@ -1619,5 +1619,5 @@ int main() {
 
 **Created**: 2025-11-21
 **Updated**: 2025-01-09
-**Version**: 0.3.1.0
+**Version**: 1.0.0
 **Author**: kcenon@naver.com

--- a/docs/ARCHITECTURE.kr.md
+++ b/docs/ARCHITECTURE.kr.md
@@ -473,5 +473,5 @@ struct alignas(64) WorkerThread {
 ---
 
 **작성일**: 2026-02-08
-**버전**: 0.3.0
+**버전**: 1.0.0
 **작성자**: kcenon@naver.com

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -510,5 +510,5 @@ graph TD
 ---
 
 **Date**: 2026-02-08
-**Version**: 0.3.0.0
+**Version**: 1.0.0
 **Author**: kcenon@naver.com

--- a/docs/FEATURES.kr.md
+++ b/docs/FEATURES.kr.md
@@ -12,7 +12,7 @@ category: "FEAT"
 
 > **SSOT**: This document is the single source of truth for **Thread System 기능 상세**.
 
-**버전**: 0.3.0
+**버전**: 1.0.0
 **최종 업데이트**: 2026-02-08
 **언어**: [English](FEATURES.md) | [한국어]
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -12,7 +12,7 @@ category: "FEAT"
 
 > **SSOT**: This document is the single source of truth for **Thread System Features**.
 
-**Version**: 0.3.0.0
+**Version**: 1.0.0
 **Last Updated**: 2026-02-08
 **Language**: [English] | [한국어](FEATURES.kr.md)
 

--- a/docs/PROJECT_STRUCTURE.kr.md
+++ b/docs/PROJECT_STRUCTURE.kr.md
@@ -12,7 +12,7 @@ category: "PROJ"
 
 > **SSOT**: This document is the single source of truth for **Thread System 프로젝트 구조**.
 
-**버전**: 0.3.0
+**버전**: 1.0.0
 **최종 업데이트**: 2026-01-11
 **언어**: [English](PROJECT_STRUCTURE.md) | **한국어**
 

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -12,7 +12,7 @@ category: "PROJ"
 
 > **SSOT**: This document is the single source of truth for **Thread System Project Structure**.
 
-**Version**: 0.3.0.0
+**Version**: 1.0.0
 **Last Updated**: 2026-01-11
 **Language**: [English] | [한국어](PROJECT_STRUCTURE.kr.md)
 

--- a/docs/advanced/KNOWN_ISSUES.md
+++ b/docs/advanced/KNOWN_ISSUES.md
@@ -12,7 +12,7 @@ category: "GUID"
 
 > **SSOT**: This document is the single source of truth for **Known Issues**.
 
-**Version**: 0.3.0.0
+**Version**: 1.0.0
 **Last Updated**: 2026-01-11
 **Status**: Active Tracking
 

--- a/docs/advanced/USER_MIGRATION_GUIDE.md
+++ b/docs/advanced/USER_MIGRATION_GUIDE.md
@@ -815,7 +815,7 @@ include(FetchContent)
 FetchContent_Declare(
     thread_system
     GIT_REPOSITORY https://github.com/kcenon/thread_system.git
-    GIT_TAG v0.3.0  # Pin to a specific release tag; do NOT use main
+    GIT_TAG v1.0.0  # Pin to a specific release tag; do NOT use main
 )
 FetchContent_MakeAvailable(thread_system)
 ```

--- a/docs/guides/QUICK_START.kr.md
+++ b/docs/guides/QUICK_START.kr.md
@@ -126,7 +126,7 @@ include(FetchContent)
 FetchContent_Declare(
     thread_system
     GIT_REPOSITORY https://github.com/kcenon/thread_system.git
-    GIT_TAG v0.3.0  # Pin to a specific release tag; do NOT use main
+    GIT_TAG v1.0.0  # Pin to a specific release tag; do NOT use main
 )
 FetchContent_MakeAvailable(thread_system)
 

--- a/docs/guides/QUICK_START.md
+++ b/docs/guides/QUICK_START.md
@@ -126,7 +126,7 @@ include(FetchContent)
 FetchContent_Declare(
     thread_system
     GIT_REPOSITORY https://github.com/kcenon/thread_system.git
-    GIT_TAG v0.3.0  # Pin to a specific release tag; do NOT use main
+    GIT_TAG v1.0.0  # Pin to a specific release tag; do NOT use main
 )
 FetchContent_MakeAvailable(thread_system)
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "kcenon-thread-system",
-  "version-semver": "0.3.1",
+  "version-semver": "1.0.0",
   "port-version": 0,
   "description": "High-performance C++20 multithreading framework with common_system integration",
   "homepage": "https://github.com/kcenon/thread_system",


### PR DESCRIPTION
Closes #673

## Summary

- Bump project version from 0.3.1 to 1.0.0 in CMakeLists.txt and vcpkg.json
- Add comprehensive v1.0.0 CHANGELOG section covering all changes since 0.3.1
- Update FetchContent GIT_TAG from v0.3.0 to v1.0.0 across all docs and READMEs
- Correct code coverage claim from 72% to 49% (verified via Codecov badge)
- Update version references in 12 documentation files (frontmatter, footers)

## What

### Version Updates (16 files)

| File | Previous | Updated |
|------|----------|---------|
| `CMakeLists.txt` | 0.3.1 | 1.0.0 |
| `vcpkg.json` | 0.3.1 | 1.0.0 |
| `README.md` (FetchContent) | v0.3.0 | v1.0.0 |
| `README.md` (coverage) | 72% | 49% |
| `README.kr.md` (FetchContent) | v0.3.0 | v1.0.0 |
| 11 docs files | 0.3.x | 1.0.0 |

### CHANGELOG v1.0.0 Section

Covers: API freeze, Result<T> migration, CMake project rename, deprecated API removal,
5 performance improvements, 5 bug fixes, comprehensive documentation overhaul, and
infrastructure upgrades.

## Why

Part of v1.0.0 release preparation (#670). All API-breaking changes are complete
(#675, #676), and version references must reflect the stable release before tagging.

## Test Plan

- [ ] Verify no stale 0.3.x version references remain (except CHANGELOG history)
- [ ] Verify CHANGELOG follows keep-a-changelog format
- [ ] Verify FetchContent examples reference v1.0.0
- [ ] CI passes (no code changes, docs only)