### PR TITLE
fix(cmake): export common_system usage requirements from thread_system

### DIFF
--- a/README.kr.md
+++ b/README.kr.md
@@ -454,7 +454,7 @@ add_subdirectory(thread_system)
 target_link_libraries(your_target PRIVATE thread_system)
 ```
 
-common_system 체크아웃은 `kcenon::common_system` 타깃을 제공해야 합니다. common_system의 `main` 브랜치는 이 타깃을 제공하지만, v0.2.0 태그는 `kcenon::common`만 정의합니다.
+thread_system은 `kcenon::common_system` 타깃이 있으면 이를 링크하고(common_system `main`이 이 타깃을 정의합니다), 없으면 찾은 common_system 헤더의 include 디렉터리(예: 형제 체크아웃)를 소비자에게 내보냅니다.
 
 ### With FetchContent
 

--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ add_subdirectory(thread_system)
 target_link_libraries(your_target PRIVATE thread_system)
 ```
 
-The common_system checkout must provide the `kcenon::common_system` target. Its `main` branch does; the v0.2.0 tag defines only `kcenon::common`.
+thread_system links the `kcenon::common_system` target when it exists (common_system `main` defines it); otherwise it exports the include directory of the common_system headers it found, such as a sibling checkout.
 
 ### With FetchContent
 

--- a/cmake/thread_system-config.cmake.in
+++ b/cmake/thread_system-config.cmake.in
@@ -17,6 +17,23 @@ find_dependency(simdutf CONFIG REQUIRED)
 # Include the targets file
 include("${CMAKE_CURRENT_LIST_DIR}/thread_system-targets.cmake")
 
+# The public headers include common_system headers. A package built against a
+# common_system checkout found by path exports no link to common_system, so
+# attach the target that find_dependency(common_system) provided above.
+if(TARGET thread_system::thread_system)
+    get_target_property(_thread_system_links thread_system::thread_system INTERFACE_LINK_LIBRARIES)
+    if(NOT _thread_system_links MATCHES "kcenon::common")
+        if(TARGET kcenon::common_system)
+            set_property(TARGET thread_system::thread_system APPEND PROPERTY
+                INTERFACE_LINK_LIBRARIES kcenon::common_system)
+        elseif(TARGET kcenon::common)
+            set_property(TARGET thread_system::thread_system APPEND PROPERTY
+                INTERFACE_LINK_LIBRARIES kcenon::common)
+        endif()
+    endif()
+    unset(_thread_system_links)
+endif()
+
 # Determine available target structure
 # Unified build exports thread_system::thread_system as a single library
 # Legacy build exports individual component libraries

--- a/cmake/thread_system_targets.cmake
+++ b/cmake/thread_system_targets.cmake
@@ -74,7 +74,26 @@ function(create_thread_system_targets)
   if(TARGET kcenon::common_system)
     target_link_libraries(thread_system PUBLIC kcenon::common_system)
     message(STATUS "thread_system: linked kcenon::common_system target")
+  elseif(COMMON_SYSTEM_INCLUDE_DIR)
+    # common_system was found by path (a preset COMMON_SYSTEM_INCLUDE_DIR or a
+    # sibling checkout) and provides no target. Export its include directory so
+    # add_subdirectory() and FetchContent consumers can compile the public
+    # headers, which include kcenon/common headers.
+    target_include_directories(thread_system PUBLIC
+      $<BUILD_INTERFACE:${COMMON_SYSTEM_INCLUDE_DIR}>
+    )
+    message(STATUS "thread_system: exporting common_system include directory ${COMMON_SYSTEM_INCLUDE_DIR}")
   endif()
+
+  # Public headers read these definitions: di/service_registration.h is empty
+  # without BUILD_WITH_COMMON_SYSTEM, and typed_thread_pool_t derives from
+  # common::interfaces::IExecutor only when KCENON_HAS_COMMON_EXECUTOR is 1.
+  # The library is always compiled with both (thread_system_dependencies.cmake),
+  # so consumers must see the same values.
+  target_compile_definitions(thread_system PUBLIC
+    BUILD_WITH_COMMON_SYSTEM
+    KCENON_HAS_COMMON_EXECUTOR=1
+  )
 
   if(DEFINED THREAD_SYSTEM_SIMDUTF_FOUND AND THREAD_SYSTEM_SIMDUTF_FOUND)
     target_link_libraries(thread_system PUBLIC ${THREAD_SYSTEM_SIMDUTF_TARGET})


