### PR TITLE
docs(readme): correct the Quick Start comment on stop(false)

### DIFF
--- a/README.kr.md
+++ b/README.kr.md
@@ -174,7 +174,8 @@ int main() {
     }
     std::cout << "Sum of results: " << total << "\n";  // 999000
 
-    // Clean shutdown (immediately_stop = false waits for queued jobs)
+    // Clean shutdown: stop(false) lets running jobs finish but does not run
+    // jobs that are still queued, so the results are collected first (above).
     if (auto r = pool->stop(); r.is_err()) {
         std::cerr << "stop failed: " << r.error().message << "\n";
         return 1;

--- a/README.md
+++ b/README.md
@@ -174,7 +174,8 @@ int main() {
     }
     std::cout << "Sum of results: " << total << "\n";  // 999000
 
-    // Clean shutdown (immediately_stop = false waits for queued jobs)
+    // Clean shutdown: stop(false) lets running jobs finish but does not run
+    // jobs that are still queued, so the results are collected first (above).
     if (auto r = pool->stop(); r.is_err()) {
         std::cerr << "stop failed: " << r.error().message << "\n";
         return 1;


### PR DESCRIPTION
## Description

The README Quick Start added in #711 says `// Clean shutdown (immediately_stop = false waits for queued jobs)`. `thread_pool::stop(false)` does not wait for queued jobs. It cancels the pool token, stops the queue without draining it, and stops the workers after their current job (`src/impl/thread_pool/thread_pool.cpp:518-564`). `thread_pool.h:349-351` documents that "each worker attempts to finish its current job before stopping". The Quick Start's output is unaffected, because it collects every future before it calls `stop()`; only the comment is wrong.

This was found while reviewing the documentation changes in #719, which describe `stop(false)` the same way.

## Changes

- `README.md`, `README.kr.md`: the comment now says "stop(false) lets running jobs finish but does not run jobs that are still queued, so the results are collected first (above)". The code fences stay identical in both files.

## Testing

- A runtime probe on develop (`eccacab`, built through an add_subdirectory consumer with common_system main): a pool with one worker received twenty 50 ms jobs through `submit()`, and `stop(false)` was called 10 ms later. When `stop()` returned, 1 job had completed and the other 19 futures were not ready; 300 ms later it was still 1 of 20.
- The Quick Start fence compiles with `-std=c++20 -Wall -Wextra` against the develop headers. Only a comment changed.
- All 15 fences are identical between README.md and README.kr.md. The doc_audit findings are identical to the develop baseline (0 critical), and `git diff --check` is clean.

## Related Issues

- Refs #711, #719
