### PR TITLE
fix(compat): extend utility_module instead of aliasing it

### DIFF
--- a/include/kcenon/thread/compatibility.h
+++ b/include/kcenon/thread/compatibility.h
@@ -38,7 +38,13 @@ namespace thread_module = kcenon::thread;
 namespace thread_namespace = kcenon::thread;
 
 // Legacy utility namespace names still expected by some consumers.
-namespace utility_module = kcenon::thread::utils;
+// utils/convert_string.h, utils/formatter.h, and utils/span.h declare a
+// global namespace utility_module, so an alias with the same name is a
+// redefinition in any translation unit that includes one of them. Extend
+// that namespace instead.
+namespace utility_module {
+using namespace kcenon::thread::utils;
+} // namespace utility_module
 
 #if !defined(THREAD_SUPPRESS_LEGACY_NAMESPACE_WARNING) \
     && !defined(KCENON_THREAD_COMPATIBILITY_H_WARNED)


### PR DESCRIPTION
## Description

`include/kcenon/thread/compatibility.h` declares the global namespace alias `namespace utility_module = kcenon::thread::utils;`. At the same time, `utils/convert_string.h`, `utils/formatter.h`, and `utils/span.h` declare a global `namespace utility_module { ... }`. Any translation unit that includes compatibility.h together with one of those headers fails with "redefinition of 'utility_module'". No library translation unit does that today, but the C++20 module unit `src/modules/core.cppm` does, so the module build fails there. A consumer that uses the legacy spellings from both headers hits the same error.

This PR reopens the namespace and brings `kcenon::thread::utils` into it with a using-directive. `utility_module::name` keeps resolving to both the names the utils headers declare there and the names in `kcenon::thread::utils`.

I found this while checking follow-up 8 of #711 (the module build).

## Changes

- `include/kcenon/thread/compatibility.h`: `namespace utility_module { using namespace kcenon::thread::utils; }` replaces the alias, with a comment explaining why.

## Testing

Head `7ac7e33`; base develop `f3f6dd6`. Apple clang 21.0.0, macOS arm64.

| Check | develop | This PR |
|---|---|---|
| A translation unit that includes `utils/convert_string.h` and `compatibility.h` and names `utility_module::convert_string::get_system_code_page` | compile error: "redefinition of 'utility_module'" (compatibility.h:41) | compiles with `-Wall -Wextra` (0 warnings) and runs |
| Full build with `BUILD_TESTING=ON` (library, examples, integration tests, 9 unit-test executables) | not run | builds, 0 errors |
| `utilities_unit`, which includes tests that use `using namespace utility_module;` | not run | 44 tests passed |

Module build: with this change and #713 applied, `THREAD_BUILD_MODULES=ON` with LLVM 23 gets past the header errors. It still fails in `src/modules/core.cppm` and `src/modules/queue.cppm`, which export names that no longer exist (for example `lockfree_queue`, `concurrent_queue`, `queue_type`, `thread_config`, `is_retriable`, `future_status_result`, and `concepts::PoolLike`). That needs a separate update of the module interface units, so this PR does not claim that the module build works.

## Related Issues

- Refs #711 (found while checking follow-up 8)
