### PR TITLE
fix(cmake): align compiler minimums with the documented baseline

### DIFF
--- a/cmake/CompilerChecks.cmake
+++ b/cmake/CompilerChecks.cmake
@@ -5,11 +5,14 @@
 # Minimum Compiler Version Requirements
 ##################################################
 
-# Define minimum compiler versions for C++20 support
-set(MIN_GCC_VERSION "10.0")
-set(MIN_CLANG_VERSION "11.0")
+# Define minimum compiler versions. They match the documented baseline
+# (README "Requirements"): C++20 std::format needs GCC 13+, Clang 17+, and
+# MSVC 19.30+ (Visual Studio 2022). Apple Clang has no documented minimum;
+# check_std_format_support() in thread_system_features.cmake decides there.
+set(MIN_GCC_VERSION "13.0")
+set(MIN_CLANG_VERSION "17.0")
 set(MIN_APPLECLANG_VERSION "12.0")
-set(MIN_MSVC_VERSION "19.26")  # Visual Studio 2019 16.6
+set(MIN_MSVC_VERSION "19.30")  # Visual Studio 2022 17.0
 
 # Check compiler version
 function(check_compiler_version)
@@ -40,8 +43,8 @@ function(check_compiler_version)
         message(STATUS "Apple Clang ${CMAKE_CXX_COMPILER_VERSION} - C++20 support verified")
         
     elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-        if(MSVC_VERSION LESS 1926)
-            message(FATAL_ERROR "MSVC version ${MSVC_VERSION} is not supported. Minimum required version is ${MIN_MSVC_VERSION} (Visual Studio 2019 16.6)")
+        if(MSVC_VERSION LESS 1930)
+            message(FATAL_ERROR "MSVC version ${MSVC_VERSION} is not supported. Minimum required version is ${MIN_MSVC_VERSION} (Visual Studio 2022)")
         endif()
         message(STATUS "MSVC ${MSVC_VERSION} - C++20 support verified")
         

--- a/cmake/thread_system_features.cmake
+++ b/cmake/thread_system_features.cmake
@@ -41,14 +41,14 @@ endfunction()
 ##################################################
 function(check_std_format_support)
   # C++20 std::format is required - no fallback to fmt library
-  # This project requires C++20 compliant compilers (GCC 13+, Clang 14+, MSVC 19.29+)
+  # This project requires C++20 compliant compilers (GCC 13+, Clang 17+, MSVC 19.30+)
 
   # MSVC: Use version-based detection instead of compile tests
   # Reason: CMake's check_cxx_source_compiles has issues with Ninja generator
   # because MSVC flags like /Zc:__cplusplus aren't properly propagated
-  # MSVC 19.29+ (VS 2019 16.10+) has full std::format support
+  # The documented minimum is MSVC 19.30 (Visual Studio 2022)
   if(MSVC)
-    if(MSVC_VERSION GREATER_EQUAL 1929)
+    if(MSVC_VERSION GREATER_EQUAL 1930)
       message(STATUS "MSVC ${MSVC_VERSION} detected - using version-based std::format detection")
       add_definitions(-DUSE_STD_FORMAT)
       set(USE_STD_FORMAT TRUE CACHE BOOL "Using std::format (C++20)" FORCE)
@@ -56,8 +56,8 @@ function(check_std_format_support)
       set(USE_STD_FORMAT TRUE PARENT_SCOPE)
       return()
     else()
-      message(FATAL_ERROR "❌ MSVC ${MSVC_VERSION} does not support std::format.\n"
-        "Please use MSVC 19.29 or later (Visual Studio 2019 16.10+)")
+      message(FATAL_ERROR "❌ MSVC ${MSVC_VERSION} is not supported.\n"
+        "Please use MSVC 19.30 or later (Visual Studio 2022)")
     endif()
   endif()
 
@@ -117,16 +117,16 @@ function(check_std_format_support)
       message(FATAL_ERROR "❌ std::format compile test failed. This project requires C++20 std::format support.\n"
         "Please use a compatible compiler:\n"
         "  - GCC 13 or later\n"
-        "  - Clang 14 or later\n"
-        "  - MSVC 19.29 or later (Visual Studio 2019 16.10+)\n"
+        "  - Clang 17 or later\n"
+        "  - MSVC 19.30 or later (Visual Studio 2022)\n"
         "Compile output: ${COMPILE_OUTPUT}")
     endif()
   else()
     message(FATAL_ERROR "❌ std::format is not available. This project requires C++20 std::format support.\n"
       "Please use a compatible compiler:\n"
       "  - GCC 13 or later\n"
-      "  - Clang 14 or later\n"
-      "  - MSVC 19.29 or later (Visual Studio 2019 16.10+)")
+      "  - Clang 17 or later\n"
+      "  - MSVC 19.30 or later (Visual Studio 2022)")
   endif()
 
   # Export result to parent scope


### PR DESCRIPTION
## Description

The CMake compiler gates disagree with each other and with the documented baseline. The README (#711) and CLAUDE.md document GCC 13+, Clang 17+, and MSVC 2022+, because `std::format` is required. However:

- `cmake/CompilerChecks.cmake:9-12` accepted GCC 10, Clang 11, AppleClang 12, and MSVC 19.26, and printed "C++20 support verified" for them.
- `cmake/thread_system_features.cmake` accepted MSVC 19.29 in its version-based `std::format` check and named "Clang 14 or later" and "MSVC 19.29 or later" in its error messages (`:44`, `:49-60`, `:117-129`).

This PR makes both files use the documented minimums: GCC 13, Clang 17, and MSVC 19.30 (Visual Studio 2022). The Apple Clang floor is unchanged, because the README gives no Apple Clang version; the `std::format` compile test decides there.

This is follow-up 3 from #711.

## Behavior change

Configuration now stops early, with a clear message, for GCC 10-12, Clang 11-16, and MSVC 19.26-19.29. GCC 10-12 could not pass the `std::format` compile test anyway. Clang 14-16 and MSVC 19.29 are below the documented baseline and are not built in CI (ubuntu-24.04 provides Clang 18; the Windows job uses windows-2022). No workflow selects a compiler below the new minimums (checked with a search of `.github/workflows`).

## Testing

Head `761d736`, base develop `f3f6dd6`.

- Real configure: Apple clang 21.0.0 ("Apple Clang 21.0.0.21000333 - C++20 support verified", "Using std::format") and Homebrew LLVM 23.1.1 ("Clang 23.1.1 - C++20 support verified", "Using std::format"): both succeed.
- GCC, older Clang, and MSVC are not installed locally, so the gates were exercised in CMake script mode with mocked compiler identities (`check_compiler_version()` and the MSVC branch of `check_std_format_support()`):

| Case | develop | This PR |
|---|---|---|
| GCC 12.3 | accepted | rejected ("is not supported") |
| GCC 13.1 | accepted | accepted |
| Clang 16.0.6 | accepted | rejected |
| Clang 17.0.1 | accepted | accepted |
| AppleClang 15.0 | accepted | accepted |
| MSVC 1929 (CompilerChecks) | accepted | rejected |
| MSVC 1930 (CompilerChecks) | accepted | accepted |
| MSVC 1929 (std::format check) | accepted | rejected |
| MSVC 1930 (std::format check) | accepted | accepted |

Not verified: a real GCC or MSVC configure (no toolchain available locally).

## Related Issues

- Refs #711 (follow-up 3)
