### PR TITLE
docs: replace removed thread_pool APIs in guides and Doxygen pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ include/kcenon/thread/
 ```
 
 Key abstractions:
-- `thread_pool` — Multi-worker pool with adaptive queue and submit_task API
+- `thread_pool` — Multi-worker pool with adaptive queue and future-based `submit()` API
 - `typed_thread_pool` — Priority-based scheduling with job type routing and aging
 - `adaptive_job_queue` — Auto-switches between mutex and lock-free modes (recommended)
 - `job_queue` — Mutex-based FIFO with optional bounded size
@@ -63,13 +63,13 @@ sanitizers, stress tests, benchmarks, Valgrind (Linux), CVE scan.
 
 ## Key Patterns
 
-- **Thread pool** — Workers enqueued via `enqueue_batch()`, lifecycle: `start()` -> `submit_task()` -> `shutdown_pool()`
+- **Thread pool** — Workers enqueued via `enqueue_batch()`, lifecycle: `start()` -> `submit()` / `enqueue()` -> `stop()`
 - **Queue strategies** — 2 public types: `adaptive_job_queue` (auto mutex/lockfree), `job_queue` (mutex FIFO)
 - **Priority scheduling** — `typed_thread_pool` with `job_types` enum routing and priority aging
 - **Hazard pointers** — Thread-local hazard arrays (4 slots), automatic reclamation, used by lockfree queue
 - **Lock-free queue** — Michael-Scott algorithm with hazard pointer memory reclamation
 - **DAG scheduling** — Dependency graph-based job execution with `dag_job_builder`
-- **Result wrappers** — `thread::result<T>` / `thread::result_void` wrap `common::Result`
+- **Results** — Public APIs return `common::Result<T>` / `common::VoidResult`; the `thread::result<T>` / `thread::result_void` wrappers were removed
 
 ## Ecosystem Position
 
@@ -93,5 +93,5 @@ sanitizers, stress tests, benchmarks, Valgrind (Linux), CVE scan.
 - C++20 required; **higher compiler baseline**: GCC 13+, Clang 17+, MSVC 2022+ (due to `std::format`)
 - C++20 modules experimental (CMake 3.28+, Clang 16+/GCC 14+)
 - ARMv7 and RISC-V untested; UWP/Xbox unsupported
-- `thread::result<T>` uses `.get_error()` (not `.error()`) for backward compatibility
+- Legacy `thread::result<T>` / `thread::result_void` / `thread::error` were removed; use `common::Result<T>` / `common::VoidResult` / `common::error_info`
 - Work-stealing scheduler OFF by default (experimental)

--- a/docs/FEATURES.kr.md
+++ b/docs/FEATURES.kr.md
@@ -256,27 +256,28 @@ thread_system은 서로 다른 사용 사례에 최적화된 두 가지 스레�
 ```cpp
 class thread_pool {
 public:
-    thread_pool(const std::string& name = "ThreadPool");
+    thread_pool(const std::string& thread_title = "thread_pool",
+                const thread_context& context = thread_context());
 
-    auto start() -> result_void;
-    auto stop(bool immediately = false) -> result_void;
+    auto start() -> common::VoidResult;
+    auto stop(const bool& immediately_stop = false) -> common::VoidResult;
 
     // 작업 제출
-    auto enqueue(std::unique_ptr<job>&& job) -> result_void;
-    auto enqueue_batch(std::vector<std::unique_ptr<job>>&& jobs) -> result_void;
-    bool submit_task(std::function<void()> task);  // 편의 API
+    auto enqueue(std::unique_ptr<job>&& job) -> common::VoidResult;
+    auto enqueue_batch(std::vector<std::unique_ptr<job>>&& jobs) -> common::VoidResult;
+    template<typename F, typename R = std::invoke_result_t<std::decay_t<F>>>
+    auto submit(F&& callable, const submit_options& opts = {}) -> std::future<R>;
 
     // 워커 관리
-    auto add_worker(std::unique_ptr<thread_worker>&& worker) -> result_void;
-    auto add_workers(size_t count) -> result_void;
+    auto enqueue(std::unique_ptr<thread_worker>&& worker) -> common::VoidResult;
+    auto enqueue_batch(std::vector<std::unique_ptr<thread_worker>>&& workers)
+        -> common::VoidResult;
 
     // 모니터링
-    auto get_thread_count() const -> size_t;
-    auto get_pending_task_count() const -> size_t;
-    auto get_idle_worker_count() const -> size_t;
-
-    // 종료
-    bool shutdown_pool(bool immediately = false);
+    auto is_running() const -> bool;
+    auto get_pending_task_count() const -> std::size_t;
+    auto get_active_worker_count() const -> std::size_t;
+    std::size_t get_idle_worker_count() const;
 };
 ```
 
@@ -293,8 +294,8 @@ public:
    - 배치 처리 기능
 
 3. **듀얼 API 설계**
-   - 상세한 에러 처리를 위한 Result 기반 API
-   - 단순성을 위한 편의 API (`submit_task`, `shutdown_pool`)
+   - 상세한 에러 처리를 위한 Result 기반 API (`start()`, `enqueue()`, `stop()`은 `common::VoidResult` 반환)
+   - 값을 반환하는 호출 가능 객체를 위한 future 기반 `submit()`
 
 4. **포괄적인 모니터링**
    - 워커 수 추적
@@ -479,7 +480,7 @@ public:
 auto token = std::make_shared<cancellation_token>();
 
 // 워커 스레드에서
-pool->submit_task([token]() {
+auto work = pool->submit([token]() {
     for (int i = 0; i < 1000000; ++i) {
         if (token->is_cancelled()) {
             return;  // 조기 종료

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -269,27 +269,28 @@ Multi-worker thread pool with adaptive queue support.
 ```cpp
 class thread_pool {
 public:
-    thread_pool(const std::string& name = "ThreadPool");
+    thread_pool(const std::string& thread_title = "thread_pool",
+                const thread_context& context = thread_context());
 
-    auto start() -> result_void;
-    auto stop(bool immediately = false) -> result_void;
+    auto start() -> common::VoidResult;
+    auto stop(const bool& immediately_stop = false) -> common::VoidResult;
 
     // Job submission
-    auto enqueue(std::unique_ptr<job>&& job) -> result_void;
-    auto enqueue_batch(std::vector<std::unique_ptr<job>>&& jobs) -> result_void;
-    bool submit_task(std::function<void()> task);  // Convenience API
+    auto enqueue(std::unique_ptr<job>&& job) -> common::VoidResult;
+    auto enqueue_batch(std::vector<std::unique_ptr<job>>&& jobs) -> common::VoidResult;
+    template<typename F, typename R = std::invoke_result_t<std::decay_t<F>>>
+    auto submit(F&& callable, const submit_options& opts = {}) -> std::future<R>;
 
     // Worker management
-    auto add_worker(std::unique_ptr<thread_worker>&& worker) -> result_void;
-    auto add_workers(size_t count) -> result_void;
+    auto enqueue(std::unique_ptr<thread_worker>&& worker) -> common::VoidResult;
+    auto enqueue_batch(std::vector<std::unique_ptr<thread_worker>>&& workers)
+        -> common::VoidResult;
 
     // Monitoring
-    auto get_thread_count() const -> size_t;
-    auto get_pending_task_count() const -> size_t;
-    auto get_idle_worker_count() const -> size_t;
-
-    // Shutdown
-    bool shutdown_pool(bool immediately = false);
+    auto is_running() const -> bool;
+    auto get_pending_task_count() const -> std::size_t;
+    auto get_active_worker_count() const -> std::size_t;
+    std::size_t get_idle_worker_count() const;
 };
 ```
 
@@ -306,8 +307,8 @@ public:
    - Batch processing capabilities
 
 3. **Dual API Design**
-   - Result-based API for detailed error handling
-   - Convenience API (`submit_task`, `shutdown_pool`) for simplicity
+   - Result-based API (`start()`, `enqueue()`, `stop()` return `common::VoidResult`) for detailed error handling
+   - Future-based `submit()` for callables that return a value
 
 4. **Comprehensive Monitoring**
    - Worker count tracking
@@ -740,7 +741,7 @@ public:
 auto token = std::make_shared<cancellation_token>();
 
 // In worker thread
-pool->submit_task([token]() {
+auto work = pool->submit([token]() {
     for (int i = 0; i < 1000000; ++i) {
         if (token->is_cancelled()) {
             return;  // Exit early

--- a/docs/advanced/THREAD_SYSTEM_ARCHITECTURE.md
+++ b/docs/advanced/THREAD_SYSTEM_ARCHITECTURE.md
@@ -262,30 +262,31 @@ public:
 **Purpose**: Standard thread pool with mutex-based job queue
 
 ```cpp
