### PR TITLE
docs(readme): align statements with repository state

### DIFF
--- a/README.kr.md
+++ b/README.kr.md
@@ -36,7 +36,7 @@
 Thread System은 고성능 thread-safe 애플리케이션 구축을 위한 직관적인 추상화와 견고한 구현을 제공하는 포괄적인 멀티스레딩 프레임워크입니다.
 
 **핵심 가치(Key Value Propositions)**:
-- **검증된 품질**: 95%+ CI/CD 성공률, ThreadSanitizer 경고 제로, 49% 코드 커버리지
+- **검증된 품질**: 최근 100회 ci.yml 실행 기준 CI 성공률 94% (2026-03-19~2026-04-15, 2026-09-13 측정), 49% 코드 커버리지
 - **고성능**: 초당 1.16M 작업 처리(baseline), lock-free 큐 4배 성능 향상, 적응형 최적화
 - **개발자 친화적**: 직관적 API, 포괄적 문서, 풍부한 예제
 - **유연한 아키텍처**: 선택적 logger/monitoring 통합이 가능한 모듈식 설계
@@ -47,7 +47,6 @@ Thread System은 고성능 thread-safe 애플리케이션 구축을 위한 직�
 - ✅ Hazard Pointer 구현 완료 - lock-free 큐가 프로덕션에 안전
 - ✅ Lock-free 큐로 4배 성능 향상 (71 μs vs 291 μs)
 - ✅ 향상된 동기화 프리미티브 및 취소 토큰
-- ✅ 모든 CI/CD 파이프라인 정상 (ThreadSanitizer 및 AddressSanitizer 클린)
 
 ---
 
@@ -55,7 +54,7 @@ Thread System은 고성능 thread-safe 애플리케이션 구축을 위한 직�
 
 ### Requirements
 
