### PR TITLE
fix(vcpkg): move the kcenon registry baseline past the SHA512 fix

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -8,7 +8,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/kcenon/vcpkg-registry.git",
-      "baseline": "50d89f5b1962e811dfb779bc46fa3d251db42ce7",
+      "baseline": "40632164c62b2256579a27eda228c48b057cbee9",
       "packages": [
         "kcenon-*"
       ]


### PR DESCRIPTION
## Description

`vcpkg-configuration.json` pins the kcenon registry at `50d89f5b`, which resolves `kcenon-common-system` 0.2.0#0. That port's SHA512 does not match `https://github.com/kcenon/common_system/archive/v0.2.0.tar.gz`, so a manifest install of this repository fails ("download ... had an unexpected hash"), and `scripts/build.sh` then silently falls back to system libraries.

The registry corrected the hashes of all kcenon ports in kcenon/vcpkg-registry#88 (`de0c64d`, 2026-05-03). Its current HEAD, `40632164`, provides `kcenon-common-system` 0.2.0#3. There are no port or version-database changes between `1be52cbd` (the baseline common_system main uses) and `40632164`, and `40632164` is the baseline the README documents for consumers (#711).

`ci.yml`'s build job installs this manifest in a step without `continue-on-error`, so the next build on main can fail there once no binary cache is available. That path was not exercised here: `ci.yml` does not run for pull requests to develop.

This is follow-up 2 (the repository-side part) from #711.

## Changes

- `vcpkg-configuration.json`: kcenon registry baseline `50d89f5b` -> `40632164`. The builtin baseline (`d90a9b15`) is unchanged.

## Testing

README install layout: common_system main (`c2f4037`) as a sibling checkout, a bootstrapped vcpkg at `../vcpkg` (microsoft/vcpkg `a1cae005`, tool 2026-07-27), then `./scripts/build.sh`. Apple clang 21.0.0, CMake 4.3.4. The simdutf port needs pkg-config; pkgconf 2.3.0 was built locally and put on PATH (no system package installed).

| Step | Before (develop, same vcpkg files) | After (head `720849f`) |
|---|---|---|
| vcpkg manifest install | failed: kcenon-common-system 0.2.0, unexpected hash | done: kcenon-common-system 0.2.0#3 |
| CMake configure | fell back to system libraries | first attempt succeeded; common_system found through its vcpkg CMake config |
| `./scripts/build.sh` exit | 0 (after the fallback) | 0 |
| `./build/bin/minimal_thread_pool` | exit 0 | exit 0 |

## Related Issues

- Refs #711 (follow-up 2)