### PR DESCRIPTION
## Description

On develop, a consumer that adds thread_system with `add_subdirectory()` or FetchContent and provides common_system by path fails to compile. This covers a sibling checkout, a preset `COMMON_SYSTEM_INCLUDE_DIR`, and a FetchContent of common_system v0.2.0; each fails with "'kcenon/common/patterns/result.h' file not found". The cause: `cmake/thread_system_dependencies.cmake` adds the common_system include directory with `include_directories()`, which has directory scope and never reaches consumers, and the `thread_system` target links common_system only when a `kcenon::common_system` target exists (`cmake/thread_system_targets.cmake:74-77`). v1.0.0 exported that directory as PUBLIC from `thread_core` (`core/CMakeLists.txt:163-168`, removed on develop by #690). This is follow-up 1 from #711 and blocks the next release.

Two related gaps showed up while validating the consumer view:

- Installed packages had the same problem. A package built against a common_system found by path exported no link to common_system, so `find_package(thread_system)` consumers failed with the same error. This also happens on develop.
- Public headers read `BUILD_WITH_COMMON_SYSTEM` and `KCENON_HAS_COMMON_EXECUTOR`. The library is always compiled with both, but neither reached consumers. `typed_thread_pool_t` derives from `common::interfaces::IExecutor` only when `KCENON_HAS_COMMON_EXECUTOR` is 1, so consumers compiled a different definition of the class than the library did (a one-definition-rule violation). `di/service_registration.h` is empty without `BUILD_WITH_COMMON_SYSTEM`.

## Changes

- `cmake/thread_system_targets.cmake`: when no `kcenon::common_system` target exists, export `COMMON_SYSTEM_INCLUDE_DIR` as a PUBLIC `$<BUILD_INTERFACE:...>` include directory (so no build path reaches installed exports). Export `BUILD_WITH_COMMON_SYSTEM` and `KCENON_HAS_COMMON_EXECUTOR=1` as PUBLIC compile definitions.
- `cmake/thread_system-config.cmake.in`: after including the targets file, link the common_system target that `find_dependency(common_system)` already provides (`kcenon::common_system`, else `kcenon::common`) when the exported target does not reference one.
- `README.md`, `README.kr.md`: the add_subdirectory note now says thread_system links `kcenon::common_system` when it exists and otherwise exports the include directory of the common_system headers it found. The note no longer requires that target.

## Testing

Head `cd6e93a`; base develop `f3f6dd6` (the develop column was built from `eccacab`, whose sources differ only in README files). Apple clang 21.0.0, CMake 4.3.4, Ninja 1.13.2, common_system main `c2f4037` unless noted. Each consumer builds and runs the README Quick Start ("Sum of results: 999000") unless noted.

| Scenario | develop | This PR |
|---|---|---|
| `add_subdirectory(thread_system)` with only a sibling common_system checkout | compile error: result.h not found | PASS |
| README snippet: `add_subdirectory(common_system)` (main) first | PASS | PASS |
| README snippet with common_system v0.2.0, which has no `kcenon::common_system` target | not run | PASS |
| Old README snippet (links `thread_base thread_pool utilities`), sibling checkout | compile error: result.h not found | PASS |
| README FetchContent snippet (common_system v0.2.0 downloaded) with thread_system sources from this branch | compile error: result.h not found | PASS |
| Consumer view of `typed_thread_pool_t`: a probe prints `KCENON_HAS_COMMON_EXECUTOR` and whether the class derives from `IExecutor` (the library uses 1) | 0, not derived | 1, derived |
| Install with common_system found through its installed CMake config, then a `find_package` consumer | not run | PASS; the export has `INTERFACE_COMPILE_DEFINITIONS "BUILD_WITH_COMMON_SYSTEM;KCENON_HAS_COMMON_EXECUTOR=1"` and `INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"` |
| Install with common_system found as a sibling checkout, then a `find_package` consumer | compile error: result.h not found | PASS |

README checks: all 15 code fences are identical in both files (unchanged), the link check found 0 failures, and doc_audit reports the same 15 findings as the develop baseline (0 critical).

Not covered: GCC and MSVC (not available locally). `ci.yml` does not run for pull requests to develop.

## Related Issues

- Refs #711 (follow-up 1, which blocks the next release)