-- **C++20 컴파일러**: GCC 13+ / Clang 17+ / MSVC 2022+
+- **C++20 컴파일러**: GCC 13+ / Clang 17+ / MSVC 2022+ (`std::format`이 필수이며, 사용할 수 없으면 CMake 구성(configure)이 실패합니다)
 - **CMake 3.20+**
 - **[common_system](https://github.com/kcenon/common_system)**: 필수 의존성 (thread_system과 나란히 클론해야 함)
 
@@ -78,26 +77,67 @@ cd thread_system
 ./scripts/build.bat      # Windows
 
 # Run examples
-./build/bin/thread_pool_sample
+./build/bin/minimal_thread_pool
 ```
 
 ### Installation via vcpkg
 
+`kcenon-thread-system`은 공식 vcpkg 레지스트리가 아닌 [kcenon vcpkg 레지스트리](https://github.com/kcenon/vcpkg-registry)에 게시되어 있습니다. 매니페스트 모드(manifest mode)를 사용하고 `vcpkg-configuration.json`에 kcenon 레지스트리를 추가하세요:
+
+```json
+{
+  "default-registry": {
+    "kind": "builtin",
+    "baseline": "d90a9b159c08169f39adcd1b0f1ac0ca12c4b96c"
+  },
+  "registries": [
+    {
+      "kind": "git",
+      "repository": "https://github.com/kcenon/vcpkg-registry.git",
+      "baseline": "40632164c62b2256579a27eda228c48b057cbee9",
+      "packages": ["kcenon-*"]
+    }
+  ]
+}
+```
+
+`vcpkg.json`에 의존성을 선언합니다:
+
+```json
+{
+  "dependencies": [
+    "kcenon-thread-system"
+  ]
+}
+```
+
+vcpkg 툴체인 파일로 구성(configure)합니다:
+
 ```bash
-vcpkg install kcenon-thread-system
+cmake -B build -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"
+cmake --build build
 ```
 
 `CMakeLists.txt`에서:
 ```cmake
 find_package(thread_system CONFIG REQUIRED)
-target_link_libraries(your_target PRIVATE kcenon::thread_system)
+target_link_libraries(your_target PRIVATE thread_system::thread_system)
 ```
+
+kcenon 레지스트리는 현재 0.3.2를 제공하며, v1.0.0은 아직 게시되지 않았습니다. v1.0.0으로 빌드하려면 [FetchContent](#with-fetchcontent)를 사용하세요.
 
 ### Basic Usage
 
 ```cpp
 #include <kcenon/thread/core/thread_pool.h>
-#include <kcenon/thread/jobs/callback_job.h>
+#include <kcenon/thread/core/thread_worker.h>
+
+#include <algorithm>
+#include <future>
+#include <iostream>
+#include <memory>
+#include <thread>
+#include <vector>
 
 using namespace kcenon::thread;
 
@@ -107,23 +147,38 @@ int main() {
 
     // Add workers
     std::vector<std::unique_ptr<thread_worker>> workers;
-    for (size_t i = 0; i < std::thread::hardware_concurrency(); ++i) {
+    const unsigned worker_count = std::max(1u, std::thread::hardware_concurrency());
+    for (unsigned i = 0; i < worker_count; ++i) {
         workers.push_back(std::make_unique<thread_worker>());
     }
-    pool->enqueue_batch(std::move(workers));
-
-    // Start processing
-    pool->start();
-
-    // Submit jobs (convenience API)
-    for (int i = 0; i < 1000; ++i) {
-        pool->submit_task([i]() {
-            std::cout << "Processing job " << i << "\n";
-        });
+    if (auto r = pool->enqueue_batch(std::move(workers)); r.is_err()) {
+        std::cerr << "enqueue_batch failed: " << r.error().message << "\n";
+        return 1;
     }
 
-    // Clean shutdown
-    pool->shutdown_pool(false);  // Wait for completion
+    // Start processing
+    if (auto r = pool->start(); r.is_err()) {
+        std::cerr << "start failed: " << r.error().message << "\n";
+        return 1;
+    }
+
+    // Submit tasks; submit() returns a future for each result
+    std::vector<std::future<int>> results;
+    for (int i = 0; i < 1000; ++i) {
+        results.push_back(pool->submit([i] { return i * 2; }));
+    }
+
+    long long total = 0;
+    for (auto& f : results) {
+        total += f.get();
+    }
+    std::cout << "Sum of results: " << total << "\n";  // 999000
+
+    // Clean shutdown (immediately_stop = false waits for queued jobs)
+    if (auto r = pool->stop(); r.is_err()) {
+        std::cerr << "stop failed: " << r.error().message << "\n";
+        return 1;
+    }
     return 0;
 }
 ```
@@ -158,9 +213,9 @@ Kent Beck의 Simple Design 원칙에 따라 이제 2개의 공개 큐 타입만 
 - **Worker Policies**: 세밀한 제어(스케줄링, 유휴 동작, CPU 친화성)
 
 ### Error Handling
-- `thread::result<T>`와 `thread::result_void`는 `common::Result`를 래핑하되 thread 전용 헬퍼를 유지합니다(`include/kcenon/thread/core/error_handling.h` 참조).
-- thread_system 리포지토리 내부에서 작업할 때는 `result.has_error()` / `result.get_error()`를 사용하고, 모듈 경계를 넘을 때는 `detail::to_common_error(...)`를 통해 `common::error_info`로 변환합니다.
-- 공유 문서를 갱신할 때는, 다른 시스템이 `.error()`에 의존하더라도 thread 전용 래퍼는 하위 호환성을 위해 의도적으로 `.get_error()`를 노출한다는 점을 명시하세요.
+- 공개 API는 `kcenon::common::Result<T>` 또는 `kcenon::common::VoidResult`를 반환합니다. Quick Start와 같이 `is_err()`로 확인하고 `error().message`를 읽습니다.
+- `get_error_code(...)` 같은 thread 전용 오류 코드와 헬퍼는 `include/kcenon/thread/core/error_handling.h`에 있습니다.
+- 이전의 `thread::result<T>`, `thread::result_void`, `thread::error` 타입은 제거되었습니다.
 
 **📚 [상세 기능 →](docs/FEATURES.md)**
 
@@ -321,15 +376,13 @@ graph TD
 thread_system (core interfaces)
     ↑                    ↑
 logger_system    monitoring_system
-    ↑                    ↑
-    └── integrated_thread_system ──┘
 ```
 
 ### Optional Components
 
 - **[logger_system](https://github.com/kcenon/logger_system)**: 고성능 비동기 로깅
 - **[monitoring_system](https://github.com/kcenon/monitoring_system)**: 실시간 메트릭 및 모니터링
-- **[integrated_thread_system](https://github.com/kcenon/integrated_thread_system)**: 완전한 통합 예제
+- **[integration_example](examples/integration_example)**: mock ILogger/IMonitor 서비스를 사용하는 스레드 풀 통합 예제 (기본 빌드에 포함)
 
 ### Integration Benefits
 
@@ -393,20 +446,30 @@ int main() {
 ### Basic Integration
 
 ```cmake
-# Using as subdirectory
+# Using as subdirectory. Add common_system first: thread_system links
+# kcenon::common_system when that target exists.
+add_subdirectory(common_system)
 add_subdirectory(thread_system)
 
-target_link_libraries(your_target PRIVATE
-    thread_base
-    thread_pool
-    utilities
-)
+target_link_libraries(your_target PRIVATE thread_system)
 ```
+
+common_system 체크아웃은 `kcenon::common_system` 타깃을 제공해야 합니다. common_system의 `main` 브랜치는 이 타깃을 제공하지만, v0.2.0 태그는 `kcenon::common`만 정의합니다.
 
 ### With FetchContent
 
+thread_system은 common_system을 직접 가져오지 않습니다. common_system을 먼저 가져온 뒤 `COMMON_SYSTEM_INCLUDE_DIR`이 그 헤더를 가리키도록 설정하세요. 아래 예시는 thread_system v1.0.0과 common_system v0.2.0을 고정(pin)합니다:
+
 ```cmake
 include(FetchContent)
+FetchContent_Declare(
+    common_system
+    GIT_REPOSITORY https://github.com/kcenon/common_system.git
+    GIT_TAG v0.2.0
+)
+FetchContent_MakeAvailable(common_system)
+set(COMMON_SYSTEM_INCLUDE_DIR "${common_system_SOURCE_DIR}/include")
+
 FetchContent_Declare(
     thread_system
     GIT_REPOSITORY https://github.com/kcenon/thread_system.git
@@ -419,35 +482,11 @@ target_link_libraries(your_target PRIVATE thread_system)
 
 ### With vcpkg
 
-이 패키지는 kcenon vcpkg 레지스트리에서 `kcenon-thread-system`으로 제공됩니다:
+레지스트리 구성, 매니페스트, CMake 타깃은 [Installation via vcpkg](#installation-via-vcpkg)를 참조하세요.
 
-```json
-{
-  "dependencies": [
-    "kcenon-thread-system"
-  ]
-}
-```
+> **참고**: `kcenon-thread-system`은 `kcenon-common-system`에 의존하며, vcpkg가 kcenon 레지스트리에서 자동으로 설치합니다(이 포트는 공식 vcpkg 레지스트리에도 있습니다). vcpkg로 설치할 때는 common_system을 별도로 체크아웃할 필요가 없습니다.
 
-> **참고**: 이 패키지는 thread_system과 나란히 클론해야 하는
-> [kcenon-common-system](https://github.com/kcenon/common_system)을 필요로 합니다.
-> common_system에 대한 vcpkg 통합은 kcenon vcpkg 레지스트리가 구축되면 제공될 예정입니다.
-
-선택적 기능(Optional features):
-- `testing`: 단위 테스트를 위한 gtest 및 benchmark 포함
-- `logging`: spdlog 통합 활성화
-- `development`: 모든 testing 및 logging 의존성
-
-```json
-{
-  "dependencies": [
-    {
-      "name": "kcenon-thread-system",
-      "features": ["testing", "logging"]
-    }
-  ]
-}
-```
+이 저장소의 `vcpkg.json`에 있는 `testing`, `logging`, `development` 기능(feature)은 thread_system 자체를 매니페스트 모드로 빌드할 때만 적용되며, 게시된 포트는 기능을 선언하지 않습니다.
 
 ---
 
@@ -455,13 +494,13 @@ target_link_libraries(your_target PRIVATE thread_system)
 
 ### Sample Applications
 
-- **[thread_pool_sample](examples/thread_pool_sample)**: 적응형 큐를 사용한 기본 스레드 풀 사용법
-- **[typed_thread_pool_sample](examples/typed_thread_pool_sample)**: 우선순위 기반 작업 스케줄링
+- **[minimal_thread_pool](examples/minimal_thread_pool)**: logger 의존성 없는 기본 스레드 풀 사용법
+- **[typed_thread_pool_sample](examples/typed_thread_pool_sample)**: 우선순위 기반 작업 스케줄링 (소스만 제공, 기본 빌드에서 제외)
 - **[adaptive_queue_sample](examples/adaptive_queue_sample)**: 큐 성능 비교
 - **[queue_factory_sample](examples/queue_factory_sample)**: 요구사항 기반 큐 생성
 - **[queue_capabilities_sample](examples/queue_capabilities_sample)**: 런타임 기능 인트로스펙션
-- **[hazard_pointer_sample](examples/hazard_pointer_sample)**: Lock-free 메모리 회수
-- **[integration_example](examples/integration_example)**: logger/monitoring과의 완전한 통합
+- **[hazard_pointer_sample](examples/hazard_pointer_sample)**: Lock-free 메모리 회수 (소스만 제공, 기본 빌드에서 제외)
+- **[integration_example](examples/integration_example)**: mock ILogger/IMonitor 서비스를 사용한 스레드 풀 통합
 
 ### Running Examples
 
@@ -471,8 +510,8 @@ cmake -B build
 cmake --build build
 
 # Run specific example
-./build/bin/thread_pool_sample
-./build/bin/typed_thread_pool_sample
+./build/bin/minimal_thread_pool
+./build/bin/adaptive_queue_sample
 ```
 
 ---
@@ -481,12 +520,12 @@ cmake --build build
 
 ### Quality Metrics
 
-- ✅ **95%+ CI/CD 성공률** (모든 플랫폼)
+- ✅ **CI 성공률 94%** (최근 100회 ci.yml 실행, 2026-03-19~2026-04-15, 2026-09-13 측정)
 - ✅ **49% 코드 커버리지** (포괄적인 테스트 스위트)
 - ✅ **ThreadSanitizer 경고 제로** (프로덕션 코드)
 - ✅ **AddressSanitizer 누수 제로** - 100% RAII 준수
 - ✅ **다중 플랫폼 지원**: Linux, macOS, Windows
-- ✅ **다중 컴파일러**: GCC 11+, Clang 14+, MSVC 2022+
+- ✅ **다중 컴파일러**: GCC 13+, Clang 17+, MSVC 2022+
 
 ### Thread Safety
 
@@ -496,10 +535,7 @@ cmake --build build
 - 적응형 큐 모드 전환
 - 엣지 케이스 (shutdown, overflow, underflow)
 
-**ThreadSanitizer 결과**: ✅ CLEAN
-- 데이터 레이스 제로
-- 데드락 제로
-- 안전한 메모리 접근 패턴
+**ThreadSanitizer**: [`.github/workflows/ci.yml`](.github/workflows/ci.yml)의 `Sanitizer / thread` 잡은 단위 테스트 실행 파일(`*_unit`)을 ThreadSanitizer로 실행하며, 워크플로에 나열된 알려진 문제 9건을 제외합니다. 자세한 내용은 [CI Verification Gates](docs/contributing/VERIFICATION_GATES.md)를 참조하세요.
 
 ### Resource Management
 
@@ -519,8 +555,8 @@ cmake --build build
 
 | 플랫폼 | 컴파일러 | 상태 |
 |----------|-----------|--------|
-| **Linux** | GCC 11+, Clang 14+ | ✅ 완전 지원 |
-| **macOS** | Apple Clang 14+, GCC 11+ | ✅ 완전 지원 |
+| **Linux** | GCC 13+, Clang 17+ | ✅ 완전 지원 |
+| **macOS** | Apple Clang (`std::format`을 지원하는 Xcode; CI: `macos-latest`) | ✅ 완전 지원 |
 | **Windows** | MSVC 2022+ | ✅ 완전 지원 |
 
 ### Architecture Support
@@ -561,7 +597,6 @@ cmake --build build
 ## Support
 
 - **Issues**: [GitHub Issues](https://github.com/kcenon/thread_system/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/kcenon/thread_system/discussions)
 - **Email**: kcenon@naver.com
 
 ---
@@ -575,7 +610,7 @@ cmake --build build
 ## Acknowledgments
 
 - 현대 동시성 프로그래밍 패턴과 모범 사례에서 영감을 받았습니다
-- 최대 성능과 안전성을 위해 C++20 기능(GCC 11+, Clang 14+, MSVC 2022+)으로 구축되었습니다
+- 최대 성능과 안전성을 위해 C++20 기능(GCC 13+, Clang 17+, MSVC 2022+)으로 구축되었습니다
 - 관리자: kcenon@naver.com
 
 ---

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ A modern C++20 multithreading framework designed to democratize concurrent progr
 Thread System is a comprehensive multithreading framework that provides intuitive abstractions and robust implementations for building high-performance, thread-safe applications.
 
 **Key Value Propositions**:
-- **Well-Tested**: 95%+ CI/CD success rate, zero ThreadSanitizer warnings, 49% code coverage
+- **Well-Tested**: 94% CI success rate over the last 100 ci.yml runs (2026-03-19 to 2026-04-15, measured 2026-09-13), 49% code coverage
 - **High Performance**: 1.16M jobs/second baseline, 4x faster lock-free queues, adaptive optimization
 - **Developer Friendly**: Intuitive API, comprehensive documentation, rich examples
 - **Flexible Architecture**: Modular design with optional logger/monitoring integration
@@ -47,7 +47,6 @@ Thread System is a comprehensive multithreading framework that provides intuitiv
 - ✅ Hazard Pointer implementation completed - lock-free queue safe for production
 - ✅ 4x performance improvement with lock-free queue (71 μs vs 291 μs)
 - ✅ Enhanced synchronization primitives and cancellation tokens
-- ✅ All CI/CD pipelines green (ThreadSanitizer & AddressSanitizer clean)
 
 ---
 
@@ -55,7 +54,7 @@ Thread System is a comprehensive multithreading framework that provides intuitiv
 
 ### Requirements
 
-- **C++20 Compiler**: GCC 13+ / Clang 17+ / MSVC 2022+
+- **C++20 Compiler**: GCC 13+ / Clang 17+ / MSVC 2022+ (`std::format` is required; configuration fails without it)
 - **CMake 3.20+**
 - **[common_system](https://github.com/kcenon/common_system)**: Required dependency (must be cloned alongside thread_system)
 
@@ -78,26 +77,67 @@ cd thread_system
 ./scripts/build.bat      # Windows
 
 # Run examples
-./build/bin/thread_pool_sample
+./build/bin/minimal_thread_pool
 ```
 
 ### Installation via vcpkg
 
+`kcenon-thread-system` is published in the [kcenon vcpkg registry](https://github.com/kcenon/vcpkg-registry), not in the official vcpkg registry. Use manifest mode and add the kcenon registry in `vcpkg-configuration.json`:
+
+```json
+{
+  "default-registry": {
+    "kind": "builtin",
+    "baseline": "d90a9b159c08169f39adcd1b0f1ac0ca12c4b96c"
+  },
+  "registries": [
+    {
+      "kind": "git",
+      "repository": "https://github.com/kcenon/vcpkg-registry.git",
+      "baseline": "40632164c62b2256579a27eda228c48b057cbee9",
+      "packages": ["kcenon-*"]
+    }
+  ]
+}
+```
+
+Declare the dependency in `vcpkg.json`:
+
+```json
+{
+  "dependencies": [
+    "kcenon-thread-system"
+  ]
+}
+```
+
+Configure with the vcpkg toolchain file:
+
 ```bash
-vcpkg install kcenon-thread-system
+cmake -B build -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"
+cmake --build build
 ```
 
 In your `CMakeLists.txt`:
 ```cmake
 find_package(thread_system CONFIG REQUIRED)
-target_link_libraries(your_target PRIVATE kcenon::thread_system)
+target_link_libraries(your_target PRIVATE thread_system::thread_system)
 ```
+
+The kcenon registry currently provides 0.3.2; v1.0.0 has not been published there yet. Use [FetchContent](#with-fetchcontent) to build against v1.0.0.
 
 ### Basic Usage
 
 ```cpp
 #include <kcenon/thread/core/thread_pool.h>
-#include <kcenon/thread/jobs/callback_job.h>
+#include <kcenon/thread/core/thread_worker.h>
+
+#include <algorithm>
+#include <future>
+#include <iostream>
+#include <memory>
+#include <thread>
+#include <vector>
 
 using namespace kcenon::thread;
 
@@ -107,23 +147,38 @@ int main() {
 
     // Add workers
     std::vector<std::unique_ptr<thread_worker>> workers;
-    for (size_t i = 0; i < std::thread::hardware_concurrency(); ++i) {
+    const unsigned worker_count = std::max(1u, std::thread::hardware_concurrency());
+    for (unsigned i = 0; i < worker_count; ++i) {
         workers.push_back(std::make_unique<thread_worker>());
     }
-    pool->enqueue_batch(std::move(workers));
-
-    // Start processing
-    pool->start();
-
-    // Submit jobs (convenience API)
-    for (int i = 0; i < 1000; ++i) {
-        pool->submit_task([i]() {
-            std::cout << "Processing job " << i << "\n";
-        });
+    if (auto r = pool->enqueue_batch(std::move(workers)); r.is_err()) {
+        std::cerr << "enqueue_batch failed: " << r.error().message << "\n";
+        return 1;
     }
 
-    // Clean shutdown
-    pool->shutdown_pool(false);  // Wait for completion
+    // Start processing
+    if (auto r = pool->start(); r.is_err()) {
+        std::cerr << "start failed: " << r.error().message << "\n";
+        return 1;
+    }
+
+    // Submit tasks; submit() returns a future for each result
+    std::vector<std::future<int>> results;
+    for (int i = 0; i < 1000; ++i) {
+        results.push_back(pool->submit([i] { return i * 2; }));
+    }
+
+    long long total = 0;
+    for (auto& f : results) {
+        total += f.get();
+    }
+    std::cout << "Sum of results: " << total << "\n";  // 999000
+
+    // Clean shutdown (immediately_stop = false waits for queued jobs)
+    if (auto r = pool->stop(); r.is_err()) {
+        std::cerr << "stop failed: " << r.error().message << "\n";
+        return 1;
+    }
     return 0;
 }
 ```
@@ -158,9 +213,9 @@ Following Kent Beck's Simple Design principle, we now offer only 2 public queue 
 - **Worker Policies**: Fine-grained control (scheduling, idle behavior, CPU affinity)
 
 ### Error Handling
-- `thread::result<T>` and `thread::result_void` wrap `common::Result` but keep thread-specific helpers (see `include/kcenon/thread/core/error_handling.h`).
-- Use `result.has_error()` / `result.get_error()` when working inside the thread_system repo, and convert to `common::error_info` via `detail::to_common_error(...)` when crossing module boundaries.
-- When updating shared documentation, call out that the thread-specific wrappers intentionally expose `.get_error()` for backward compatibility even though other systems rely on `.error()`.
+- Public APIs return `kcenon::common::Result<T>` or `kcenon::common::VoidResult`. Check `is_err()` and read `error().message`, as the Quick Start does.
+- Thread-specific error codes and helpers such as `get_error_code(...)` are in `include/kcenon/thread/core/error_handling.h`.
+- The former `thread::result<T>`, `thread::result_void`, and `thread::error` types have been removed.
 
 **📚 [Detailed Features →](docs/FEATURES.md)**
 
@@ -321,15 +376,13 @@ This project is part of a modular ecosystem:
 thread_system (core interfaces)
     ↑                    ↑
 logger_system    monitoring_system
-    ↑                    ↑
-    └── integrated_thread_system ──┘
 ```
 
 ### Optional Components
 
 - **[logger_system](https://github.com/kcenon/logger_system)**: High-performance asynchronous logging
 - **[monitoring_system](https://github.com/kcenon/monitoring_system)**: Real-time metrics and monitoring
-- **[integrated_thread_system](https://github.com/kcenon/integrated_thread_system)**: Complete integration examples
+- **[integration_example](examples/integration_example)**: Thread-pool integration example with mock ILogger/IMonitor services (built by default)
 
 ### Integration Benefits
 
@@ -393,20 +446,30 @@ int main() {
 ### Basic Integration
 
 ```cmake
-# Using as subdirectory
+# Using as subdirectory. Add common_system first: thread_system links
+# kcenon::common_system when that target exists.
+add_subdirectory(common_system)
 add_subdirectory(thread_system)
 
-target_link_libraries(your_target PRIVATE
-    thread_base
-    thread_pool
-    utilities
-)
+target_link_libraries(your_target PRIVATE thread_system)
 ```
+
+The common_system checkout must provide the `kcenon::common_system` target. Its `main` branch does; the v0.2.0 tag defines only `kcenon::common`.
 
 ### With FetchContent
 
+thread_system does not fetch common_system itself. Fetch common_system first and point `COMMON_SYSTEM_INCLUDE_DIR` at its headers. This example pins thread_system v1.0.0 with common_system v0.2.0:
+
 ```cmake
 include(FetchContent)
+FetchContent_Declare(
+    common_system
+    GIT_REPOSITORY https://github.com/kcenon/common_system.git
+    GIT_TAG v0.2.0
+)
+FetchContent_MakeAvailable(common_system)
+set(COMMON_SYSTEM_INCLUDE_DIR "${common_system_SOURCE_DIR}/include")
+
 FetchContent_Declare(
     thread_system
     GIT_REPOSITORY https://github.com/kcenon/thread_system.git
@@ -419,35 +482,11 @@ target_link_libraries(your_target PRIVATE thread_system)
 
 ### With vcpkg
 
-The package is available as `kcenon-thread-system` in the kcenon vcpkg registry:
+See [Installation via vcpkg](#installation-via-vcpkg) for the registry configuration, the manifest, and the CMake target.
 
-```json
-{
-  "dependencies": [
-    "kcenon-thread-system"
-  ]
-}
-```
+> **Note**: `kcenon-thread-system` depends on `kcenon-common-system`; vcpkg installs it automatically from the kcenon registry (the port is also in the official vcpkg registry). A vcpkg install needs no separate common_system checkout.
 
-> **Note**: This package requires [kcenon-common-system](https://github.com/kcenon/common_system)
-> which must be cloned alongside thread_system. The vcpkg integration for common_system
-> will be available once the kcenon vcpkg registry is established.
-
-Optional features:
-- `testing`: Includes gtest and benchmark for unit tests
-- `logging`: Enables spdlog integration
-- `development`: All testing and logging dependencies
-
-```json
-{
-  "dependencies": [
-    {
-      "name": "kcenon-thread-system",
-      "features": ["testing", "logging"]
-    }
-  ]
-}
-```
+The `testing`, `logging`, and `development` features in this repository's `vcpkg.json` apply only when building thread_system itself in manifest mode; the published port declares no features.
 
 ---
 
@@ -455,13 +494,13 @@ Optional features:
 
 ### Sample Applications
 
-- **[thread_pool_sample](examples/thread_pool_sample)**: Basic thread pool usage with adaptive queues
-- **[typed_thread_pool_sample](examples/typed_thread_pool_sample)**: Priority-based task scheduling
+- **[minimal_thread_pool](examples/minimal_thread_pool)**: Basic thread pool usage without a logger dependency
+- **[typed_thread_pool_sample](examples/typed_thread_pool_sample)**: Priority-based task scheduling (source only; not built by default)
 - **[adaptive_queue_sample](examples/adaptive_queue_sample)**: Queue performance comparison
 - **[queue_factory_sample](examples/queue_factory_sample)**: Requirements-based queue creation
 - **[queue_capabilities_sample](examples/queue_capabilities_sample)**: Runtime capability introspection
-- **[hazard_pointer_sample](examples/hazard_pointer_sample)**: Lock-free memory reclamation
-- **[integration_example](examples/integration_example)**: Full integration with logger/monitoring
+- **[hazard_pointer_sample](examples/hazard_pointer_sample)**: Lock-free memory reclamation (source only; not built by default)
+- **[integration_example](examples/integration_example)**: Thread-pool integration with mock ILogger/IMonitor services
 
 ### Running Examples
 
@@ -471,8 +510,8 @@ cmake -B build
 cmake --build build
 
 # Run specific example
-./build/bin/thread_pool_sample
-./build/bin/typed_thread_pool_sample
+./build/bin/minimal_thread_pool
+./build/bin/adaptive_queue_sample
 ```
 
 ---
@@ -481,12 +520,12 @@ cmake --build build
 
 ### Quality Metrics
 
-- ✅ **95%+ CI/CD Success Rate** across all platforms
+- ✅ **94% CI Success Rate** over the last 100 ci.yml runs (2026-03-19 to 2026-04-15, measured 2026-09-13)
 - ✅ **49% Code Coverage** with comprehensive test suite
 - ✅ **Zero ThreadSanitizer Warnings** in production code
 - ✅ **Zero AddressSanitizer Leaks** - 100% RAII compliance
 - ✅ **Multi-Platform Support**: Linux, macOS, Windows
-- ✅ **Multiple Compilers**: GCC 11+, Clang 14+, MSVC 2022+
+- ✅ **Multiple Compilers**: GCC 13+, Clang 17+, MSVC 2022+
 
 ### Thread Safety
 
@@ -496,10 +535,7 @@ cmake --build build
 - Adaptive queue mode switching
 - Edge cases (shutdown, overflow, underflow)
 
-**ThreadSanitizer Results**: ✅ CLEAN
-- Zero data races
-- Zero deadlocks
-- Safe memory access patterns
+**ThreadSanitizer**: The `Sanitizer / thread` job in [`.github/workflows/ci.yml`](.github/workflows/ci.yml) runs the unit-test executables (`*_unit`) under ThreadSanitizer, with nine known-issue exclusions listed in the workflow; see [CI Verification Gates](docs/contributing/VERIFICATION_GATES.md).
 
 ### Resource Management
 
@@ -519,8 +555,8 @@ cmake --build build
 
 | Platform | Compilers | Status |
 |----------|-----------|--------|
-| **Linux** | GCC 11+, Clang 14+ | ✅ Fully supported |
-| **macOS** | Apple Clang 14+, GCC 11+ | ✅ Fully supported |
+| **Linux** | GCC 13+, Clang 17+ | ✅ Fully supported |
+| **macOS** | Apple Clang (Xcode with `std::format`; CI: `macos-latest`) | ✅ Fully supported |
 | **Windows** | MSVC 2022+ | ✅ Fully supported |
 
 ### Architecture Support
@@ -561,7 +597,6 @@ We welcome contributions! Please see our [Contributing Guide](docs/contributing/
 ## Support
 
 - **Issues**: [GitHub Issues](https://github.com/kcenon/thread_system/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/kcenon/thread_system/discussions)
 - **Email**: kcenon@naver.com
 
 ---
@@ -575,7 +610,7 @@ This project is licensed under the BSD 3-Clause License - see the [LICENSE](LICE
 ## Acknowledgments
 
 - Inspired by modern concurrent programming patterns and best practices
-- Built with C++20 features (GCC 11+, Clang 14+, MSVC 2022+) for maximum performance and safety
+- Built with C++20 features (GCC 13+, Clang 17+, MSVC 2022+) for maximum performance and safety
 - Maintained by kcenon@naver.com
 
 ---


### PR DESCRIPTION
## Description

Aligns every path, command, version, count, and guarantee in `README.md` and `README.kr.md` with the repository, per #709. Where the README promised something the repository does not do, the README changed, not the code. The diff touches only `README.md` and `README.kr.md`. Both files receive the same factual changes; `README.kr.md` keeps its Korean prose, English headings, and the "Korean(English)" form, and all code fences in the two files are byte-identical.

Base branch: `develop` (`eccacab`). Every merged PR since 2026-05 (#688-#705) targets `develop`, which merges into `main` at release time, so this fix reaches `main`, the default branch, with the next release. "Builds against the default branch" is interpreted as follows: every snippet builds against the PR base (`develop`), and a snippet pinned to a published artifact (tag `v1.0.0`, the common_system `v0.2.0` tag, or the kcenon registry port) also builds against that artifact.

## Disposition

Line numbers refer to `develop` (the 2026-09-10 audit numbers plus 1); both files share them.

| ID | Line(s) | Status | Change / reason | Evidence |
|---|---|---|---|---|
| C1 | 39, 484 | Resolved | "95%+ CI/CD success rate" became "94% CI success rate over the last 100 ci.yml runs (2026-03-19 to 2026-04-15, measured 2026-09-13)"; "across all platforms" dropped. In L39 only this phrase changed (A5 handles the TSan phrase; coverage belongs to #710). | `gh api repos/kcenon/thread_system/actions/workflows/ci.yml/runs?per_page=100`: 94 success, 6 failure, created 2026-03-19T08:46Z to 2026-04-15T23:05Z (re-measured 2026-09-12T15:23Z). ci.yml runs only on pushes to main/phase-* and PRs to main. |
| C2 | 50 | Resolved (deleted) | "All CI/CD pipelines green (ThreadSanitizer & AddressSanitizer clean)" removed, with no replacement claim. | Latest main run 24482909215 (head 6dd5c9e) failed at `Sanitizer / undefined`; `Sanitizer / thread` failed on the main pushes 24003388461 (2026-04-05) and 24166602707 (2026-04-09); 5 of the 6 failures are sanitizer jobs. ci.yml:338-355 excludes nine tests under TSan, one a documented non-atomic write (:342). The build job ignores test failures (ci.yml:243, 248, 259-264). |
| C3 | 58 vs 489, 522-523; 578 | Resolved | L58 keeps GCC 13+ / Clang 17+ / MSVC 2022+ and adds "std::format is required; configuration fails without it". L489, L522, and L578 now say GCC 13+, Clang 17+ (and MSVC 2022+ where listed). L523 (macOS) now says "Apple Clang (Xcode with std::format; CI: macos-latest)"; GCC 11+ dropped because CI does not build it. | `check_std_format_support()` (cmake/thread_system_features.cmake:42) stops configuration when `<format>` is unusable; public headers include `<format>` (utils/formatter.h:13, utils/formatter_macros.h:28, core/thread_pool_fmt.h:33); libstdc++ provides `<format>` from GCC 13; CI matrix at ci.yml:37-52; the repository CLAUDE.md says "GCC 13+, Clang 17+, MSVC 2022+ (due to std::format)". 11+/14+ are common_system's header-only minimums. Source inspection plus CI configuration only: no GCC was available locally. |
| C4 | 325 (diagram) | Resolved | The integrated_thread_system row and its connector row were removed from the Project Ecosystem diagram. | `gh api repos/kcenon/integrated_thread_system` returns 404. |
| C5 | 432-434 | Resolved | The note now says kcenon-thread-system depends on kcenon-common-system, vcpkg installs it automatically from the kcenon registry (the port is also in the official vcpkg registry), and a vcpkg install needs no separate common_system checkout. Merged into a single vcpkg section (see C6). | kcenon/vcpkg-registry@40632164 versions/baseline.json: kcenon-common-system 0.2.0#3, kcenon-thread-system 0.3.2#2; the registry port declares the dependency; microsoft/vcpkg has ports/kcenon-common-system (0.2.0). The manifest install below resolved it without a checkout. |
| C6 | 87 (84-94) | Resolved | `vcpkg install kcenon-thread-system` was replaced by manifest mode: a vcpkg-configuration.json (builtin baseline d90a9b15, kcenon registry baseline 40632164), the vcpkg.json dependency, the toolchain file, find_package with the corrected target (A1), and "The kcenon registry currently provides 0.3.2; v1.0.0 has not been published there yet. Use FetchContent to build against v1.0.0." The second vcpkg section (CMake Integration) now only cross-references it. | Classic-mode install without a registry fails with "kcenon-thread-system does not exist" (microsoft/vcpkg has no such port). on-release-sync-registry failed for v1.0.0 at "Verify port installs correctly", so 1.0.0 is not in the registry. |
| C7 | 325 (link) | Resolved | Removed together with C4. | 404, as above. |
| C8 | 332 | Resolved | Retargeted to `examples/integration_example`: a thread-pool integration example with mock ILogger/IMonitor services, built by default. | examples/CMakeLists.txt:89; integration_example.cpp:12-13. |
| C9 | 564 | Resolved (deleted) | The Discussions line was removed; the Issues entry remains. This settles #710's "enable Discussions or remove the link" item in favor of removal. | `has_discussions: false`; https://github.com/kcenon/thread_system/discussions returns 404. |
| A1 | 93 | Resolved | `kcenon::thread_system` became `thread_system::thread_system`. | The export namespace is `thread_system::` (cmake/thread_system_install.cmake:82); both port usage files use `thread_system::thread_system`. |
| A2 | 436-450 | Resolved | The vcpkg "Optional features" block was removed; one sentence says the testing/logging/development features apply only when building thread_system itself in manifest mode. | Neither the registry port nor vcpkg-ports/kcenon-thread-system declares features; they exist only in the repository's development vcpkg.json. |
| A3 | 81, 458-464, 474-475 | Resolved | Run paths now use ./build/bin/minimal_thread_pool and ./build/bin/adaptive_queue_sample. In the sample list, thread_pool_sample became minimal_thread_pool, and typed_thread_pool_sample and hazard_pointer_sample are labeled "source only; not built by default". | examples/CMakeLists.txt:37, :43, and :75 comment the three samples out; build/bin after scripts/build.sh contains neither thread_pool_sample nor typed_thread_pool_sample. |
| A4 | 408-418 | Resolved | The FetchContent snippet fetches common_system v0.2.0 first and sets COMMON_SYSTEM_INCLUDE_DIR before fetching thread_system v1.0.0. | cmake/thread_system_dependencies.cmake:32-95 tries a preset COMMON_SYSTEM_INCLUDE_DIR, then find_package(common_system CONFIG), then sibling paths, and otherwise stops with "common_system not found"; there is no FetchContent fallback. |
| A5 | 39, 499-502 | Resolved | "zero ThreadSanitizer warnings" dropped from L39. "ThreadSanitizer Results: CLEAN / Zero data races / Zero deadlocks" became one sentence on the scope of the `Sanitizer / thread` job, linking docs/contributing/VERIFICATION_GATES.md. L486-487 stay for #710. | C2 evidence. See "Deviation (A5)" below for the scope wording. |
| A6 | 99-128 | Resolved | The Quick Start is a program that uses core/thread_worker.h, enqueue_batch(), start(), submit() futures, and stop(), checks each result, and prints "Sum of results: 999000". | Old snippet: "'kcenon/thread/jobs/callback_job.h' file not found"; with the include path corrected: "no member named 'submit_task'" and "no member named 'shutdown_pool'". The real API is start() (thread_pool.h:267), enqueue_batch() (:345), stop() (:354), submit() (:424). |
| A7 | 161-163 | Resolved | Error Handling now says: public APIs return kcenon::common::Result<T> or kcenon::common::VoidResult (check is_err(), read error().message); thread error codes and helpers such as get_error_code(...) are in include/kcenon/thread/core/error_handling.h; thread::result<T>, thread::result_void, and thread::error were removed. | error_handling.h:14-17 and :220; `detail::to_common_error` exists nowhere in include/, src/, or core/ on develop or v1.0.0; the api-guard job (ci.yml:18-27) rejects the legacy types. docs/ERROR_SYSTEM_MIGRATION_GUIDE.md is not linked because it does not exist. |
| A8 | 395-404 | Resolved | The add_subdirectory snippet adds common_system first and links `thread_system`; one sentence says the common_system checkout must provide `kcenon::common_system` (its main branch does; the v0.2.0 tag defines only `kcenon::common`). The legacy aliases (thread_base, thread_pool, utilities) are not advertised. | Old snippet: v1.0.0 fails to link with "library 'thread_pool' not found"; develop fails to compile with "'kcenon/common/patterns/result.h' file not found" (cmake/thread_system_targets.cmake:45-48, :74-77). common_system main defines kcenon::common_system (cmake/common-targets.cmake:29); v0.2.0 does not. |
| X1 | 464 | Resolved (added) | The integration_example description "Full integration with logger/monitoring" became "Thread-pool integration with mock ILogger/IMonitor services", matching C8 and the source. | integration_example.cpp:12-13 ("Uses mock implementations of ILogger and IMonitor"); mock_logger.h; mock_monitoring.h. |
| K1 | 60 | Kept | "(must be cloned alongside thread_system)" is accurate for the documented standalone source route, which searches sibling paths. | cmake/thread_system_dependencies.cmake:70-92; the README install layout built with a sibling checkout (Testing 6). |
| K2 | 62 | Kept | The Downstream Impact note already says GCC 13+/Clang 17+. | - |
| K3 | 349-352 | Kept | The module requirements match CMakeLists.txt:206-216. | - |
| K4 | 284-288 | Kept, not verified | The docs target exists when Doxygen is found (cmake/thread_system_targets.cmake:135-152), and the Doxyfile writes documents/html (OUTPUT_DIRECTORY = documents, HTML_OUTPUT = html). Doxygen is not installed locally. | - |

Unchanged for #710: the performance figures and tables, qualifier wording, the 49% coverage claims, "Zero ThreadSanitizer Warnings" / "Zero AddressSanitizer Leaks", "70+ Thread Safety Tests", "RAII Compliance: Grade A", and the L13 tagline. No badge was added or removed (every workflow badge points at an existing file), and no PERFORMANCE_METRICS markers were added.

### Deviation (A5)

The prepared wording was "the Sanitizer / thread CI job runs the unit and integration tests". ci.yml:357-370 runs every `bin/*_unit` executable (with the TSan filter) when `bin/thread_base_unit` exists, and runs `ctest` (without the filter) otherwise. Emulating the sanitizer job's configure (no system simdutf or GTest, BUILD_INTEGRATION_TESTS=ON) gives BUILD_TESTING=ON, because the FetchContent'd simdutf calls include(CTest), and nine unit-test executables including thread_base_unit. The job therefore runs the unit-test executables, and the integration tests are built but not run by that job. The README says "runs the unit-test executables (`*_unit`)". docs/contributing/VERIFICATION_GATES.md still says "Unit + integration tests" (follow-up 4).

## Testing

Revisions: base develop `eccacab56884e59b18e1737ec91f7cd533d034cb`; head `fe35686f6cf3fb7715e624edb64cdade6f6bee27`; tag v1.0.0 = `6dd5c9e8c224fcd177560623cd7eccad6415f3e4`; tag v0.3.2 = `a9e1b8f01dab995ef2a916df7c3a18ef81b24b71`; common_system main `c2f40375bd2e95855d0f7b1ceb610f3718c59ae8` and tag v0.2.0 = `1b5b0642ee9eb574f9ffd9054aa2cb02381b8404`; kcenon/vcpkg-registry `40632164c62b2256579a27eda228c48b057cbee9`; microsoft/vcpkg `a1cae005c39be7b18ba319fced856b68d7276271` (contains the builtin baseline d90a9b15).

Toolchain: macOS 27.0 arm64; Apple clang 21.0.0; Homebrew LLVM 23.1.1 (module attempt only); CMake 4.3.4; Ninja 1.13.2; Python 3.9.6; vcpkg tool 2026-07-27. GCC, Docker, and Doxygen are not available. vcpkg's simdutf port needs pkg-config, which is not installed; pkgconf 2.3.0 was built from its release tarball in the evidence directory and put on PATH (no system package was installed).

| # | Check | Result |
|---|---|---|
| 1 | Fences | 15 fences per file, identical between README.md and README.kr.md (7 cpp/cmake/json fences). The consumer inputs below are byte-identical to the README fences (sha256 prefixes: Quick Start 03d93d04, add_subdirectory 445d012a, FetchContent 33b154e9, vcpkg CMake 5abdf140, vcpkg-configuration.json e562df3f, vcpkg.json 876c1fc1). |
| 2 | Quick Start compile, `-std=c++20 -Wall -Wextra`, Apple clang 21 | PASS with 0 warnings against v1.0.0 + common_system v0.2.0, develop + common_system main, and v0.3.2 + common_system v0.2.0. The old snippet fails on v1.0.0 and develop (header not found; with the include fixed, no member submit_task / shutdown_pool). |
| 3 | add_subdirectory, final snippet, common_system main added first | PASS on head fe35686 (Quick Start prints "Sum of results: 999000"), on develop eccacab, and on v1.0.0. Negative: the old snippet on v1.0.0 fails to link ("library 'thread_pool' not found"); the old snippet on develop fails to compile ("'kcenon/common/patterns/result.h' file not found"); the final snippet without add_subdirectory(common_system), with only a sibling checkout, fails the same way on develop. |
| 4 | FetchContent, final snippet verbatim, real downloads, no FETCHCONTENT_SOURCE_DIR overrides | PASS: resolved thread_system 6dd5c9e (v1.0.0) and common_system 1b5b064 (v0.2.0); the Quick Start prints "Sum of results: 999000". |
| 5 | vcpkg | Classic `vcpkg install kcenon-thread-system` without a registry fails as expected ("kcenon-thread-system does not exist"). Manifest mode with the documented files in a fresh consumer installs kcenon-common-system 0.2.0#3, kcenon-thread-system 0.3.2#2, and simdutf 8.2.0; find_package(thread_system CONFIG REQUIRED) with thread_system::thread_system builds and runs the Quick Start ("Sum of results: 999000"). A re-run with the README's two cmake commands verbatim also passes. |
| 6 | README commands | `./scripts/build.sh` in the README layout (common_system main as a sibling, a bootstrapped vcpkg at ../vcpkg): exit 0. Its vcpkg configure failed (follow-up 2) and the script fell back to system libraries. `./build/bin/minimal_thread_pool` and `./build/bin/adaptive_queue_sample`: exit 0. The Running Examples block (`cmake -B build`, `cmake --build build`, both binaries) in a fresh layout: PASS. `./scripts/dependency.sh` was inspected and not run, because it runs `brew update`, `brew upgrade`, and `brew install` (system-wide package changes). |
| 7 | Module example | Not verified. THREAD_BUILD_MODULES=ON with LLVM 23.1.1 and Ninja configures (standalone, and as a subproject after common_system main with COMMON_BUILD_MODULES=ON), but compilation stops in a regular source before any module unit: include/kcenon/thread/scaling/autoscaler.h:206 "no template named 'vector' in namespace 'std'" with LLVM 23's libc++ (follow-up 8). The module section is unchanged. |
| 8 | Doxygen commands | Not verified: Doxygen is not installed. |
| 9 | Link audit: all http(s) URLs (including those in fences), relative paths, and anchors | Per file: 28 URLs (22 unique, all HTTP 200), 37 relative paths, 16 anchors; 0 failures. Before: 2 dead URLs (L332, L564). |
| 10 | doc_audit (tools/doc-audit from common_system main c2f4037, `python3 -m doc_audit . --quick --format markdown`, as in doc-audit.yml) | Exit 0; 15 findings, 0 critical, 10 warnings, "PASS with warnings". The finding list is identical to the develop baseline. |
| 11 | git diff --check | Clean. The diff touches only README.md and README.kr.md (+106/-71 each). |
| 12 | Pre-check reproduction | v1.0.0 with COMMON_SYSTEM_INCLUDE_DIR pointing at common_system v0.2.0 configures and builds (90/90) and produces minimal_thread_pool, adaptive_queue_sample, queue_factory_sample, queue_capabilities_sample, integration_example, job_cancellation_example, composition_example, config_example, service_registry_sample, and multi_process_monitoring_integration. thread_pool.h, thread_worker.h, and callback_job.h are identical in v1.0.0 and develop. |

### Version strings in the final README

| String | Lines (new files) | Source |
|---|---|---|
| C++20 | 13, 24, 57, 325, 398, 400, 440, 613 | CMAKE_CXX_STANDARD 20 (CMakeLists.txt:79) |
| GCC 13+, Clang 17+, MSVC 2022+ | 57, 61, 528, 558, 560, 613 | std::format compiler baseline (cmake/thread_system_features.cmake:42, repository CLAUDE.md, ci.yml:38 and :48) |
| CMake 3.20+ | 58 | cmake_minimum_required(VERSION 3.20) (CMakeLists.txt:8) |
| CMake 3.28+; Clang 16+, GCC 14+, MSVC 2022 17.4+ | 403-404 | module minimums (CMakeLists.txt:206-216), scoped to the module section |
| d90a9b159c08169f39adcd1b0f1ac0ca12c4b96c | 91 | builtin baseline, same as the repository's vcpkg-configuration.json |
| 40632164c62b2256579a27eda228c48b057cbee9 | 97 | kcenon/vcpkg-registry commit used by the validated install |
| 0.3.2 | 127 | kcenon registry version of kcenon-thread-system, scoped by its sentence |
| v1.0.0 | 127, 461, 476 | latest release tag; equals project VERSION 1.0.0 (CMakeLists.txt:15) and vcpkg.json version-semver 1.0.0 |
| v0.2.0 | 457, 461, 468 | common_system release tag (1b5b064), scoped to common_system |

The remaining numbers (performance tables, "70+") belong to #710.

## Related Issues

- Closes #709 (merged into develop; see Additional Notes)
- Unblocks #710
- Part of kcenon/kcenon#29

## Follow-ups

No existing issue covers these, and no new issue was filed; they are proposed pending maintainer confirmation.

1. Blocks the next release: develop no longer propagates common_system to subproject consumers. v1.0.0 exported COMMON_SYSTEM_INCLUDE_DIR and BUILD_WITH_COMMON_SYSTEM as PUBLIC on thread_core (core/CMakeLists.txt:163-168, a file removed on develop by e2bbca2b, #690); develop's thread_system target exports only its own include directory (cmake/thread_system_targets.cmake:45-48) and links common_system only through a kcenon::common_system target (:74-77). Consumers that provide common_system by path fail to compile: a sibling checkout, a COMMON_SYSTEM_INCLUDE_DIR setting, and a FetchContent of common_system v0.2.0, which lacks kcenon::common_system. Reproduced: the README FetchContent snippet with thread_system taken from develop fails with "'kcenon/common/patterns/result.h' file not found". Fix this before the next release, then recheck the README FetchContent and add_subdirectory snippets.
2. Packaging (improvement plan phase 04): 1.0.0 is not in the kcenon registry; on-release-sync-registry failed for v0.3.2 and v1.0.0 (for v1.0.0 at "Verify port installs correctly"). In addition, the repository's own vcpkg-configuration.json pins kcenon registry baseline 50d89f5b, whose kcenon-common-system 0.2.0 download fails with an archive hash mismatch, and scripts/build.sh then silently falls back to system libraries.
3. The CMake compiler minimums disagree with each other and with the documented baseline: cmake/CompilerChecks.cmake:9-12 still accepts GCC 10, Clang 11, AppleClang 12, and MSVC 19.26, and cmake/thread_system_features.cmake:120 and :128 print "Clang 14 or later".
4. CI integrity (improvement plan phase 01): sanitizer jobs fail intermittently on main (TSan on 2026-04-05 and 04-09; UBSan on 2026-03-19 and 04-15), and the TSan filter excludes a test that exercises a documented real race (ci.yml:342). docs/contributing/VERIFICATION_GATES.md gives the sanitizer scope as "Unit + integration tests", although ci.yml:357-370 runs only the *_unit executables when they exist.
5. Stale API names in docs (improvement plan phase 05): submit_task and shutdown_pool still appear across docs/, examples/, and tests/ (for example docs/guides/QUICK_START.kr.md, docs/FEATURES.md, docs/FEATURES.kr.md, docs/faq.dox, docs/mainpage.dox, docs/troubleshooting.dox); the repository CLAUDE.md "Key Patterns" still lists start() -> submit_task() -> shutdown_pool() and thread::result<T>; error_handling.h:16 cites the missing docs/ERROR_SYSTEM_MIGRATION_GUIDE.md.
6. docs/PRODUCTION_QUALITY.md and docs/PRODUCTION_QUALITY.kr.md still say "95%+" (improvement plan phase 05 / #710).
7. thread_pool_sample, typed_thread_pool_sample, and hazard_pointer_sample are commented out of the build.
8. include/kcenon/thread/scaling/autoscaler.h uses std::vector without including `<vector>`; the library does not compile with LLVM 23's libc++, which also blocks the module build.

## Additional Notes

- The base is develop, so the change reaches main with the next release. GitHub does not auto-close issues from a non-default base; #709 will be closed manually after the merge with a link to this PR.
- Left for #710 (line numbers in the new files): performance figures, tables, and qualifier wording; the 49% coverage claims (L39, L524); "Zero ThreadSanitizer Warnings" / "Zero AddressSanitizer Leaks" (L525-526); "70+ Thread Safety Tests" (L532); "RAII Compliance: Grade A" (L542) and its bullets; the L13 tagline.
- Evidence (commands, exit codes, logs, and consumer projects) was kept outside the repository.