-class thread_pool : public executor_interface {
+// IExecutor integration: adapters/common_executor_adapter.h
+class thread_pool : public std::enable_shared_from_this<thread_pool> {
 public:
-    thread_pool(const std::string& pool_name = "thread_pool");
+    thread_pool(const std::string& thread_title = "thread_pool",
+                const thread_context& context = thread_context());
 
     // Lifecycle
-    auto start() -> result_void;
-    auto stop(bool immediately = false) -> result_void;
-    auto shutdown() -> result_void;
+    auto start() -> common::VoidResult;
+    auto stop(const bool& immediately_stop = false) -> common::VoidResult;
 
     // Job submission
-    auto execute(std::unique_ptr<job>&& job) -> result_void;  // executor_interface
-    auto enqueue(std::unique_ptr<job>&& job) -> result_void;
-    auto enqueue_batch(std::vector<std::unique_ptr<job>>&& jobs) -> result_void;
-
-    // Convenience wrapper
-    bool submit_task(std::function<void()> task);
+    auto enqueue(std::unique_ptr<job>&& job) -> common::VoidResult;
+    auto enqueue_batch(std::vector<std::unique_ptr<job>>&& jobs) -> common::VoidResult;
+    template<typename F, typename R = std::invoke_result_t<std::decay_t<F>>>
+    auto submit(F&& callable, const submit_options& opts = {}) -> std::future<R>;
 
     // Worker management
-    auto add_worker(std::unique_ptr<thread_worker>&& worker) -> result_void;
-    auto get_thread_count() const -> size_t;
-    auto get_idle_worker_count() const -> size_t;
+    auto enqueue(std::unique_ptr<thread_worker>&& worker) -> common::VoidResult;
+    auto enqueue_batch(std::vector<std::unique_ptr<thread_worker>>&& workers)
+        -> common::VoidResult;
+    auto get_active_worker_count() const -> std::size_t;
+    std::size_t get_idle_worker_count() const;
 
     // Status
-    auto get_pending_task_count() const -> size_t;
+    auto get_pending_task_count() const -> std::size_t;
     auto is_running() const -> bool;
 };
 ```

--- a/docs/faq.dox
+++ b/docs/faq.dox
@@ -20,7 +20,7 @@ based on queue depth and observed latency.
 @section faq_cancel How do I handle task cancellation?
 
 Use a @c kcenon::thread::cancellation_token. Pass the token to long-running
-jobs and check @c is_cancellation_requested() between work units. Cancellation
+jobs and check @c is_cancelled() between work units. Cancellation
 is cooperative — the runtime cannot interrupt arbitrary code, so jobs must poll
 periodically. Tokens form a hierarchy: cancelling a parent cancels all linked
 children, which is useful for shutting down a request and all of its background
@@ -28,14 +28,14 @@ fan-out.
 
 @code{.cpp}
 auto token = kcenon::thread::cancellation_token::create();
-pool->submit_task([token]() -> kcenon::thread::result_void {
-    while (!token->is_cancellation_requested()) {
+auto work = pool->submit([token]() {
+    while (!token.is_cancelled()) {
         // do a chunk of work
     }
-    return {};
 });
 // later
-token->cancel();
+token.cancel();
+work.get();
 @endcode
 
 @section faq_async Thread pool vs. std::async — which is better?
@@ -68,7 +68,7 @@ A few rules prevent the most common cases:
   pool. Use the DAG scheduler for in-pool dependencies instead.
 - Acquire locks in a consistent global order across jobs.
 - Prefer @c std::scoped_lock to lock multiple mutexes atomically.
-- Avoid holding a mutex across @c submit_task — release first, then submit.
+- Avoid holding a mutex across @c submit — release first, then submit.
 - Watch for hidden blocking inside callbacks (logging, allocators, mutexes
   used by other threads). The thread pool diagnostics can flag long-running
   jobs that point at hidden contention.
@@ -100,25 +100,27 @@ Thread System works on Linux, macOS, and Windows. Notable differences:
 Jobs are heap-allocated by the queue (typically as @c std::unique_ptr nodes).
 Lock-free queues defer node deletion until hazard pointer scanning confirms
 no thread is reading them. As a user you do not need to manage queue node
-lifetimes; just pass a callable into @c submit_task or build a typed job and
+lifetimes; just pass a callable into @c submit or build a typed job and
 the framework owns it from there. Avoid capturing very large objects by value
 in the lambda — capture by @c std::shared_ptr or move into the job.
 
 @section faq_errors How are errors propagated from jobs?
 
-Jobs return @c kcenon::thread::result_void or @c result<T>, which wrap the
-@c common_system Result type. Failures surface through the future returned by
-@c submit_task — calling @c .get() rethrows nothing; instead inspect the
-result and call @c get_error() (note: not @c error()) to read the failure
-detail. The DAG scheduler aggregates failures across nodes and exposes them
-through the run result.
+Pool operations such as @c start(), @c enqueue(), and @c stop() return
+@c kcenon::common::VoidResult; check @c is_err() and read @c error().message.
+Jobs enqueued as job objects return @c kcenon::common::VoidResult as well. A
+callable passed to @c submit() returns a plain value, and the returned
+@c std::future rethrows an exception thrown by the callable (or a
+@c std::runtime_error when the pool rejects the job) when you call @c get().
+The DAG scheduler aggregates failures across nodes and exposes them through
+the run result.
 
 @section faq_testing How do I test code that uses the thread pool?
 
 - For unit tests, prefer the @c minimal_thread_pool example as a lightweight
   fixture: it has predictable startup and shutdown costs.
 - Use a small worker count (1 or 2) so concurrency bugs surface deterministically.
-- Wait on futures returned from @c submit_task; never sleep-and-hope.
+- Wait on futures returned from @c submit; never sleep-and-hope.
 - For races, run the test under TSan (@c cmake --preset tsan) and inside
   Valgrind on Linux (@c valgrind --tool=helgrind).
 - The repository includes stress and sanitizer presets — use them in CI to

--- a/docs/guides/QUICK_START.kr.md
+++ b/docs/guides/QUICK_START.kr.md
@@ -68,7 +68,7 @@ cmake --build build -j
 
 ```bash
 # 샘플 애플리케이션 실행
-./build/bin/thread_pool_sample
+./build/bin/minimal_thread_pool
 ```
 
 ---
@@ -79,10 +79,13 @@ cmake --build build -j
 
 ```cpp
 #include <kcenon/thread/core/thread_pool.h>
-#include <kcenon/thread/jobs/callback_job.h>
+#include <kcenon/thread/core/thread_worker.h>
 
+#include <algorithm>
+#include <future>
 #include <iostream>
 #include <memory>
+#include <thread>
 #include <vector>
 
 using namespace kcenon::thread;
@@ -93,7 +96,8 @@ int main() {
 
     // 2. 워커 추가 (CPU 코어 수만큼)
     std::vector<std::unique_ptr<thread_worker>> workers;
-    for (size_t i = 0; i < std::thread::hardware_concurrency(); ++i) {
+    const unsigned worker_count = std::max(1u, std::thread::hardware_concurrency());
+    for (unsigned i = 0; i < worker_count; ++i) {
         workers.push_back(std::make_unique<thread_worker>());
     }
     pool->enqueue_batch(std::move(workers));
@@ -101,15 +105,19 @@ int main() {
     // 3. 풀 시작
     pool->start();
 
-    // 4. 태스크 제출
+    // 4. 태스크 제출 (submit()은 태스크마다 std::future를 반환)
+    std::vector<std::future<void>> tasks;
     for (int i = 0; i < 10; ++i) {
-        pool->submit_task([i]() {
+        tasks.push_back(pool->submit([i]() {
             std::cout << "태스크 " << i << " 처리 중\n";
-        });
+        }));
+    }
+    for (auto& task : tasks) {
+        task.get();  // 각 태스크 완료 대기
     }
 
-    // 5. 정상 종료 (모든 태스크 완료 대기)
-    pool->shutdown_pool(false);
+    // 5. 정상 종료
+    pool->stop(false);
 
     std::cout << "모든 태스크 완료!\n";
     return 0;
@@ -121,8 +129,16 @@ int main() {
 `CMakeLists.txt`에 추가:
 
 ```cmake
-# FetchContent 사용
+# FetchContent 사용: thread_system은 common_system을 직접 가져오지 않음
 include(FetchContent)
+FetchContent_Declare(
+    common_system
+    GIT_REPOSITORY https://github.com/kcenon/common_system.git
+    GIT_TAG v0.2.0
+)
+FetchContent_MakeAvailable(common_system)
+set(COMMON_SYSTEM_INCLUDE_DIR "${common_system_SOURCE_DIR}/include")
+
 FetchContent_Declare(
     thread_system
     GIT_REPOSITORY https://github.com/kcenon/thread_system.git
@@ -131,11 +147,7 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(thread_system)
 
 add_executable(my_app main.cpp)
-target_link_libraries(my_app PRIVATE
-    thread_base
-    thread_pool
-    utilities
-)
+target_link_libraries(my_app PRIVATE thread_system)
 ```
 
 ---
@@ -149,7 +161,7 @@ target_link_libraries(my_app PRIVATE
 auto pool = std::make_shared<thread_pool>("PoolName");
 pool->start();
 // ... 태스크 제출 ...
-pool->shutdown_pool(false);  // false = 완료 대기
+pool->stop(false);  // false = 워커가 현재 작업을 마친 뒤 종료
 ```
 
 ### 워커
@@ -166,13 +178,13 @@ pool->enqueue_batch(std::move(workers));
 실행할 작업 단위입니다.
 
 ```cpp
-// 편의 API 사용
-pool->submit_task([]() {
+// submit() 사용: std::future를 반환
+auto future = pool->submit([]() {
     // 작업 내용
 });
 
 // callback_job을 사용하여 더 세밀한 제어
-pool->execute(std::make_unique<callback_job>([]() -> kcenon::common::VoidResult {
+pool->enqueue(std::make_unique<callback_job>([]() -> kcenon::common::VoidResult {
     // 작업 내용
     return kcenon::common::ok();
 }));
@@ -186,19 +198,23 @@ pool->execute(std::make_unique<callback_job>([]() -> kcenon::common::VoidResult 
 
 ```cpp
 std::atomic<int> counter{0};
+std::vector<std::future<void>> futures;
 for (int i = 0; i < 1000; ++i) {
-    pool->submit_task([&counter]() {
+    futures.push_back(pool->submit([&counter]() {
         counter++;
-    });
+    }));
+}
+for (auto& f : futures) {
+    f.get();  // 모든 태스크가 실행될 때까지 대기
 }
 ```
 
 ### 오류 처리
 
 ```cpp
-pool->execute(std::make_unique<callback_job>([]() -> kcenon::common::VoidResult {
+pool->enqueue(std::make_unique<callback_job>([]() -> kcenon::common::VoidResult {
     if (some_error_condition) {
-        return kcenon::thread::make_error_result(kcenon::thread::error_code::operation_failed, "태스크 실패");
+        return kcenon::thread::make_error_result(kcenon::thread::error_code::job_execution_failed, "태스크 실패");
     }
     return kcenon::common::ok();
 }));
@@ -207,11 +223,12 @@ pool->execute(std::make_unique<callback_job>([]() -> kcenon::common::VoidResult 
 ### 정상 종료
 
 ```cpp
-// 모든 태스크 완료 대기
-pool->shutdown_pool(false);
+// 제출한 태스크의 future를 먼저 기다린 뒤 종료; stop(false)는
+// 각 워커가 현재 작업을 마치게 함 (대기 중인 작업은 비우지 않음)
+pool->stop(false);
 
-// 또는 즉시 강제 종료
-pool->shutdown_pool(true);
+// 또는 즉시 종료 (진행 중인 작업이 중단될 수 있음)
+pool->stop(true);
 ```
 
 ---

--- a/docs/guides/QUICK_START.md
+++ b/docs/guides/QUICK_START.md
@@ -68,7 +68,7 @@ cmake --build build -j
 
 ```bash
 # Run the sample application
-./build/bin/thread_pool_sample
+./build/bin/minimal_thread_pool
 ```
 
 ---
@@ -79,10 +79,13 @@ Create a simple thread pool application:
 
 ```cpp
 #include <kcenon/thread/core/thread_pool.h>
-#include <kcenon/thread/jobs/callback_job.h>
+#include <kcenon/thread/core/thread_worker.h>
 
+#include <algorithm>
+#include <future>
 #include <iostream>
 #include <memory>
+#include <thread>
 #include <vector>
 
 using namespace kcenon::thread;
@@ -93,7 +96,8 @@ int main() {
 
     // 2. Add workers (one per CPU core)
     std::vector<std::unique_ptr<thread_worker>> workers;
-    for (size_t i = 0; i < std::thread::hardware_concurrency(); ++i) {
+    const unsigned worker_count = std::max(1u, std::thread::hardware_concurrency());
+    for (unsigned i = 0; i < worker_count; ++i) {
         workers.push_back(std::make_unique<thread_worker>());
     }
     pool->enqueue_batch(std::move(workers));
@@ -101,15 +105,19 @@ int main() {
     // 3. Start the pool
     pool->start();
 
-    // 4. Submit tasks
+    // 4. Submit tasks; submit() returns a std::future for each one
+    std::vector<std::future<void>> tasks;
     for (int i = 0; i < 10; ++i) {
-        pool->submit_task([i]() {
+        tasks.push_back(pool->submit([i]() {
             std::cout << "Processing task " << i << "\n";
-        });
+        }));
+    }
+    for (auto& task : tasks) {
+        task.get();  // Wait for each task to complete
     }
 
-    // 5. Clean shutdown (wait for all tasks to complete)
-    pool->shutdown_pool(false);
+    // 5. Clean shutdown
+    pool->stop(false);
 
     std::cout << "All tasks completed!\n";
     return 0;
@@ -121,8 +129,16 @@ int main() {
 Add to your `CMakeLists.txt`:
 
 ```cmake
-# Using FetchContent
+# Using FetchContent: thread_system does not fetch common_system itself
 include(FetchContent)
+FetchContent_Declare(
+    common_system
+    GIT_REPOSITORY https://github.com/kcenon/common_system.git
+    GIT_TAG v0.2.0
+)
+FetchContent_MakeAvailable(common_system)
+set(COMMON_SYSTEM_INCLUDE_DIR "${common_system_SOURCE_DIR}/include")
+
 FetchContent_Declare(
     thread_system
     GIT_REPOSITORY https://github.com/kcenon/thread_system.git
@@ -131,11 +147,7 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(thread_system)
 
 add_executable(my_app main.cpp)
-target_link_libraries(my_app PRIVATE
-    thread_base
-    thread_pool
-    utilities
-)
+target_link_libraries(my_app PRIVATE thread_system)
 ```
 
 ---
@@ -149,7 +161,7 @@ The core component for managing worker threads and executing jobs.
 auto pool = std::make_shared<thread_pool>("PoolName");
 pool->start();
 // ... submit tasks ...
-pool->shutdown_pool(false);  // false = wait for completion
+pool->stop(false);  // false = let workers finish their current job
 ```
 
 ### Workers
@@ -166,13 +178,13 @@ pool->enqueue_batch(std::move(workers));
 Units of work to be executed.
 
 ```cpp
-// Using convenience API
-pool->submit_task([]() {
+// Using submit(), which returns a std::future
+auto future = pool->submit([]() {
     // Your work here
 });
 
 // Using callback_job for more control
-pool->execute(std::make_unique<callback_job>([]() -> kcenon::common::VoidResult {
+pool->enqueue(std::make_unique<callback_job>([]() -> kcenon::common::VoidResult {
     // Your work here
     return kcenon::common::ok();
 }));
@@ -186,19 +198,23 @@ pool->execute(std::make_unique<callback_job>([]() -> kcenon::common::VoidResult 
 
 ```cpp
 std::atomic<int> counter{0};
+std::vector<std::future<void>> futures;
 for (int i = 0; i < 1000; ++i) {
-    pool->submit_task([&counter]() {
+    futures.push_back(pool->submit([&counter]() {
         counter++;
-    });
+    }));
+}
+for (auto& f : futures) {
+    f.get();  // Wait until every task has run
 }
 ```
 
 ### Error Handling
 
 ```cpp
-pool->execute(std::make_unique<callback_job>([]() -> kcenon::common::VoidResult {
+pool->enqueue(std::make_unique<callback_job>([]() -> kcenon::common::VoidResult {
     if (some_error_condition) {
-        return kcenon::thread::make_error_result(kcenon::thread::error_code::operation_failed, "Task failed");
+        return kcenon::thread::make_error_result(kcenon::thread::error_code::job_execution_failed, "Task failed");
     }
     return kcenon::common::ok();
 }));
@@ -207,11 +223,12 @@ pool->execute(std::make_unique<callback_job>([]() -> kcenon::common::VoidResult 
 ### Graceful Shutdown
 
 ```cpp
-// Wait for all tasks to complete
-pool->shutdown_pool(false);
+// Wait on the futures of submitted tasks first; stop(false) then lets
+// each worker finish its current job (queued jobs are not drained)
+pool->stop(false);
 
-// Or force immediate stop
-pool->shutdown_pool(true);
+// Or stop immediately; ongoing jobs may be interrupted
+pool->stop(true);
 ```
 
 ---

--- a/docs/guides/TROUBLESHOOTING.kr.md
+++ b/docs/guides/TROUBLESHOOTING.kr.md
@@ -170,8 +170,8 @@ pool->start();
 1. 동일한 풀에서 다른 작업을 기다리는 작업 제출 피하기:
 ```cpp
 // 나쁨: 잠재적 데드락
-pool->submit_task([&pool]() {
-    auto future = pool->submit_task([]() { /* 내부 작업 */ });
+auto outer = pool->submit([&pool]() {
+    auto future = pool->submit([]() { /* 내부 작업 */ });
     future.get();  // 모든 워커가 바쁘면 데드락
 });
 ```
@@ -193,7 +193,7 @@ cmake -S . -B build -DENABLE_TSAN=ON
 
 1. 적절한 종료 확인:
 ```cpp
-pool->shutdown_pool(false);  // 완료 대기
+pool->stop(false);  // 워커가 현재 작업을 마친 뒤 종료
 ```
 
 2. AddressSanitizer로 실행:

--- a/docs/guides/TROUBLESHOOTING.md
+++ b/docs/guides/TROUBLESHOOTING.md
@@ -170,8 +170,8 @@ pool->start();
 1. Avoid submitting jobs that wait for other jobs from the same pool:
 ```cpp
 // BAD: Potential deadlock
-pool->submit_task([&pool]() {
-    auto future = pool->submit_task([]() { /* inner job */ });
+auto outer = pool->submit([&pool]() {
+    auto future = pool->submit([]() { /* inner job */ });
     future.get();  // Deadlock if all workers are busy
 });
 ```
@@ -193,7 +193,7 @@ cmake -S . -B build -DENABLE_TSAN=ON
 
 1. Ensure proper shutdown:
 ```cpp
-pool->shutdown_pool(false);  // Wait for completion
+pool->stop(false);  // Let workers finish their current job
 ```
 
 2. Run with AddressSanitizer:

--- a/docs/mainpage.dox
+++ b/docs/mainpage.dox
@@ -25,7 +25,7 @@ Key goals:
 
 | Category | Feature | Description |
 |----------|---------|-------------|
-| **Core** | Thread Pool | Multi-worker pool with adaptive queue and submit_task API |
+| **Core** | Thread Pool | Multi-worker pool with adaptive queue and future-based submit() API |
 | **Core** | Typed Thread Pool | Priority-based scheduling with job type routing and aging |
 | **Queue** | Adaptive Job Queue | Auto-switches between mutex and lock-free modes |
 | **Queue** | Policy Queue | Configurable sync, overflow, and bounded policies |
@@ -110,18 +110,20 @@ Create a thread pool and submit jobs in a few lines:
 
 @code{.cpp}
 #include <kcenon/thread/thread_pool.h>
+#include <kcenon/thread/core/thread_pool_builder.h>
+#include <kcenon/thread/typed_thread_pool.h>
+#include <kcenon/thread/impl/typed_pool/callback_typed_job.h>
 #include <iostream>
 #include <future>
 
 int main() {
     // Create a thread pool with hardware concurrency workers
-    auto pool = kcenon::thread::thread_pool::create();
+    auto pool = kcenon::thread::thread_pool_builder().build();
     pool->start();
 
     // Submit a job and get a future
-    auto future = pool->submit_task([]() -> kcenon::thread::result_void {
+    auto future = pool->submit([]() {
         std::cout << "Hello from thread pool!\n";
-        return {};
     });
 
     // Wait for completion
@@ -132,16 +134,18 @@ int main() {
     auto typed_pool = std::make_shared<
         kcenon::thread::typed_thread_pool_t<job_types>>();
 
-    typed_pool->add_worker(job_types::High);
-    typed_pool->add_worker({job_types::High, job_types::Normal});
+    typed_pool->enqueue(std::make_unique<kcenon::thread::typed_thread_worker_t<job_types>>(
+        std::vector<job_types>{job_types::RealTime}));
+    typed_pool->enqueue(std::make_unique<kcenon::thread::typed_thread_worker_t<job_types>>(
+        std::vector<job_types>{job_types::RealTime, job_types::Batch}));
     typed_pool->start();
 
     typed_pool->enqueue(
         std::make_unique<kcenon::thread::callback_typed_job_t<job_types>>(
-            []() -> kcenon::thread::result_void {
+            []() -> kcenon::common::VoidResult {
                 std::cout << "High-priority task executed\n";
-                return {};
-            }, job_types::High));
+                return kcenon::common::ok();
+            }, job_types::RealTime));
 
     typed_pool->stop();
     pool->stop();
@@ -153,27 +157,39 @@ int main() {
 
 @subsection install_fetchcontent CMake FetchContent (Recommended)
 
+thread_system does not fetch common_system itself; fetch it first and point
+@c COMMON_SYSTEM_INCLUDE_DIR at its headers.
+
 @code{.cmake}
 include(FetchContent)
 FetchContent_Declare(
+    common_system
+    GIT_REPOSITORY https://github.com/kcenon/common_system.git
+    GIT_TAG v0.2.0
+)
+FetchContent_MakeAvailable(common_system)
+set(COMMON_SYSTEM_INCLUDE_DIR "${common_system_SOURCE_DIR}/include")
+
+FetchContent_Declare(
     thread_system
     GIT_REPOSITORY https://github.com/kcenon/thread_system.git
-    GIT_TAG        v0.3.1
+    GIT_TAG v1.0.0  # Pin to a specific release tag; do NOT use main
 )
 FetchContent_MakeAvailable(thread_system)
 
-target_link_libraries(your_target PRIVATE kcenon::thread_core)
+target_link_libraries(your_target PRIVATE thread_system)
 @endcode
 
 @subsection install_vcpkg vcpkg
 
-@code{.bash}
-vcpkg install kcenon-thread-system
-@endcode
+The port is published in the kcenon vcpkg registry, not in the official vcpkg
+registry. Add the registry to @c vcpkg-configuration.json and
+@c kcenon-thread-system to @c vcpkg.json (see "Installation via vcpkg" in the
+README), then:
 
 @code{.cmake}
 find_package(thread_system CONFIG REQUIRED)
-target_link_libraries(your_target PRIVATE kcenon::thread_core)
+target_link_libraries(your_target PRIVATE thread_system::thread_system)
 @endcode
 
 @subsection install_manual Build from Source

--- a/docs/troubleshooting.dox
+++ b/docs/troubleshooting.dox
@@ -30,14 +30,14 @@ complete.
    test. TSan detects most lock-order inversions automatically.
 
 **Fix**: Use the DAG scheduler for in-pool dependencies. Adopt @c std::scoped_lock
-to lock multiple mutexes atomically. Never hold a mutex across @c submit_task.
+to lock multiple mutexes atomically. Never hold a mutex across @c submit.
 
 @section ts_leak 2. Memory leak with futures
 
 **Symptoms**: RSS grows steadily under load even though jobs complete.
 
 **Common causes**:
-- The pool returns a future from @c submit_task and the caller never reads or
+- The pool returns a future from @c submit and the caller never reads or
   drops it. The shared state stays alive until the future is destroyed.
 - Lambdas capture large objects by value; the lambda lives until the job
   finishes, pinning the captures.

--- a/docs/tutorial_threadpool.dox
+++ b/docs/tutorial_threadpool.dox
@@ -88,15 +88,15 @@ worker count over time based on queue depth and latency.
 
 @code{.cpp}
 #include <kcenon/thread/thread_pool.h>
+#include <kcenon/thread/core/thread_pool_builder.h>
 #include <iostream>
 
 int main() {
-    auto pool = kcenon::thread::thread_pool::create();
+    auto pool = kcenon::thread::thread_pool_builder().build();
     pool->start();
 
-    auto fut = pool->submit_task([]() -> kcenon::thread::result_void {
+    auto fut = pool->submit([]() {
         std::cout << "Hello from a worker thread\n";
-        return {};
     });
     fut.wait();
 
@@ -109,30 +109,33 @@ int main() {
 
 @code{.cpp}
 #include <kcenon/thread/typed_thread_pool.h>
+#include <kcenon/thread/impl/typed_pool/callback_typed_job.h>
 
 int main() {
     using job_types = kcenon::thread::job_types;
     auto pool = std::make_shared<
         kcenon::thread::typed_thread_pool_t<job_types>>();
 
-    // Dedicated high-priority worker bounds tail latency for interactive jobs.
-    pool->add_worker(job_types::High);
-    // Mixed worker handles normal and background work.
-    pool->add_worker({job_types::Normal, job_types::Background});
+    // Dedicated real-time worker bounds tail latency for interactive jobs.
+    pool->enqueue(std::make_unique<kcenon::thread::typed_thread_worker_t<job_types>>(
+        std::vector<job_types>{job_types::RealTime}));
+    // Mixed worker handles batch and background work.
+    pool->enqueue(std::make_unique<kcenon::thread::typed_thread_worker_t<job_types>>(
+        std::vector<job_types>{job_types::Batch, job_types::Background}));
     pool->start();
 
     pool->enqueue(
         std::make_unique<kcenon::thread::callback_typed_job_t<job_types>>(
-            []() -> kcenon::thread::result_void {
+            []() -> kcenon::common::VoidResult {
                 // Latency-sensitive interactive task
-                return {};
-            }, job_types::High));
+                return kcenon::common::ok();
+            }, job_types::RealTime));
 
     pool->enqueue(
         std::make_unique<kcenon::thread::callback_typed_job_t<job_types>>(
-            []() -> kcenon::thread::result_void {
+            []() -> kcenon::common::VoidResult {
                 // Lower priority background task
-                return {};
+                return kcenon::common::ok();
             }, job_types::Background));
 
     pool->stop();
@@ -144,23 +147,30 @@ int main() {
 
 @code{.cpp}
 #include <kcenon/thread/thread_pool.h>
+#include <kcenon/thread/core/thread_pool_builder.h>
+#include <algorithm>
+#include <future>
 #include <thread>
+#include <vector>
 
 int main() {
     // I/O-bound workload: roughly 4x oversubscription is a reasonable start.
     const std::size_t cores  = std::thread::hardware_concurrency();
     const std::size_t workers = std::max<std::size_t>(cores * 4, 8);
 
-    auto pool = kcenon::thread::thread_pool::builder{}
-        .worker_count(workers)
+    auto pool = kcenon::thread::thread_pool_builder("io_pool")
+        .with_workers(workers)
         .build();
     pool->start();
 
+    std::vector<std::future<void>> pending;
     for (int i = 0; i < 100; ++i) {
-        pool->submit_task([i]() -> kcenon::thread::result_void {
+        pending.push_back(pool->submit([]() {
             // Blocking network or disk operation here.
-            return {};
-        });
+        }));
+    }
+    for (auto& f : pending) {
+        f.get();
     }
 
     pool->stop();

--- a/include/kcenon/thread/core/error_handling.h
+++ b/include/kcenon/thread/core/error_handling.h
@@ -13,8 +13,8 @@
  *
  * @note As of v3.0, all result types have been unified to use kcenon::common::Result<T>
  *       and kcenon::common::VoidResult. The legacy thread::result<T>, thread::result_void,
- *       and thread::error types have been removed. See docs/ERROR_SYSTEM_MIGRATION_GUIDE.md
- *       for migration instructions.
+ *       and thread::error types have been removed. See
+ *       docs/advanced/ERROR_SYSTEM_MIGRATION_GUIDE.md for migration instructions.
  */
 
 #include <string>


### PR DESCRIPTION
## Description

The guides and Doxygen pages still presented `thread_pool` members and types that no longer exist on develop (`submit_task`, `shutdown_pool`, `execute`, `add_worker(s)`, `get_thread_count`, `thread_pool::create()`, `thread_pool::builder`, `kcenon::thread::result_void`), so their examples did not compile. This PR rewrites them with the current public API, verified against `include/` on develop (f3f6dd6):

- `submit()` returning `std::future<R>` (core/thread_pool.h:424), `enqueue()` / `enqueue_batch()` for jobs and workers (:324-:345), `stop(const bool& immediately_stop = false)` (:354), `start()` (:267)
- `thread_pool_builder` with `with_workers()` and `build()` (core/thread_pool_builder.h; `build()` does not start the pool)
- `typed_thread_worker_t` added with `enqueue()`, `callback_typed_job_t` (impl/typed_pool/callback_typed_job.h), `job_types::RealTime/Batch/Background`
- value-type `cancellation_token` with `create()`, `is_cancelled()`, `cancel()`
- `kcenon::common::VoidResult` / `Result<T>` instead of the removed `thread::result_void` / `thread::result<T>`

Documentation and one header comment only; no code, CMake, or workflow changes. English and Korean files receive the same changes.

## Changes

- `docs/guides/QUICK_START.md`, `QUICK_START.kr.md`
  - Sample path `./build/bin/thread_pool_sample` (not built) -> `./build/bin/minimal_thread_pool`.
  - "Your First Thread Pool": `core/thread_worker.h` instead of the missing `jobs/callback_job.h`; tasks submitted with `submit()` and awaited through their futures; `stop(false)`.
  - FetchContent snippet: fetches common_system v0.2.0 first, sets `COMMON_SYSTEM_INCLUDE_DIR`, pins thread_system v1.0.0, and links `thread_system` (the old snippet did not provision common_system and linked `thread_pool`, a target v1.0.0 does not define).
  - Key Concepts, Jobs, Parallel Processing, Error Handling, Graceful Shutdown: `submit()`, `enqueue()` (thread_pool has no `execute()`), `stop()`, and `error_code::job_execution_failed` (`error_code::operation_failed` does not exist).
  - `stop(false)` is described as "workers finish their current job; queued jobs are not drained": `stop_unsafe()` stops the queue before the workers, and the `stop()` documentation says each worker finishes its current job.
- `docs/FEATURES.md`, `FEATURES.kr.md`: the `thread_pool` listing now matches the public API of `thread_pool.h`; the "Dual API Design" bullets no longer name removed methods; the cancellation example uses `submit()`.
- `docs/guides/TROUBLESHOOTING.md`, `TROUBLESHOOTING.kr.md`: the nested-submit deadlock example and the shutdown example use `submit()` and `stop(false)`.
- `docs/advanced/THREAD_SYSTEM_ARCHITECTURE.md`: the `thread_pool` listing matches the header; the base class is `std::enable_shared_from_this<thread_pool>`, and IExecutor integration lives in `adapters/common_executor_adapter.h`.
- `docs/faq.dox`: cancellation snippet uses `cancellation_token::create()`, `is_cancelled()`, `cancel()` (`is_cancellation_requested()` does not exist) and `submit()`; the error-propagation answer now says that pool operations return `kcenon::common::VoidResult` and that `std::future::get()` rethrows the callable's exception, or a `std::runtime_error` when the pool rejects the job (core/thread_pool_impl.h:45-53, core/future_job.h:105-106); `submit_task` mentions -> `submit`.
- `docs/mainpage.dox`: feature table; Quick Start rewritten (`thread_pool_builder`, `submit()`, typed workers added with `enqueue()`, `job_types::RealTime/Batch` because `High/Normal` do not exist); the FetchContent block is the README-verified form (it pinned v0.3.1 and linked `kcenon::thread_core`); the vcpkg block points at the kcenon registry and `thread_system::thread_system` instead of a bare `vcpkg install` and `kcenon::thread_core`.
- `docs/tutorial_threadpool.dox`: Examples 1-3 rewritten the same way (builder `with_workers()`; Example 3 waits on its futures before stopping).
- `docs/troubleshooting.dox`: `submit_task` mentions -> `submit`.
- `CLAUDE.md`: the `thread_pool` abstraction line, the thread-pool lifecycle, the Results line, and the Known Constraints line about `thread::result<T>`.
- `include/kcenon/thread/core/error_handling.h`: the comment cited the missing `docs/ERROR_SYSTEM_MIGRATION_GUIDE.md`; it now cites `docs/advanced/ERROR_SYSTEM_MIGRATION_GUIDE.md`, which exists.

The Korean files keep their translated code comments and messages, as before. Their C++ fences are identical to the English ones after removing comments and string literals, and the CMake fence differs only in its first comment line.

## Testing

Base develop f3f6dd6, head d3e2780. Apple clang 21.0.0, CMake 4.3.4, Ninja 1.13.2, macOS arm64. Compile checks use `clang++ -std=c++20 -Wall -Wextra` with the develop headers (eccacab, identical to f3f6dd6 under `include/`) and common_system main (c2f4037). Fragments are compiled unchanged: the harness `#include`s the extracted fence inside a function that provides `std::shared_ptr<thread_pool> pool` (or nothing, for fragments that declare their own pool).

| Snippet (file:line of the fence) | Harness | Result |
|---|---|---|
| QUICK_START.md:80, QUICK_START.kr.md:80 (first thread pool program) | compile; build and run through an add_subdirectory consumer (common_system main added first) at d3e2780 | compile PASS, 0 warnings; run PASS for both files: ten task lines, then "All tasks completed!" (Korean messages in the Korean file), exit 0 |
| QUICK_START.md:131 (FetchContent) | real-download consumer: minimal preamble + the snippet verbatim (it declares `my_app`), main.cpp = the program above | PASS: resolved thread_system 6dd5c9e (v1.0.0) and common_system 1b5b064 (v0.2.0), no FETCHCONTENT_SOURCE_DIR overrides, prints "All tasks completed!" |
| QUICK_START.md / .kr.md:160 (Key Concepts) | fragment, declares its own pool | PASS, 0 warnings |
| QUICK_START.md / .kr.md:180 (Jobs) | fragment with `pool` | PASS, 0 warnings |
| QUICK_START.md / .kr.md:199 (Parallel Processing) | fragment with `pool` | PASS, 0 warnings |
| QUICK_START.md / .kr.md:214 (Error Handling) | fragment with `pool` (harness defines `some_error_condition`) | PASS, 0 warnings |
| QUICK_START.md / .kr.md:225 (Graceful Shutdown) | fragment with `pool` | PASS, 0 warnings |
| FEATURES.md:269, FEATURES.kr.md:256 (thread_pool listing) | static_assert harness: every listed member exists with the listed parameter and return types; base class; constructors | PASS, 0 warnings |
| FEATURES.md:740, FEATURES.kr.md:479 (cancellation) | fragment with `pool` | PASS, 0 warnings |
| TROUBLESHOOTING.md / .kr.md:171 (deadlock example) | fragment with `pool` | PASS, 0 warnings |
| TROUBLESHOOTING.md / .kr.md:195 (shutdown) | fragment with `pool` | PASS, 0 warnings |
| THREAD_SYSTEM_ARCHITECTURE.md:264 (thread_pool listing) | same static_assert harness | PASS, 0 warnings |
| faq.dox:29 (cancellation) | fragment with `pool` | PASS, 0 warnings |
| mainpage.dox:111 (Quick Start) | compile; build and run at d3e2780 | compile PASS, 0 warnings; run PASS: prints "Hello from thread pool!" and "High-priority task executed", exit 0 |
| mainpage.dox:163 (FetchContent) | byte-identical to the README snippet validated in #711 (real downloads, v1.0.0 with common_system v0.2.0) | not re-run |
| mainpage.dox:190 (vcpkg CMake) | byte-identical to the README vcpkg snippet validated in #711 (kcenon registry port 0.3.2#2) | not re-run |
| tutorial_threadpool.dox:89 (Example 1) | compile; build and run at d3e2780 | compile PASS, 0 warnings; run PASS: prints "Hello from a worker thread", exit 0 |
| tutorial_threadpool.dox:110 (Example 2) | compile; build and run at d3e2780 | compile PASS, 0 warnings; run PASS (no output by design), exit 0 |
| tutorial_threadpool.dox:148 (Example 3) | compile; build and run at d3e2780 | compile PASS, 0 warnings; run PASS (waits on 100 futures; no output by design), exit 0 |

Other checks:

- doc_audit (tools/doc-audit from common_system main, `python3 -m doc_audit . --quick --format markdown`, as in doc-audit.yml): exit 0, 0 critical, 10 warnings; the finding list is identical to the develop baseline.
- `tools/check_links.py` on every changed Markdown file (QUICK_START x2, FEATURES x2, TROUBLESHOOTING x2, THREAD_SYSTEM_ARCHITECTURE.md, CLAUDE.md): 0 failures (5 unique URLs, all HTTP 200; every relative path and anchor resolves); same as the develop baseline.
- `git diff --check`: clean.
- `stop(false)` wording, checked at runtime on develop: a pool with one worker received twenty 50 ms jobs through `submit()`, and `stop(false)` was called 10 ms later. When `stop()` returned, 1 job had completed and the other 19 futures were not ready; 300 ms later it was still 1 of 20. Workers finish their current job, and queued jobs are not run.
- The edited files no longer contain `submit_task`, `shutdown_pool`, `add_worker(`, `thread_pool::create`, or `is_cancellation_requested`.

## Not changed

- `docs/advanced/CPP20_CONCEPTS.md` and `.kr.md` (around L249-253): `submit_task` there is a generic example of constraining your own API with concepts, not a statement about `thread_pool`.
- `docs/CHANGELOG.md`, `docs/guides/THREAD_POOL_API_MIGRATION_GUIDE.md`, `docs/advanced/USER_MIGRATION_GUIDE.md`: historical and migration mentions of the old names.
- Other class listings still use `result_void`: `docs/FEATURES.md` / `.kr.md` (thread_base, job_queue, typed pool; around L62-L196 and L442-L524) and `docs/advanced/THREAD_SYSTEM_ARCHITECTURE.md` (around L163-L329). They need an API audit of those classes and are left for a separate change.
- `docs/tutorial_threadpool.dox` work-stealing snippet (L52-L61) uses `stealing/work_stealing_pool.h`, which does not exist; the mainpage module table lists the same header. Not a removed thread_pool API; needs its own fix.
- `docs/mainpage.dox` example table references samples that are not built (thread_pool_sample, typed_thread_pool_sample, and others).
- QUICK_START prerequisites and troubleshooting still say CMake 3.16, GCC 11+, and Clang 14+, while CMakeLists.txt requires CMake 3.20 and the README documents GCC 13+ / Clang 17+. Compiler-baseline alignment is a separate change.
- The file comment in `include/kcenon/thread/core/thread_pool.h` (L16) shows `pool->enqueue([] { ... })`, which does not compile because `enqueue()` takes a job; outside this PR's files.
- `README.md` / `README.kr.md` (from #711): the Quick Start comment "immediately_stop = false waits for queued jobs" overstates `stop(false)`, which lets workers finish their current job and does not drain queued jobs. The Quick Start itself waits on every future before `stop()`, so its output is unaffected; the comment should be corrected in a README change.

## Related

- Refs kcenon/thread_system#709 and kcenon/thread_system#711 (follow-up 5: removed API names in the documentation).
