### PR TITLE
chore(vcpkg-ports): sync the source-local port with the registry and v1.0.0

### DIFF
--- a/vcpkg-ports/kcenon-thread-system/portfile.cmake
+++ b/vcpkg-ports/kcenon-thread-system/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO kcenon/thread_system
     REF "v${VERSION}"
-    SHA512 7ff506e34c22d5e5c2e517e8dd8085513ed867a3f2eaa596d8adbe503ec39a79b36a26841c85611a96d0fd4b6c5ca4d9fa71587c4eea382af6c08b9fb7d7ccd6
+    SHA512 2c0e9d1cdd94a536733a9786feda4d55faf393083a95238444d57ae1c32bc58cb9db573ae9597f24e80af886d0454946832004f8ec12ac967a79cdf659abd3e6
     HEAD_REF main
 )
 
@@ -47,3 +47,5 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)

--- a/vcpkg-ports/kcenon-thread-system/vcpkg.json
+++ b/vcpkg-ports/kcenon-thread-system/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "kcenon-thread-system",
-  "version-semver": "0.3.2",
+  "version-semver": "1.0.0",
   "port-version": 0,
   "description": "High-performance C++20 multithreading framework with lock-free queues and adaptive optimization",
   "homepage": "https://github.com/kcenon/thread_system",


### PR DESCRIPTION
## Description

`vcpkg-ports/kcenon-thread-system` is the port that `on-release-sync-registry.yml` copies into kcenon/vcpkg-registry when a release is published (step "Copy port files to registry" of the reusable `sync-vcpkg-registry.yml` in common_system). It has drifted from the registry port:

- Its SHA512 is the v0.3.2 archive hash from before kcenon/vcpkg-registry#88 corrected it.
- It lacks the usage-file installation that the registry added in kcenon/vcpkg-registry#90 (`configure_file(... usage ... COPYONLY)`). The next release sync would therefore drop that fix from the registry port.
- It still declares 0.3.2, while the project (`CMakeLists.txt`) and `vcpkg.json` are at 1.0.0.

This PR takes the registry's install step and sets the port to the current release. The new values are `version-semver` 1.0.0 and `port-version` 0, with the SHA512 of `https://github.com/kcenon/thread_system/archive/refs/tags/v1.0.0.tar.gz` (`2c0e9d1c...abd3e6`, computed from a fresh download). The release workflow rewrites the version and SHA512 from the tag at every release, so for future syncs the only effect is that the usage step is kept.

This is part of follow-up 2 from #711: 1.0.0 is not in the kcenon registry. A companion registry PR adds it.

## Changes

- `vcpkg-ports/kcenon-thread-system/portfile.cmake`: the v1.0.0 SHA512, and the usage file installed as the registry port does.
- `vcpkg-ports/kcenon-thread-system/vcpkg.json`: `version-semver` 1.0.0.

## Testing

This reproduces the release workflow's "Verify port installs correctly" step: a classic-mode `vcpkg install kcenon-thread-system --overlay-ports=<this branch>/vcpkg-ports`, using microsoft/vcpkg `a1cae005` (tool 2026-07-27) with `kcenon-common-system` 0.2.0 from the builtin registry. It ran on macOS arm64 with Apple clang 21. The simdutf port needs pkg-config, so pkgconf 2.3.0 was built locally and put on PATH.

- The install exits 0. `share/kcenon-thread-system/` contains `usage` (installed by the new step) and `copyright`.
- A consumer that uses `find_package(thread_system CONFIG REQUIRED)` and links `thread_system::thread_system` against that install tree builds and runs the README Quick Start ("Sum of results: 999000").

The same step also passes today with the v1.0.0 tag's own `vcpkg-ports` (only the version and SHA512 replaced, as the workflow does). The April failure of on-release-sync-registry for v1.0.0 (run 24482958940, "Verify port installs correctly") therefore does not reproduce with current vcpkg. The run's logs have expired, so its original cause cannot be confirmed.

## Related Issues

- Refs #711 (follow-up 2)
- Companion registry PR: kcenon/vcpkg-registry#103 adds kcenon-thread-system 1.0.0 with these port files
