### PR TITLE
fix(headers): include <vector> and <shared_mutex> where they are used

### DIFF
--- a/include/kcenon/thread/core/sync_primitives.h
+++ b/include/kcenon/thread/core/sync_primitives.h
@@ -15,6 +15,7 @@
 #include <atomic>
 #include <chrono>
 #include <memory>
+#include <shared_mutex>
 
 namespace kcenon::thread::sync {
     /**

--- a/include/kcenon/thread/scaling/autoscaler.h
+++ b/include/kcenon/thread/scaling/autoscaler.h
@@ -23,6 +23,7 @@
 #include <memory>
 #include <mutex>
 #include <thread>
+#include <vector>
 
 namespace kcenon::thread
 {


### PR DESCRIPTION
## Description

`include/kcenon/thread/scaling/autoscaler.h` uses `std::vector`, and `include/kcenon/thread/core/sync_primitives.h` uses `std::shared_mutex` and `std::shared_lock`, without including `<vector>` or `<shared_mutex>`. Both compiled only because another standard header included them transitively, which libc++ 23 no longer does.

With Homebrew LLVM 23.1.1 (libc++ 23), develop fails to build the library: `src/scaling/autoscaler.cpp` and `src/pool_policies/autoscaling_pool_policy.cpp` stop at `autoscaler.h:206` and `:236` ("no template named 'vector' in namespace 'std'"; the out-of-line `make_decision` mismatch reported at `autoscaler.cpp:340` follows from it). `sync_primitives.h:273-297` fails the same way in the C++20 module unit `src/modules/core.cppm`.

This is follow-up 8 from #711.

## Changes

- `include/kcenon/thread/scaling/autoscaler.h`: include `<vector>`.
- `include/kcenon/thread/core/sync_primitives.h`: include `<shared_mutex>`.

## Testing

Base develop `f3f6dd6` (the "before" column was built from `eccacab`, whose sources differ only in README files); head `94aeb22`. macOS 27.0 arm64, CMake 4.3.4, Ninja 1.13.2. Configuration: `-DBUILD_TESTING=ON`, common_system main headers, `ninja -k 0` (all targets, collect every error).

| Toolchain | Before (develop) | After (this PR) |
|---|---|---|
| Homebrew LLVM 23.1.1, libc++ 23 | 5 errors in 2 translation units (`src/scaling/autoscaler.cpp`, `src/pool_policies/autoscaling_pool_policy.cpp`); the library does not build | 0 errors; library, examples, integration tests, and 9 unit-test executables built |
| Apple clang 21.0.0 | builds | 0 errors; 9 unit-test executables built |

Not covered: the C++20 module build (`THREAD_BUILD_MODULES=ON`) still fails for separate reasons (a standalone build has no `kcenon.common` module, and `compatibility.h:41` redefines `utility_module`, which `utils/convert_string.h` also declares); GCC and MSVC were not available locally, and the change only adds standard includes.

## Related Issues

- Refs #711 (follow-up 8)
